### PR TITLE
Add @bsky/jetstream package

### DIFF
--- a/.changeset/jetstream-isomorphic-transport.md
+++ b/.changeset/jetstream-isomorphic-transport.md
@@ -1,5 +1,5 @@
 ---
-'@bsky.app/jetstream': minor
+'@bsky/jetstream': minor
 ---
 
 Isomorphic live transport: adopt `@atproto/ws-client` 0.2.0 (Node.js + browser). New `websocketTransport(options)` factory exposes websocket options (reconnect policy, lifecycle hooks, headers, liveness) as the existing `liveTransport` seam. Defaults: text frames only (binary is fatal), reconnect on a server's clean close, 60s idle timeout (`false` disables) — under defaults a live stream never ends on its own.

--- a/.changeset/jetstream-isomorphic-transport.md
+++ b/.changeset/jetstream-isomorphic-transport.md
@@ -1,0 +1,5 @@
+---
+'@bsky.app/jetstream': minor
+---
+
+Isomorphic live transport: adopt `@atproto/ws-client` 0.2.0 (Node.js + browser). New `websocketTransport(options)` factory exposes websocket options (reconnect policy, lifecycle hooks, headers, liveness) as the existing `liveTransport` seam. Defaults: text frames only (binary is fatal), reconnect on a server's clean close, 60s idle timeout (`false` disables) — under defaults a live stream never ends on its own.

--- a/.changeset/nice-buses-relax.md
+++ b/.changeset/nice-buses-relax.md
@@ -1,5 +1,5 @@
 ---
-'@bsky.app/jetstream': patch
+'@bsky/jetstream': patch
 ---
 
 Bump @atproto/lex-schema to ^0.2.2

--- a/.changeset/nice-buses-relax.md
+++ b/.changeset/nice-buses-relax.md
@@ -1,0 +1,5 @@
+---
+'@bsky.app/jetstream': patch
+---
+
+Bump @atproto/lex-schema to ^0.2.2

--- a/.changeset/tidy-eyes-refuse.md
+++ b/.changeset/tidy-eyes-refuse.md
@@ -1,0 +1,5 @@
+---
+'@bsky.app/jetstream': minor
+---
+
+Initial release: Jetstream live-mode client with schema-aware collection filters, LexIndexer, and JetstreamRunner with durable cursor tracking.

--- a/.changeset/tidy-eyes-refuse.md
+++ b/.changeset/tidy-eyes-refuse.md
@@ -1,5 +1,5 @@
 ---
-'@bsky.app/jetstream': minor
+'@bsky/jetstream': minor
 ---
 
 Initial release: Jetstream live-mode client with schema-aware collection filters, LexIndexer, and JetstreamRunner with durable cursor tracking.

--- a/packages/jetstream/README.md
+++ b/packages/jetstream/README.md
@@ -1,0 +1,43 @@
+# @bsky.app/jetstream
+
+Client library for [Jetstream](https://github.com/bluesky-social/jetstream), the
+Bluesky-operated atproto event stream with JSON framing and server-side
+filtering.
+
+This package currently supports Jetstream's live mode (the public
+`jetstream*.bsky.network` instances). Consuming events looks like:
+
+```ts
+import { Jetstream } from '@bsky.app/jetstream'
+
+const js = new Jetstream('https://jetstream1.us-east.bsky.network')
+
+for await (const evt of js.live({ collections: ['app.bsky.feed.post'] })) {
+  if (evt.kind === 'commit' && evt.commit.operation !== 'delete') {
+    console.log(evt.commit.collection, evt.commit.record)
+  }
+}
+```
+
+For indexing workloads, `LexIndexer` dispatches schema-validated records to
+per-collection handlers with bounded concurrency and per-record ordering, and
+`JetstreamRunner` drives it with durable cursor tracking:
+
+```ts
+import { Jetstream, LexIndexer } from '@bsky.app/jetstream'
+
+const indexer = new LexIndexer()
+  .commit(likeSchema, {
+    put: async (e) => {
+      /* index e.record */
+    },
+    del: async (e) => {
+      /* remove by e.uri */
+    },
+  })
+  .identity(async (e) => {
+    /* handle changes */
+  })
+
+await js.runner(indexer).live({ cursor: myCursorStore })
+```

--- a/packages/jetstream/README.md
+++ b/packages/jetstream/README.md
@@ -1,4 +1,4 @@
-# @bsky.app/jetstream
+# @bsky/jetstream
 
 Client library for [Jetstream](https://github.com/bluesky-social/jetstream), a friendly way to consume data published to AT Protocol in realtime.
 
@@ -7,13 +7,13 @@ Client library for [Jetstream](https://github.com/bluesky-social/jetstream), a f
 Install the Jetstream client:
 
 ```
-npm install @bsky.app/jetstream
+npm install @bsky/jetstream
 ```
 
 This package currently supports Jetstream's WebSocket-based live mode. Consuming events looks like:
 
 ```ts
-import { Jetstream } from '@bsky.app/jetstream'
+import { Jetstream } from '@bsky/jetstream'
 
 const js = new Jetstream('https://jetstream1.us-east.bsky.network')
 
@@ -27,7 +27,7 @@ for await (const evt of js.live({ collections: ['app.bsky.feed.post'] })) {
 Using a lexicon as your collection filter will validate and type the events for you:
 
 ```ts
-import { Jetstream } from '@bsky.app/jetstream'
+import { Jetstream } from '@bsky/jetstream'
 import { app } from '@bsky.app/sdk/lexicons'
 
 const js = new Jetstream('https://jetstream1.us-east.bsky.network')
@@ -42,7 +42,7 @@ for await (const evt of js.live({ collections: [app.bsky.feed.post] })) {
 For indexing workloads, `LexIndexer` dispatches schema-validated records to per-collection handlers with bounded concurrency and per-record ordering, and `JetstreamRunner` drives it with durable cursor tracking:
 
 ```ts
-import { Jetstream, LexIndexer, MemoryCursorStore } from '@bsky.app/jetstream'
+import { Jetstream, LexIndexer, MemoryCursorStore } from '@bsky/jetstream'
 import { app } from '@bsky.app/sdk/lexicons'
 
 const js = new Jetstream('https://jetstream1.us-east.bsky.network')
@@ -80,7 +80,7 @@ To observe or tune connection behavior, configure a transport with
 `websocketTransport()` and pass it via the `liveTransport` option:
 
 ```ts
-import { Jetstream, websocketTransport } from '@bsky.app/jetstream'
+import { Jetstream, websocketTransport } from '@bsky/jetstream'
 
 const js = new Jetstream('https://jetstream2.us-east.bsky.network')
 for await (const ev of js.live({

--- a/packages/jetstream/README.md
+++ b/packages/jetstream/README.md
@@ -65,3 +65,38 @@ const cursor = new MemoryCursorStore()
 
 await js.runner(indexer).live({ cursor })
 ```
+
+## Isomorphic
+
+This package runs on Node.js and in the browser. The live transport is built
+on `@atproto/ws-client`, which selects a platform websocket implementation
+itself; nothing in `src/` imports Node-only modules (`ws` is a devDependency
+used only by tests).
+
+Websocket behavior (reconnect policy, lifecycle hooks, headers, liveness) is
+configured through the `websocketTransport()` factory and passed via the
+`liveTransport` option:
+
+```ts
+import { Jetstream, websocketTransport } from '@bsky.app/jetstream'
+
+const js = new Jetstream('https://jetstream2.us-east.bsky.network')
+for await (const ev of js.live({
+  collections: ['app.bsky.feed.post'],
+  liveTransport: websocketTransport({
+    onReconnect: (err, { attempt }) => console.warn('reconnecting', attempt),
+  }),
+})) {
+  // ...
+}
+```
+
+Defaults: frames are text (`dataMode: 'text'`; a binary frame is fatal), a
+server's clean close reconnects (the resume cursor makes redials seamless),
+and a 60s idle timeout redials silent connections (`idleTimeoutMs: false`
+disables). Under these defaults a live stream never ends on its own — only
+`break`, aborting the `signal`, or a genuinely fatal error ends it.
+
+Two error surfaces, one sentence each: the factory's `onError` reports the
+stream-fatal websocket error (the same error the loop rejects with), while
+`LiveOpts.onError` reports skipped malformed frames at the decode layer.

--- a/packages/jetstream/README.md
+++ b/packages/jetstream/README.md
@@ -1,11 +1,8 @@
 # @bsky.app/jetstream
 
-Client library for [Jetstream](https://github.com/bluesky-social/jetstream), the
-Bluesky-operated atproto event stream with JSON framing and server-side
-filtering.
+Client library for [Jetstream](https://github.com/bluesky-social/jetstream), the AT Protocol event stream with JSON framing and server-side filtering.
 
-This package currently supports Jetstream's live mode (the public
-`jetstream*.bsky.network` instances). Consuming events looks like:
+This package currently supports Jetstream's WebSocket-based live mode. Consuming events looks like:
 
 ```ts
 import { Jetstream } from '@bsky.app/jetstream'
@@ -19,25 +16,27 @@ for await (const evt of js.live({ collections: ['app.bsky.feed.post'] })) {
 }
 ```
 
-For indexing workloads, `LexIndexer` dispatches schema-validated records to
-per-collection handlers with bounded concurrency and per-record ordering, and
-`JetstreamRunner` drives it with durable cursor tracking:
+For indexing workloads, `LexIndexer` dispatches schema-validated records to per-collection handlers with bounded concurrency and per-record ordering, and `JetstreamRunner` drives it with durable cursor tracking:
 
 ```ts
-import { Jetstream, LexIndexer } from '@bsky.app/jetstream'
+import { Jetstream, LexIndexer, MemoryCursorStore } from '@bsky.app/jetstream'
+import { app } from '@bsky.app/sdk/lexicons'
+
+const js = new Jetstream('https://jetstream1.us-east.bsky.network')
 
 const indexer = new LexIndexer()
-  .commit(likeSchema, {
+  .commit(app.bsky.feed.like, {
     put: async (e) => {
-      /* index e.record */
+      console.log('index', e.uri, e.record)
     },
     del: async (e) => {
-      /* remove by e.uri */
+      console.log('remove', e.uri)
     },
   })
   .identity(async (e) => {
-    /* handle changes */
+    console.log('identity change', e.did, e.handle)
   })
 
-await js.runner(indexer).live({ cursor: myCursorStore })
+// Implement CursorStore to persist the resume cursor durably.
+await js.runner(indexer).live({ cursor: new MemoryCursorStore() })
 ```

--- a/packages/jetstream/README.md
+++ b/packages/jetstream/README.md
@@ -28,7 +28,7 @@ Using a lexicon as your collection filter will validate and type the events for 
 
 ```ts
 import { Jetstream } from '@bsky/jetstream'
-import { app } from '@bsky.app/sdk/lexicons'
+import { app } from '@bsky/sdk/lexicons'
 
 const js = new Jetstream('https://jetstream1.us-east.bsky.network')
 
@@ -43,7 +43,7 @@ For indexing workloads, `LexIndexer` dispatches schema-validated records to per-
 
 ```ts
 import { Jetstream, LexIndexer, MemoryCursorStore } from '@bsky/jetstream'
-import { app } from '@bsky.app/sdk/lexicons'
+import { app } from '@bsky/sdk/lexicons'
 
 const js = new Jetstream('https://jetstream1.us-east.bsky.network')
 

--- a/packages/jetstream/README.md
+++ b/packages/jetstream/README.md
@@ -66,16 +66,18 @@ const cursor = new MemoryCursorStore()
 await js.runner(indexer).live({ cursor })
 ```
 
-## Isomorphic
+## Connection behavior
 
-This package runs on Node.js and in the browser. The live transport is built
-on `@atproto/ws-client`, which selects a platform websocket implementation
-itself; nothing in `src/` imports Node-only modules (`ws` is a devDependency
-used only by tests).
+This package runs on Node.js and in the browser.
 
-Websocket behavior (reconnect policy, lifecycle hooks, headers, liveness) is
-configured through the `websocketTransport()` factory and passed via the
-`liveTransport` option:
+A live stream stays up on its own: it reconnects automatically — including
+when the server closes cleanly or goes silent — and resumes from its cursor,
+so no events are lost or duplicated across reconnects. It ends only when you
+`break` out of the loop, abort the `signal`, or a genuinely fatal error
+occurs (which rejects the loop).
+
+To observe or tune connection behavior, configure a transport with
+`websocketTransport()` and pass it via the `liveTransport` option:
 
 ```ts
 import { Jetstream, websocketTransport } from '@bsky.app/jetstream'
@@ -91,12 +93,8 @@ for await (const ev of js.live({
 }
 ```
 
-Defaults: frames are text (`dataMode: 'text'`; a binary frame is fatal), a
-server's clean close reconnects (the resume cursor makes redials seamless),
-and a 60s idle timeout redials silent connections (`idleTimeoutMs: false`
-disables). Under these defaults a live stream never ends on its own — only
-`break`, aborting the `signal`, or a genuinely fatal error ends it.
-
-Two error surfaces, one sentence each: the factory's `onError` reports the
-stream-fatal websocket error (the same error the loop rejects with), while
-`LiveOpts.onError` reports skipped malformed frames at the decode layer.
+Commonly useful options: `onReconnect` to observe connection trouble (retries
+are otherwise silent), `shouldReconnect` to change when the stream gives up,
+and `idleTimeoutMs` to tune dead-connection detection (default 60s; `false`
+disables). `websocketTransport()` inherits the rest of its options from
+[`@atproto/ws-client`](https://npmx.dev/@atproto/ws-client).

--- a/packages/jetstream/README.md
+++ b/packages/jetstream/README.md
@@ -1,6 +1,14 @@
 # @bsky.app/jetstream
 
-Client library for [Jetstream](https://github.com/bluesky-social/jetstream), the AT Protocol event stream with JSON framing and server-side filtering.
+Client library for [Jetstream](https://github.com/bluesky-social/jetstream), a friendly way to consume data published to AT Protocol in realtime.
+
+## Quick start
+
+Install the Jetstream client:
+
+```
+npm install @bsky.app/jetstream
+```
 
 This package currently supports Jetstream's WebSocket-based live mode. Consuming events looks like:
 
@@ -10,8 +18,23 @@ import { Jetstream } from '@bsky.app/jetstream'
 const js = new Jetstream('https://jetstream1.us-east.bsky.network')
 
 for await (const evt of js.live({ collections: ['app.bsky.feed.post'] })) {
-  if (evt.kind === 'commit' && evt.commit.operation !== 'delete') {
+  if (evt.kind === 'commit' && evt.commit.operation === 'create') {
     console.log(evt.commit.collection, evt.commit.record)
+  }
+}
+```
+
+Using a lexicon as your collection filter will validate and type the events for you:
+
+```ts
+import { Jetstream } from '@bsky.app/jetstream'
+import { app } from '@bsky.app/sdk/lexicons'
+
+const js = new Jetstream('https://jetstream1.us-east.bsky.network')
+
+for await (const evt of js.live({ collections: [app.bsky.feed.post] })) {
+  if (evt.kind === 'commit' && evt.commit.operation === 'create') {
+    console.log(evt.commit.collection, evt.commit.record.text)
   }
 }
 ```
@@ -38,5 +61,7 @@ const indexer = new LexIndexer()
   })
 
 // Implement CursorStore to persist the resume cursor durably.
-await js.runner(indexer).live({ cursor: new MemoryCursorStore() })
+const cursor = new MemoryCursorStore()
+
+await js.runner(indexer).live({ cursor })
 ```

--- a/packages/jetstream/package.json
+++ b/packages/jetstream/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@bsky.app/jetstream",
+  "name": "@bsky/jetstream",
   "version": "0.0.0",
   "license": "MIT OR Apache-2.0",
   "description": "Client library for Jetstream (atproto event streaming)",

--- a/packages/jetstream/package.json
+++ b/packages/jetstream/package.json
@@ -36,5 +36,9 @@
   "scripts": {
     "build": "tsgo --build tsconfig.build.json",
     "test": "vitest --run"
+  },
+  "devDependencies": {
+    "@types/ws": "^8.18.1",
+    "ws": "^8.21.0"
   }
 }

--- a/packages/jetstream/package.json
+++ b/packages/jetstream/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@atproto/lex-schema": "^0.2.2",
-    "@atproto/ws-client": "^0.1.1"
+    "@atproto/ws-client": "^0.2.0"
   },
   "scripts": {
     "build": "tsgo --build tsconfig.build.json",

--- a/packages/jetstream/package.json
+++ b/packages/jetstream/package.json
@@ -30,7 +30,7 @@
     "node": ">=22.12.0"
   },
   "dependencies": {
-    "@atproto/lex-schema": "^0.1.4",
+    "@atproto/lex-schema": "^0.2.2",
     "@atproto/ws-client": "^0.1.1"
   },
   "scripts": {

--- a/packages/jetstream/package.json
+++ b/packages/jetstream/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@atproto/lex-schema": "^0.1.4",
+    "@atproto/syntax": "^0.6.4",
     "@atproto/ws-client": "^0.1.1"
   },
   "scripts": {

--- a/packages/jetstream/package.json
+++ b/packages/jetstream/package.json
@@ -34,7 +34,7 @@
     "@atproto/ws-client": "^0.2.0"
   },
   "scripts": {
-    "build": "tsgo --build tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "test": "vitest --run"
   },
   "devDependencies": {

--- a/packages/jetstream/package.json
+++ b/packages/jetstream/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "@atproto/lex-schema": "^0.1.4",
-    "@atproto/syntax": "^0.6.4",
     "@atproto/ws-client": "^0.1.1"
   },
   "scripts": {

--- a/packages/jetstream/package.json
+++ b/packages/jetstream/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@bsky.app/jetstream",
+  "version": "0.0.0",
+  "license": "MIT OR Apache-2.0",
+  "description": "Client library for Jetstream (atproto event streaming)",
+  "keywords": [
+    "atproto",
+    "bluesky",
+    "jetstream",
+    "sdk"
+  ],
+  "homepage": "https://bsky.app",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bluesky-social/bsky",
+    "directory": "packages/jetstream"
+  },
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "dependencies": {
+    "@atproto/lex-schema": "^0.1.4",
+    "@atproto/ws-client": "^0.1.1"
+  },
+  "scripts": {
+    "build": "tsgo --build tsconfig.build.json",
+    "test": "vitest --run"
+  }
+}

--- a/packages/jetstream/src/consumer.ts
+++ b/packages/jetstream/src/consumer.ts
@@ -1,4 +1,3 @@
-// src/consumer.ts
 import { type CollectionFilter } from './engine/collections.js'
 import { type EventBatch, type RawEventV1, type SeqEvent } from './event.js'
 

--- a/packages/jetstream/src/consumer.ts
+++ b/packages/jetstream/src/consumer.ts
@@ -1,3 +1,4 @@
+import { type DidString } from '@atproto/lex-schema'
 import { type CollectionFilter } from './engine/collections.js'
 import { type EventBatch, type RawEventV1, type SeqEvent } from './event.js'
 
@@ -33,7 +34,7 @@ export interface ConsumerContext {
  */
 export interface JetstreamConsumer {
   collections?: CollectionFilter[]
-  dids?: string[]
+  dids?: DidString[]
   run(
     stream: AsyncIterable<EventBatch<RawEventV1>>,
     ctx: ConsumerContext,

--- a/packages/jetstream/src/consumer.ts
+++ b/packages/jetstream/src/consumer.ts
@@ -1,0 +1,42 @@
+// src/consumer.ts
+import { type CollectionFilter } from './engine/collections.js'
+import { type EventBatch, type RawEventV1, type SeqEvent } from './event.js'
+
+/**
+ * Signals that the consumer has finished processing an event. Fire-and-forget:
+ * the source records evt.seq synchronously and never retains the event object.
+ * Not calling ack for an event holds the resume watermark below its seq. Only
+ * reads the cursor, so it accepts any SeqEvent.
+ */
+export type Ack = (evt: SeqEvent) => void
+
+/**
+ * Context handed to a consumer's run(): the ack callback plus an optional
+ * AbortSignal. `signal`, when present, is the caller's cancellation signal
+ * (the runner forwards run()'s signal here). It is optional at the seam — a
+ * non-Jetstream source need not provide one. (LexIndexer guarantees its OWN
+ * handler-facing signal regardless; see HandlerContext.)
+ */
+export interface ConsumerContext {
+  ack: Ack
+  signal?: AbortSignal
+}
+
+/**
+ * Source-agnostic event processor. `collections`/`dids` are static declarations
+ * of what the consumer handles; a Jetstream source reads them to build the
+ * server-side filter. The consumer drives its own loop over the raw-batch
+ * stream, decides its own concurrency/ordering, and calls ack(evt) on
+ * completion. It knows nothing about cursors.
+ *
+ * The seam element is the v1 raw event (parsed-JSON `record` on put commits);
+ * typedEventFromRaw normalizes it into TypedEvent.
+ */
+export interface JetstreamConsumer {
+  collections?: CollectionFilter[]
+  dids?: string[]
+  run(
+    stream: AsyncIterable<EventBatch<RawEventV1>>,
+    ctx: ConsumerContext,
+  ): Promise<void>
+}

--- a/packages/jetstream/src/decode-typed.ts
+++ b/packages/jetstream/src/decode-typed.ts
@@ -1,0 +1,54 @@
+import { type RecordSchema } from '@atproto/lex-schema'
+import { type RawEventV1, type TypedCommit, type TypedEvent } from './event.js'
+
+export function typedEventFromRaw(
+  raw: RawEventV1,
+  schemasByNsid: Map<string, RecordSchema>,
+): TypedEvent {
+  if (raw.kind !== 'commit') return raw
+  // Delete first: DeleteCommit carries no `record`, so the put-commit handling
+  // below only sees put commits.
+  if (raw.commit.operation === 'delete') {
+    return { ...raw, commit: raw.commit }
+  }
+  const rawCommit = raw.commit
+  const { collection, rkey, rev, operation } = rawCommit
+  // v1 put commit: the wire carried parsed JSON — there is no CBOR to decode.
+  // cid is the wire string (read for free via the delegating getter below).
+  const record: unknown = rawCommit.record
+  let validationError: Error | undefined
+  const schema = schemasByNsid.get(collection)
+  if (schema) {
+    const result = schema.safeValidate(record)
+    if (!result.success) {
+      validationError = new Error(
+        `record validation failed for ${collection}`,
+        {
+          cause: result.reason,
+        },
+      )
+    }
+  }
+  // cid delegates via a getter, mirroring the source package where the v2 raw
+  // layer computes it lazily; v1's cid is a plain string, read for free
+  // through the same getter. Keeping the delegation means the future v2 port
+  // changes nothing here.
+  const commit = {
+    operation,
+    collection,
+    rkey,
+    rev,
+    record,
+    ...(validationError ? { validationError } : {}),
+  } as TypedCommit
+  Object.defineProperty(commit, 'cid', {
+    enumerable: true,
+    configurable: true,
+    get(): string {
+      return rawCommit.cid
+    },
+  })
+  // NOTE: spreading the raw EVENT ({ ...raw, commit }) is fine — commit is
+  // replaced wholesale, so raw.commit.cid is never forced by the spread.
+  return { ...raw, commit }
+}

--- a/packages/jetstream/src/engine/collections.ts
+++ b/packages/jetstream/src/engine/collections.ts
@@ -21,7 +21,7 @@ function isOptsFilter(f: CollectionFilter): f is SchemaCollectionFilter {
   )
 }
 
-export function resolveNsids(filters: readonly CollectionFilter[]): {
+export function parseCollectionFilters(filters: readonly CollectionFilter[]): {
   nsids: string[]
   schemasByNsid: Map<string, RecordSchema>
 } {

--- a/packages/jetstream/src/engine/collections.ts
+++ b/packages/jetstream/src/engine/collections.ts
@@ -1,0 +1,21 @@
+import { type Main, type RecordSchema, getMain } from '@atproto/lex-schema'
+
+export type CollectionFilter = string | Main<RecordSchema>
+
+export function resolveNsids(filters: CollectionFilter[]): {
+  nsids: string[]
+  schemasByNsid: Map<string, RecordSchema>
+} {
+  const nsids: string[] = []
+  const schemasByNsid = new Map<string, RecordSchema>()
+  for (const f of filters) {
+    if (typeof f === 'string') {
+      nsids.push(f)
+    } else {
+      const schema = getMain(f)
+      nsids.push(schema.$type)
+      schemasByNsid.set(schema.$type, schema)
+    }
+  }
+  return { nsids, schemasByNsid }
+}

--- a/packages/jetstream/src/engine/collections.ts
+++ b/packages/jetstream/src/engine/collections.ts
@@ -1,4 +1,9 @@
-import { type Main, type RecordSchema, getMain } from '@atproto/lex-schema'
+import {
+  type Main,
+  type NsidString,
+  type RecordSchema,
+  getMain,
+} from '@atproto/lex-schema'
 
 export interface SchemaCollectionFilter {
   collection: Main<RecordSchema>
@@ -6,7 +11,7 @@ export interface SchemaCollectionFilter {
 }
 
 export type CollectionFilter =
-  string | Main<RecordSchema> | SchemaCollectionFilter
+  NsidString | `${string}.*` | Main<RecordSchema> | SchemaCollectionFilter
 
 // Discriminate the options form from schema shapes: a SchemaCollectionFilter
 // has `collection` and never `main` (namespace form) or `$type` (bare

--- a/packages/jetstream/src/engine/collections.ts
+++ b/packages/jetstream/src/engine/collections.ts
@@ -1,8 +1,27 @@
 import { type Main, type RecordSchema, getMain } from '@atproto/lex-schema'
 
-export type CollectionFilter = string | Main<RecordSchema>
+export interface SchemaCollectionFilter {
+  collection: Main<RecordSchema>
+  validateRecord?: boolean // default true
+}
 
-export function resolveNsids(filters: CollectionFilter[]): {
+export type CollectionFilter =
+  string | Main<RecordSchema> | SchemaCollectionFilter
+
+// Discriminate the options form from schema shapes: a SchemaCollectionFilter
+// has `collection` and never `main` (namespace form) or `$type` (bare
+// schema); a lexicon namespace could plausibly export a def named
+// `collection`, so the negative checks are load-bearing.
+function isOptsFilter(f: CollectionFilter): f is SchemaCollectionFilter {
+  return (
+    typeof f !== 'string' &&
+    'collection' in f &&
+    !('main' in f) &&
+    !('$type' in f)
+  )
+}
+
+export function resolveNsids(filters: readonly CollectionFilter[]): {
   nsids: string[]
   schemasByNsid: Map<string, RecordSchema>
 } {
@@ -11,11 +30,19 @@ export function resolveNsids(filters: CollectionFilter[]): {
   for (const f of filters) {
     if (typeof f === 'string') {
       nsids.push(f)
-    } else {
-      const schema = getMain(f)
-      nsids.push(schema.$type)
-      schemasByNsid.set(schema.$type, schema)
+      continue
     }
+    if (isOptsFilter(f)) {
+      const schema = getMain(f.collection)
+      nsids.push(schema.$type)
+      // set only, never delete: another filter may have registered a
+      // validating schema for the same NSID
+      if (f.validateRecord !== false) schemasByNsid.set(schema.$type, schema)
+      continue
+    }
+    const schema = getMain(f)
+    nsids.push(schema.$type)
+    schemasByNsid.set(schema.$type, schema)
   }
   return { nsids, schemasByNsid }
 }

--- a/packages/jetstream/src/errors.ts
+++ b/packages/jetstream/src/errors.ts
@@ -1,0 +1,9 @@
+// Ported from jetstream-sdk src/segment/read-cursor.ts (the v1-live subset
+// carries no segment machinery, so the error class lives here). The `segment:`
+// message prefix is preserved verbatim from the source package.
+export class MalformedError extends Error {
+  constructor(message: string) {
+    super(`segment: ${message}`)
+    this.name = 'MalformedError'
+  }
+}

--- a/packages/jetstream/src/errors.ts
+++ b/packages/jetstream/src/errors.ts
@@ -1,6 +1,6 @@
 export class MalformedError extends Error {
-  constructor(message: string) {
-    super(message)
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
     this.name = 'MalformedError'
   }
 }

--- a/packages/jetstream/src/errors.ts
+++ b/packages/jetstream/src/errors.ts
@@ -1,9 +1,6 @@
-// Ported from jetstream-sdk src/segment/read-cursor.ts (the v1-live subset
-// carries no segment machinery, so the error class lives here). The `segment:`
-// message prefix is preserved verbatim from the source package.
 export class MalformedError extends Error {
   constructor(message: string) {
-    super(`segment: ${message}`)
+    super(message)
     this.name = 'MalformedError'
   }
 }

--- a/packages/jetstream/src/event.ts
+++ b/packages/jetstream/src/event.ts
@@ -16,9 +16,19 @@ export interface EventBase {
   timeUs: number
 }
 
-export interface TypedPutCommit<R = unknown> {
+/**
+ * The record shape earned by collection filtering alone (no schema
+ * validation): the server routed the event by collection, and a record's
+ * $type is its collection NSID — we trust that rather than re-checking at
+ * runtime. TType carries the collection literal when the filter provides one.
+ */
+export type UnvalidatedRecord<TType extends string = string> = {
+  $type: TType
+} & Record<string, unknown>
+
+export interface TypedPutCommit<R = unknown, C extends string = string> {
   operation: 'create' | 'update'
-  collection: string
+  collection: C
   rkey: string
   rev: string
   cid: string
@@ -26,9 +36,9 @@ export interface TypedPutCommit<R = unknown> {
   validationError?: Error
 }
 
-export interface DeleteCommit {
+export interface DeleteCommit<C extends string = string> {
   operation: 'delete'
-  collection: string
+  collection: C
   rkey: string
   rev: string
 }

--- a/packages/jetstream/src/event.ts
+++ b/packages/jetstream/src/event.ts
@@ -1,3 +1,9 @@
+import {
+  type AtIdentifierString,
+  type NsidString,
+  atUri,
+} from '@atproto/lex-schema'
+
 export type Operation = 'create' | 'update' | 'delete'
 export type Kind = 'commit' | 'identity' | 'account'
 
@@ -84,7 +90,9 @@ export type RawEventV1 =
 /**
  * The at:// URI of a commit event (at://did/collection/rkey), or the bare DID
  * for non-commit kinds. Used as the default per-key serialization key for
- * concurrent indexers.
+ * concurrent indexers. atUri validates the components, so a commit event
+ * carrying a malformed did/collection/rkey throws rather than yielding a
+ * garbage URI.
  */
 export function eventUri(ev: {
   kind: string
@@ -92,7 +100,13 @@ export function eventUri(ev: {
   commit?: { collection: string; rkey: string }
 }): string {
   if (ev.kind === 'commit' && ev.commit) {
-    return `at://${ev.did}/${ev.commit.collection}/${ev.commit.rkey}`
+    // The wire carries plain strings; atUri asserts the formats at runtime,
+    // which is what makes these compile-time casts honest.
+    return atUri(
+      ev.did as AtIdentifierString,
+      ev.commit.collection as NsidString,
+      ev.commit.rkey,
+    )
   }
   return ev.did
 }

--- a/packages/jetstream/src/event.ts
+++ b/packages/jetstream/src/event.ts
@@ -1,3 +1,13 @@
+import {
+  type CidString,
+  type DatetimeString,
+  type DidString,
+  type HandleString,
+  type NsidString,
+  type RecordKeyString,
+  type TidString,
+} from '@atproto/lex-schema'
+
 export type Operation = 'create' | 'update' | 'delete'
 export type Kind = 'commit' | 'identity' | 'account'
 
@@ -11,7 +21,7 @@ export interface SeqEvent {
 }
 
 export interface EventBase {
-  did: string
+  did: DidString
   seq: number
   timeUs: number
 }
@@ -26,35 +36,35 @@ export type UnvalidatedRecord<TType extends string = string> = {
   $type: TType
 } & Record<string, unknown>
 
-export interface TypedPutCommit<R = unknown, C extends string = string> {
+export interface TypedPutCommit<R = unknown, C extends string = NsidString> {
   operation: 'create' | 'update'
   collection: C
-  rkey: string
-  rev: string
-  cid: string
+  rkey: RecordKeyString
+  rev: TidString
+  cid: CidString
   record: R
   validationError?: Error
 }
 
-export interface DeleteCommit<C extends string = string> {
+export interface DeleteCommit<C extends string = NsidString> {
   operation: 'delete'
   collection: C
-  rkey: string
-  rev: string
+  rkey: RecordKeyString
+  rev: TidString
 }
 
 export type TypedCommit<R = unknown> = TypedPutCommit<R> | DeleteCommit
 
 export interface Identity {
-  did: string
-  handle?: string
-  time?: string
+  did: DidString
+  handle?: HandleString
+  time?: DatetimeString
 }
 export interface Account {
-  did: string
+  did: DidString
   active: boolean
   status?: string
-  time?: string
+  time?: DatetimeString
 }
 
 export type TypedEvent<R = unknown> =
@@ -69,10 +79,10 @@ export interface EventBatch<E> {
 
 export interface RawPutCommitV1 {
   operation: 'create' | 'update'
-  collection: string
-  rkey: string
-  rev: string
-  cid: string
+  collection: NsidString
+  rkey: RecordKeyString
+  rev: TidString
+  cid: CidString
   record: unknown // v1 wire carries parsed JSON; no canonical CBOR exists
 }
 export type RawCommitV1 = RawPutCommitV1 | DeleteCommit

--- a/packages/jetstream/src/event.ts
+++ b/packages/jetstream/src/event.ts
@@ -1,0 +1,88 @@
+export type Operation = 'create' | 'update' | 'delete'
+export type Kind = 'commit' | 'identity' | 'account'
+
+/**
+ * The minimal envelope contract every event the SDK yields satisfies (v1: seq =
+ * time_us). It is the only thing the cursor/dedup/batching/tracking machinery
+ * needs.
+ */
+export interface SeqEvent {
+  seq: number
+}
+
+export interface EventBase {
+  did: string
+  seq: number
+  timeUs: number
+}
+
+export interface TypedPutCommit<R = unknown> {
+  operation: 'create' | 'update'
+  collection: string
+  rkey: string
+  rev: string
+  cid: string
+  record: R
+  validationError?: Error
+}
+
+export interface DeleteCommit {
+  operation: 'delete'
+  collection: string
+  rkey: string
+  rev: string
+}
+
+export type TypedCommit<R = unknown> = TypedPutCommit<R> | DeleteCommit
+
+export interface Identity {
+  did: string
+  handle?: string
+  time?: string
+}
+export interface Account {
+  did: string
+  active: boolean
+  status?: string
+  time?: string
+}
+
+export type TypedEvent<R = unknown> =
+  | (EventBase & { kind: 'commit'; commit: TypedCommit<R> })
+  | (EventBase & { kind: 'identity'; identity: Identity })
+  | (EventBase & { kind: 'account'; account: Account })
+
+export interface EventBatch<E> {
+  events: E[]
+  lastCursor: number
+}
+
+export interface RawPutCommitV1 {
+  operation: 'create' | 'update'
+  collection: string
+  rkey: string
+  rev: string
+  cid: string
+  record: unknown // v1 wire carries parsed JSON; no canonical CBOR exists
+}
+export type RawCommitV1 = RawPutCommitV1 | DeleteCommit
+export type RawEventV1 =
+  | (EventBase & { kind: 'commit'; commit: RawCommitV1 })
+  | (EventBase & { kind: 'identity'; identity: Identity })
+  | (EventBase & { kind: 'account'; account: Account })
+
+/**
+ * The at:// URI of a commit event (at://did/collection/rkey), or the bare DID
+ * for non-commit kinds. Used as the default per-key serialization key for
+ * concurrent indexers.
+ */
+export function eventUri(ev: {
+  kind: string
+  did: string
+  commit?: { collection: string; rkey: string }
+}): string {
+  if (ev.kind === 'commit' && ev.commit) {
+    return `at://${ev.did}/${ev.commit.collection}/${ev.commit.rkey}`
+  }
+  return ev.did
+}

--- a/packages/jetstream/src/event.ts
+++ b/packages/jetstream/src/event.ts
@@ -1,9 +1,3 @@
-import {
-  type AtIdentifierString,
-  type NsidString,
-  atUri,
-} from '@atproto/lex-schema'
-
 export type Operation = 'create' | 'update' | 'delete'
 export type Kind = 'commit' | 'identity' | 'account'
 
@@ -88,11 +82,12 @@ export type RawEventV1 =
   | (EventBase & { kind: 'account'; account: Account })
 
 /**
- * The at:// URI of a commit event (at://did/collection/rkey), or the bare DID
- * for non-commit kinds. Used as the default per-key serialization key for
- * concurrent indexers. atUri validates the components, so a commit event
- * carrying a malformed did/collection/rkey throws rather than yielding a
- * garbage URI.
+ * Default per-key serialization key for concurrent indexers: the record path
+ * of a commit event, or the bare DID for non-commit kinds. This is ONLY a
+ * concurrency key — it needs stability and per-record uniqueness, not AT-URI
+ * validity, so naive concatenation is correct and cheap. It must not double
+ * as an event's public `uri`: it skips URI validation and can return a bare
+ * DID.
  */
 export function eventUri(ev: {
   kind: string
@@ -100,13 +95,7 @@ export function eventUri(ev: {
   commit?: { collection: string; rkey: string }
 }): string {
   if (ev.kind === 'commit' && ev.commit) {
-    // The wire carries plain strings; atUri asserts the formats at runtime,
-    // which is what makes these compile-time casts honest.
-    return atUri(
-      ev.did as AtIdentifierString,
-      ev.commit.collection as NsidString,
-      ev.commit.rkey,
-    )
+    return `at://${ev.did}/${ev.commit.collection}/${ev.commit.rkey}`
   }
   return ev.did
 }

--- a/packages/jetstream/src/execute/commit-tracker.ts
+++ b/packages/jetstream/src/execute/commit-tracker.ts
@@ -4,10 +4,8 @@ export class CommitTracker {
   private readonly store: CursorStore | undefined
   private readonly tracked: number[] = []
   private readonly doneSet = new Set<number>()
-  private cursor = 0 // index into tracked of the next not-yet-confirmed seq
   private mark = 0
   private savePromise: Promise<void> | undefined
-  private pendingSave = false
 
   constructor(store?: CursorStore) {
     this.store = store
@@ -20,20 +18,20 @@ export class CommitTracker {
 
   done(seq: number): void {
     this.doneSet.add(seq)
+    let cursor = 0 // index into tracked of the next not-yet-confirmed seq
     while (
-      this.cursor < this.tracked.length &&
-      this.doneSet.has(this.tracked[this.cursor])
+      cursor < this.tracked.length &&
+      this.doneSet.has(this.tracked[cursor])
     ) {
-      this.mark = this.tracked[this.cursor]
-      this.doneSet.delete(this.tracked[this.cursor])
-      this.cursor++
+      this.mark = this.tracked[cursor]
+      this.doneSet.delete(this.tracked[cursor])
+      cursor++
     }
     // Trim consumed prefix to bound memory usage
-    if (this.cursor > 0) {
-      this.tracked.splice(0, this.cursor)
-      this.cursor = 0
+    if (cursor > 0) {
+      this.tracked.splice(0, cursor)
     }
-    void this.scheduleSave()
+    this.scheduleSave()
   }
 
   watermark(): number {
@@ -43,18 +41,15 @@ export class CommitTracker {
   async flush(): Promise<void> {
     if (!this.store) return
     // Ensure a save covering the current mark is scheduled, then wait for drain.
-    this.pendingSave = true
-    if (!this.savePromise) {
-      this.savePromise = this.runSaveLoop()
-    }
+    this.scheduleSave()
     await this.savePromise
   }
 
-  // Coalesced save: at most one in-flight store.save; a request during a save
-  // triggers exactly one more save afterward with the latest watermark.
+  // Coalesced save: at most one in-flight store.save; the loop re-saves until
+  // the saved value catches up with the latest watermark, so saves requested
+  // during an in-flight save collapse into exactly one more.
   private scheduleSave(): void {
     if (!this.store) return
-    this.pendingSave = true
     if (!this.savePromise) {
       this.savePromise = this.runSaveLoop()
     }
@@ -62,10 +57,11 @@ export class CommitTracker {
 
   private async runSaveLoop(): Promise<void> {
     try {
+      let saved: number
       do {
-        this.pendingSave = false
-        await this.store!.save(this.mark)
-      } while (this.pendingSave)
+        saved = this.mark
+        await this.store!.save(saved)
+      } while (saved !== this.mark)
     } finally {
       this.savePromise = undefined
     }

--- a/packages/jetstream/src/execute/commit-tracker.ts
+++ b/packages/jetstream/src/execute/commit-tracker.ts
@@ -1,0 +1,73 @@
+import { type CursorStore } from './cursor-store.js'
+
+export class CommitTracker {
+  private readonly store: CursorStore | undefined
+  private readonly tracked: number[] = []
+  private readonly doneSet = new Set<number>()
+  private cursor = 0 // index into tracked of the next not-yet-confirmed seq
+  private mark = 0
+  private savePromise: Promise<void> | undefined
+  private pendingSave = false
+
+  constructor(store?: CursorStore) {
+    this.store = store
+  }
+
+  track(seq: number): void {
+    // Dispatch is in ascending seq order; push maintains the invariant.
+    this.tracked.push(seq)
+  }
+
+  done(seq: number): void {
+    this.doneSet.add(seq)
+    while (
+      this.cursor < this.tracked.length &&
+      this.doneSet.has(this.tracked[this.cursor])
+    ) {
+      this.mark = this.tracked[this.cursor]
+      this.doneSet.delete(this.tracked[this.cursor])
+      this.cursor++
+    }
+    // Trim consumed prefix to bound memory usage
+    if (this.cursor > 0) {
+      this.tracked.splice(0, this.cursor)
+      this.cursor = 0
+    }
+    void this.scheduleSave()
+  }
+
+  watermark(): number {
+    return this.mark
+  }
+
+  async flush(): Promise<void> {
+    if (!this.store) return
+    // Ensure a save covering the current mark is scheduled, then wait for drain.
+    this.pendingSave = true
+    if (!this.savePromise) {
+      this.savePromise = this.runSaveLoop()
+    }
+    await this.savePromise
+  }
+
+  // Coalesced save: at most one in-flight store.save; a request during a save
+  // triggers exactly one more save afterward with the latest watermark.
+  private scheduleSave(): void {
+    if (!this.store) return
+    this.pendingSave = true
+    if (!this.savePromise) {
+      this.savePromise = this.runSaveLoop()
+    }
+  }
+
+  private async runSaveLoop(): Promise<void> {
+    try {
+      do {
+        this.pendingSave = false
+        await this.store!.save(this.mark)
+      } while (this.pendingSave)
+    } finally {
+      this.savePromise = undefined
+    }
+  }
+}

--- a/packages/jetstream/src/execute/cursor-store.ts
+++ b/packages/jetstream/src/execute/cursor-store.ts
@@ -1,0 +1,14 @@
+export interface CursorStore {
+  load(): Promise<number | undefined>
+  save(seq: number): Promise<void>
+}
+
+export class MemoryCursorStore implements CursorStore {
+  private value: number | undefined
+  async load(): Promise<number | undefined> {
+    return this.value
+  }
+  async save(seq: number): Promise<void> {
+    this.value = seq
+  }
+}

--- a/packages/jetstream/src/filter-types.ts
+++ b/packages/jetstream/src/filter-types.ts
@@ -1,0 +1,58 @@
+import { type InferOutput, type RecordSchema } from '@atproto/lex-schema'
+import { type CollectionFilter } from './engine/collections.js'
+import {
+  type Account,
+  type DeleteCommit,
+  type EventBase,
+  type Identity,
+  type TypedEvent,
+  type TypedPutCommit,
+  type UnvalidatedRecord,
+} from './event.js'
+
+// Unwrap Main<S> = S | { main: S } to the schema itself.
+type MainOf<M> = M extends { main: infer S } ? S : M
+
+// Put + delete union for one collection literal. UnvalidatedCommit keeps
+// validationError (decode failures still flow through it); ValidatedCommit
+// drops it — invalid events were skipped, so record is honestly valid. These
+// names surface in editor hovers on TypedCommitFor.
+type UnvalidatedCommit<C extends string, R> =
+  TypedPutCommit<R, C> | DeleteCommit<C>
+type ValidatedCommit<C extends string, R> =
+  Omit<TypedPutCommit<R, C>, 'validationError'> | DeleteCommit<C>
+
+// 'app.test.*' → `app.test.${string}`; literal NSIDs keep their literal;
+// non-literal string degrades to string.
+type StringFilterCommit<F extends string> = F extends `${infer P}.*`
+  ? UnvalidatedCommit<`${P}.${string}`, UnvalidatedRecord<`${P}.${string}`>>
+  : string extends F
+    ? UnvalidatedCommit<string, UnvalidatedRecord>
+    : UnvalidatedCommit<F, UnvalidatedRecord<F>>
+
+// The commit shape(s) contributed by ONE filter. Distributes over a union of
+// filters (F[number]) to build the correlated union: checking
+// commit.collection === '...' narrows commit.record.
+export type TypedCommitFor<F extends CollectionFilter> = F extends string
+  ? StringFilterCommit<F>
+  : F extends { collection: infer M; validateRecord: false }
+    ? MainOf<M> extends infer S extends RecordSchema
+      ? UnvalidatedCommit<S['$type'], UnvalidatedRecord<S['$type']>>
+      : never
+    : F extends { collection: infer M }
+      ? MainOf<M> extends infer S extends RecordSchema
+        ? ValidatedCommit<S['$type'], InferOutput<S>>
+        : never
+      : MainOf<F> extends infer S extends RecordSchema
+        ? ValidatedCommit<S['$type'], InferOutput<S>>
+        : never
+
+// The typed event union for a filter tuple. No filters (readonly []) means
+// no narrowing was earned: plain TypedEvent. Non-commit kinds are identical
+// across all filters.
+export type TypedEventFor<F extends readonly CollectionFilter[]> =
+  F extends readonly []
+    ? TypedEvent
+    : | (EventBase & { kind: 'commit'; commit: TypedCommitFor<F[number]> })
+      | (EventBase & { kind: 'identity'; identity: Identity })
+      | (EventBase & { kind: 'account'; account: Account })

--- a/packages/jetstream/src/index.ts
+++ b/packages/jetstream/src/index.ts
@@ -3,7 +3,10 @@ export { Jetstream } from './jetstream.js'
 export type { JetstreamOpts, LiveOpts } from './jetstream.js'
 export { typedEventFromRaw } from './decode-typed.js'
 export type { LiveTransport } from './live/transport.js'
-export type { CollectionFilter } from './engine/collections.js'
+export type {
+  CollectionFilter,
+  SchemaCollectionFilter,
+} from './engine/collections.js'
 export type {
   Account,
   DeleteCommit,
@@ -15,8 +18,10 @@ export type {
   SeqEvent,
   TypedCommit,
   TypedEvent,
+  UnvalidatedRecord,
 } from './event.js'
 export { eventUri } from './event.js'
+export type { TypedCommitFor, TypedEventFor } from './filter-types.js'
 export { CommitTracker } from './execute/commit-tracker.js'
 export { type CursorStore, MemoryCursorStore } from './execute/cursor-store.js'
 export { LexIndexer } from './lex-indexer.js'
@@ -28,10 +33,10 @@ export type {
   IdentityEvent,
   LexIndexerOpts,
   PutEvent,
-  UnvalidatedRecord,
   ValidationErrorEvent,
 } from './lex-indexer.js'
 export type { Ack, ConsumerContext, JetstreamConsumer } from './consumer.js'
 export { JetstreamRunner } from './runner.js'
 export type { RunnerLiveOpts } from './runner.js'
 export { MalformedError } from './errors.js'
+export { RecordValidationError } from './shape.js'

--- a/packages/jetstream/src/index.ts
+++ b/packages/jetstream/src/index.ts
@@ -19,7 +19,6 @@ export type {
   TypedEvent,
   UnvalidatedRecord,
 } from './event.js'
-export { eventUri } from './event.js'
 export type { TypedCommitFor, TypedEventFor } from './filter-types.js'
 export { CommitTracker } from './execute/commit-tracker.js'
 export { type CursorStore, MemoryCursorStore } from './execute/cursor-store.js'

--- a/packages/jetstream/src/index.ts
+++ b/packages/jetstream/src/index.ts
@@ -1,4 +1,3 @@
-export { PACKAGE_NAME } from './version.js'
 export { Jetstream } from './jetstream.js'
 export type { JetstreamOpts, LiveOpts } from './jetstream.js'
 export { typedEventFromRaw } from './decode-typed.js'

--- a/packages/jetstream/src/index.ts
+++ b/packages/jetstream/src/index.ts
@@ -1,7 +1,11 @@
 export { Jetstream } from './jetstream.js'
 export type { JetstreamOpts, LiveOpts } from './jetstream.js'
 export { typedEventFromRaw } from './decode-typed.js'
-export type { LiveTransport } from './live/transport.js'
+export { websocketTransport } from './live/transport.js'
+export type {
+  LiveTransport,
+  WebsocketTransportOptions,
+} from './live/transport.js'
 export type {
   CollectionFilter,
   SchemaCollectionFilter,

--- a/packages/jetstream/src/index.ts
+++ b/packages/jetstream/src/index.ts
@@ -1,0 +1,37 @@
+export { PACKAGE_NAME } from './version.js'
+export { Jetstream } from './jetstream.js'
+export type { JetstreamOpts, LiveOpts } from './jetstream.js'
+export { typedEventFromRaw } from './decode-typed.js'
+export type { LiveTransport } from './live/transport.js'
+export type { CollectionFilter } from './engine/collections.js'
+export type {
+  Account,
+  DeleteCommit,
+  EventBatch,
+  Identity,
+  RawCommitV1,
+  RawEventV1,
+  RawPutCommitV1,
+  SeqEvent,
+  TypedCommit,
+  TypedEvent,
+} from './event.js'
+export { eventUri } from './event.js'
+export { CommitTracker } from './execute/commit-tracker.js'
+export { type CursorStore, MemoryCursorStore } from './execute/cursor-store.js'
+export { LexIndexer } from './lex-indexer.js'
+export type {
+  AccountEvent,
+  CommitHandlers,
+  DelEvent,
+  HandlerContext,
+  IdentityEvent,
+  LexIndexerOpts,
+  PutEvent,
+  UnvalidatedRecord,
+  ValidationErrorEvent,
+} from './lex-indexer.js'
+export type { Ack, ConsumerContext, JetstreamConsumer } from './consumer.js'
+export { JetstreamRunner } from './runner.js'
+export type { RunnerLiveOpts } from './runner.js'
+export { MalformedError } from './errors.js'

--- a/packages/jetstream/src/jetstream.ts
+++ b/packages/jetstream/src/jetstream.ts
@@ -4,7 +4,7 @@ import { type CollectionFilter, resolveNsids } from './engine/collections.js'
 import { type EventBatch, type RawEventV1, type TypedEvent } from './event.js'
 import { type CursorStore } from './execute/cursor-store.js'
 import { type TypedEventFor } from './filter-types.js'
-import { batchEvents, liveEvents } from './live/source.js'
+import { liveEvents } from './live/source.js'
 import { type LiveTransport } from './live/transport.js'
 import { JetstreamRunner } from './runner.js'
 import { shape } from './shape.js'
@@ -22,7 +22,6 @@ export interface LiveOpts<
   signal?: AbortSignal
   onError?: (err: Error) => void
   liveTransport?: LiveTransport
-  liveBatchSize?: number
   raw?: boolean
 }
 
@@ -49,28 +48,28 @@ export class Jetstream {
     return new JetstreamRunner(this, consumer)
   }
 
-  // The raw batch stream underlying live(); the runner drives it directly
-  // (the source package reached it through live()'s batched mode, which is
-  // not part of this package's public surface).
+  // The raw batch stream underlying live(); the runner drives it directly.
+  // Each event is wrapped in a trivial single-event "batch" with NO extra
+  // buffering — live delivery stays realtime. EventBatch is used only as the
+  // standard internal interface, looking ahead to v2 modes (snapshot/replay)
+  // where batches carry real grouping.
   async *liveRawBatches(
     opts: LiveOpts,
   ): AsyncGenerator<EventBatch<RawEventV1>> {
     const host = this.service
     const { nsids } = resolveNsids(opts.collections ?? [])
-    const batchSize = opts.liveBatchSize ?? 64
     const start = await opts.cursor?.load()
-    yield* batchEvents(
-      liveEvents({
-        host,
-        collections: nsids,
-        dids: opts.dids,
-        cursor: start,
-        dedupFloor: start, // a resume cursor is also the dedup floor
-        transport: opts.liveTransport,
-        signal: opts.signal,
-        onError: opts.onError,
-      }),
-      batchSize,
-    )
+    for await (const ev of liveEvents({
+      host,
+      collections: nsids,
+      dids: opts.dids,
+      cursor: start,
+      dedupFloor: start, // a resume cursor is also the dedup floor
+      transport: opts.liveTransport,
+      signal: opts.signal,
+      onError: opts.onError,
+    })) {
+      yield { events: [ev], lastCursor: ev.seq }
+    }
   }
 }

--- a/packages/jetstream/src/jetstream.ts
+++ b/packages/jetstream/src/jetstream.ts
@@ -1,6 +1,8 @@
-// src/jetstream.ts
 import { type JetstreamConsumer } from './consumer.js'
-import { type CollectionFilter, resolveNsids } from './engine/collections.js'
+import {
+  type CollectionFilter,
+  parseCollectionFilters,
+} from './engine/collections.js'
 import { type EventBatch, type RawEventV1, type TypedEvent } from './event.js'
 import { type CursorStore } from './execute/cursor-store.js'
 import { type TypedEventFor } from './filter-types.js'
@@ -40,7 +42,7 @@ export class Jetstream {
   ): AsyncGenerator<TypedEventFor<F>>
   live(opts: LiveOpts & { raw: true }): AsyncGenerator<RawEventV1>
   live(opts: LiveOpts = {}): AsyncGenerator<RawEventV1 | TypedEvent> {
-    const { schemasByNsid } = resolveNsids(opts.collections ?? [])
+    const { schemasByNsid } = parseCollectionFilters(opts.collections ?? [])
     return shape(this.liveRawBatches(opts), opts, schemasByNsid, opts.onError)
   }
 
@@ -57,7 +59,7 @@ export class Jetstream {
     opts: LiveOpts,
   ): AsyncGenerator<EventBatch<RawEventV1>> {
     const host = this.service
-    const { nsids } = resolveNsids(opts.collections ?? [])
+    const { nsids } = parseCollectionFilters(opts.collections ?? [])
     const start = await opts.cursor?.load()
     for await (const ev of liveEvents({
       host,

--- a/packages/jetstream/src/jetstream.ts
+++ b/packages/jetstream/src/jetstream.ts
@@ -1,9 +1,18 @@
+import { type DidString } from '@atproto/lex-schema'
 import { type JetstreamConsumer } from './consumer.js'
 import {
   type CollectionFilter,
   parseCollectionFilters,
 } from './engine/collections.js'
-import { type EventBatch, type RawEventV1, type TypedEvent } from './event.js'
+import {
+  type Account,
+  type DeleteCommit,
+  type EventBase,
+  type EventBatch,
+  type Identity,
+  type RawEventV1,
+  type TypedPutCommit,
+} from './event.js'
 import { type CursorStore } from './execute/cursor-store.js'
 import { type TypedEventFor } from './filter-types.js'
 import { liveEvents } from './live/source.js'
@@ -13,19 +22,38 @@ import { shape } from './shape.js'
 
 export interface JetstreamOpts {
   service: string
+  /**
+   * Strict wire validation. By default the branded string types on events are
+   * optimistic — "the server said so." With validateWire: true, every decode
+   * boundary checks its wire schema (lex-schema format validators); any
+   * violation — including otherwise-skipped malformed frames — throws
+   * MalformedError, fatal in every mode.
+   */
+  validateWire?: boolean
 }
 
 export interface LiveOpts<
   F extends readonly CollectionFilter[] = readonly CollectionFilter[],
 > {
   collections?: F
-  dids?: string[]
+  dids?: DidString[]
   cursor?: CursorStore
   signal?: AbortSignal
   onError?: (err: Error) => void
   liveTransport?: LiveTransport
   raw?: boolean
 }
+
+// Widest typed event accepted by the impl signature: collection is `string`
+// (not narrowed to NsidString) so TypedEventFor<F> is assignable here for any
+// CollectionFilter tuple F. record: unknown covers validated and unvalidated.
+type WideTypedEvent =
+  | (EventBase & {
+      kind: 'commit'
+      commit: TypedPutCommit<unknown, string> | DeleteCommit<string>
+    })
+  | (EventBase & { kind: 'identity'; identity: Identity })
+  | (EventBase & { kind: 'account'; account: Account })
 
 export class Jetstream {
   readonly service: string
@@ -41,7 +69,7 @@ export class Jetstream {
     opts?: LiveOpts<F> & { raw?: false },
   ): AsyncGenerator<TypedEventFor<F>>
   live(opts: LiveOpts & { raw: true }): AsyncGenerator<RawEventV1>
-  live(opts: LiveOpts = {}): AsyncGenerator<RawEventV1 | TypedEvent> {
+  live(opts: LiveOpts = {}): AsyncGenerator<RawEventV1 | WideTypedEvent> {
     const { schemasByNsid } = parseCollectionFilters(opts.collections ?? [])
     return shape(this.liveRawBatches(opts), opts, schemasByNsid, opts.onError)
   }
@@ -70,6 +98,7 @@ export class Jetstream {
       transport: opts.liveTransport,
       signal: opts.signal,
       onError: opts.onError,
+      validateWire: this.opts.validateWire,
     })) {
       yield { events: [ev], lastCursor: ev.seq }
     }

--- a/packages/jetstream/src/jetstream.ts
+++ b/packages/jetstream/src/jetstream.ts
@@ -1,0 +1,71 @@
+// src/jetstream.ts
+import { type JetstreamConsumer } from './consumer.js'
+import { type CollectionFilter, resolveNsids } from './engine/collections.js'
+import { type EventBatch, type RawEventV1, type TypedEvent } from './event.js'
+import { type CursorStore } from './execute/cursor-store.js'
+import { batchEvents, liveEvents } from './live/source.js'
+import { type LiveTransport } from './live/transport.js'
+import { JetstreamRunner } from './runner.js'
+import { shape } from './shape.js'
+
+export interface JetstreamOpts {
+  service: string
+}
+
+export interface LiveOpts {
+  collections?: CollectionFilter[]
+  dids?: string[]
+  cursor?: CursorStore
+  signal?: AbortSignal
+  onError?: (err: Error) => void
+  liveTransport?: LiveTransport
+  liveBatchSize?: number
+  raw?: boolean
+}
+
+export class Jetstream {
+  readonly service: string
+  readonly opts: JetstreamOpts
+
+  constructor(service: string | JetstreamOpts) {
+    const opts = typeof service === 'string' ? { service } : service
+    this.service = opts.service
+    this.opts = opts
+  }
+
+  live(opts?: LiveOpts & { raw?: false }): AsyncGenerator<TypedEvent>
+  live(opts: LiveOpts & { raw: true }): AsyncGenerator<RawEventV1>
+  live(opts: LiveOpts = {}): AsyncGenerator<RawEventV1 | TypedEvent> {
+    const { schemasByNsid } = resolveNsids(opts.collections ?? [])
+    return shape(this.liveRawBatches(opts), opts, schemasByNsid)
+  }
+
+  runner(consumer: JetstreamConsumer): JetstreamRunner {
+    return new JetstreamRunner(this, consumer)
+  }
+
+  // The raw batch stream underlying live(); the runner drives it directly
+  // (the source package reached it through live()'s batched mode, which is
+  // not part of this package's public surface).
+  async *liveRawBatches(
+    opts: LiveOpts,
+  ): AsyncGenerator<EventBatch<RawEventV1>> {
+    const host = this.service
+    const { nsids } = resolveNsids(opts.collections ?? [])
+    const batchSize = opts.liveBatchSize ?? 64
+    const start = await opts.cursor?.load()
+    yield* batchEvents(
+      liveEvents({
+        host,
+        collections: nsids,
+        dids: opts.dids,
+        cursor: start,
+        dedupFloor: start, // a resume cursor is also the dedup floor
+        transport: opts.liveTransport,
+        signal: opts.signal,
+        onError: opts.onError,
+      }),
+      batchSize,
+    )
+  }
+}

--- a/packages/jetstream/src/jetstream.ts
+++ b/packages/jetstream/src/jetstream.ts
@@ -3,6 +3,7 @@ import { type JetstreamConsumer } from './consumer.js'
 import { type CollectionFilter, resolveNsids } from './engine/collections.js'
 import { type EventBatch, type RawEventV1, type TypedEvent } from './event.js'
 import { type CursorStore } from './execute/cursor-store.js'
+import { type TypedEventFor } from './filter-types.js'
 import { batchEvents, liveEvents } from './live/source.js'
 import { type LiveTransport } from './live/transport.js'
 import { JetstreamRunner } from './runner.js'
@@ -12,8 +13,10 @@ export interface JetstreamOpts {
   service: string
 }
 
-export interface LiveOpts {
-  collections?: CollectionFilter[]
+export interface LiveOpts<
+  F extends readonly CollectionFilter[] = readonly CollectionFilter[],
+> {
+  collections?: F
   dids?: string[]
   cursor?: CursorStore
   signal?: AbortSignal
@@ -33,11 +36,13 @@ export class Jetstream {
     this.opts = opts
   }
 
-  live(opts?: LiveOpts & { raw?: false }): AsyncGenerator<TypedEvent>
+  live<const F extends readonly CollectionFilter[] = readonly []>(
+    opts?: LiveOpts<F> & { raw?: false },
+  ): AsyncGenerator<TypedEventFor<F>>
   live(opts: LiveOpts & { raw: true }): AsyncGenerator<RawEventV1>
   live(opts: LiveOpts = {}): AsyncGenerator<RawEventV1 | TypedEvent> {
     const { schemasByNsid } = resolveNsids(opts.collections ?? [])
-    return shape(this.liveRawBatches(opts), opts, schemasByNsid)
+    return shape(this.liveRawBatches(opts), opts, schemasByNsid, opts.onError)
   }
 
   runner(consumer: JetstreamConsumer): JetstreamRunner {

--- a/packages/jetstream/src/lex-indexer.ts
+++ b/packages/jetstream/src/lex-indexer.ts
@@ -1,4 +1,3 @@
-// src/lex-indexer.ts
 import {
   type InferOutput,
   type Main,
@@ -82,6 +81,11 @@ export interface LexIndexerOpts {
   concurrency?: number
   keyOf?: (evt: RawEventV1) => string
 }
+
+const isThenable = (v: unknown): v is PromiseLike<unknown> =>
+  v !== null &&
+  (typeof v === 'object' || typeof v === 'function') &&
+  typeof (v as { then?: unknown }).then === 'function'
 
 // Internal, type-erased handler record stored per commit-collection NSID.
 // Retains the resolved schema so run() can build the schemasByNsid map needed
@@ -373,11 +377,6 @@ export class LexIndexer implements JetstreamConsumer {
       }
       return undefined
     }
-
-    const isThenable = (v: unknown): v is PromiseLike<unknown> =>
-      v !== null &&
-      (typeof v === 'object' || typeof v === 'function') &&
-      typeof (v as { then?: unknown }).then === 'function'
 
     // Centralized settle: on success (err === undefined && !skipAck) ack the
     // event; on error record firstError once and set stopped (never ack); a

--- a/packages/jetstream/src/lex-indexer.ts
+++ b/packages/jetstream/src/lex-indexer.ts
@@ -4,6 +4,7 @@ import {
   type RecordSchema,
   getMain,
 } from '@atproto/lex-schema'
+import { AtUri } from '@atproto/syntax'
 import { type ConsumerContext, type JetstreamConsumer } from './consumer.js'
 import { typedEventFromRaw } from './decode-typed.js'
 import { type CollectionFilter } from './engine/collections.js'
@@ -86,6 +87,29 @@ const isThenable = (v: unknown): v is PromiseLike<unknown> =>
   v !== null &&
   (typeof v === 'object' || typeof v === 'function') &&
   typeof (v as { then?: unknown }).then === 'function'
+
+// Cache slot for the lazily-computed event uri. A symbol keeps it out of the
+// event's declared type (and out of JSON/spread/Object.keys).
+const kUri = Symbol('jetstream.uri')
+
+// Lazily builds and caches the validated at:// URI of a commit event. PERF:
+// most handlers never read `uri`; AtUri.make validates (and can throw on
+// mangled wire components), so the cost — and the throw — happen only on
+// first read, inside the handler's guarded execution. `self` is the event
+// object (`this` inside its getter); the cast adds the symbol slot the event
+// types deliberately don't declare.
+function lazyUri(
+  self: object,
+  did: string,
+  commit: { collection: string; rkey: string },
+): string {
+  const cache = self as { [kUri]?: string }
+  return (cache[kUri] ??= AtUri.make(
+    did,
+    commit.collection,
+    commit.rkey,
+  ).toString())
+}
 
 // Internal, type-erased handler record stored per commit-collection NSID.
 // Retains the resolved schema so run() can build the schemasByNsid map needed
@@ -302,15 +326,19 @@ export class LexIndexer implements JetstreamConsumer {
       if (!handlers) return undefined // unregistered collection: skip
       if (evt.commit.operation === 'delete') {
         if (handlers.del) {
+          const did = evt.did
+          const c = evt.commit
           return handlers.del(
             {
-              did: evt.did,
+              did,
               seq: evt.seq,
               operation: 'delete',
-              collection: evt.commit.collection,
-              rkey: evt.commit.rkey,
-              rev: evt.commit.rev,
-              uri: eventUri(evt),
+              collection: c.collection,
+              rkey: c.rkey,
+              rev: c.rev,
+              get uri(): string {
+                return lazyUri(this, did, c)
+              },
             },
             hctx,
           )
@@ -327,52 +355,50 @@ export class LexIndexer implements JetstreamConsumer {
         // Invalid record: fails schema-validation. Never reaches put; route to
         // the optional handler, otherwise ack-and-skip.
         if (this.#validationErrorHandler) {
+          const did = typed.did
           const tc = typed.commit
+          const error = typed.commit.validationError
           // PERF: cid delegates to the commit getter — do not inline
           // `cid: tc.cid` here; the source package's v2 path computes it
-          // lazily and the delegation keeps both ports identical. Cast is
-          // local because the object is completed by defineProperty below.
-          const errEvt = {
-            did: typed.did,
+          // lazily and the delegation keeps both ports identical.
+          const errEvt: ValidationErrorEvent = {
+            did,
             seq: typed.seq,
             operation: tc.operation,
             collection: tc.collection,
             rkey: tc.rkey,
             rev: tc.rev,
-            uri: eventUri(typed),
-            error: tc.validationError,
-          } as ValidationErrorEvent
-          Object.defineProperty(errEvt, 'cid', {
-            enumerable: true,
-            configurable: true,
-            get(): string {
+            get uri(): string {
+              return lazyUri(this, did, tc)
+            },
+            get cid(): string {
               return tc.cid
             },
-          })
+            error,
+          }
           return this.#validationErrorHandler(errEvt, hctx)
         }
         return undefined
       }
       if (handlers.put) {
+        const did = typed.did
         const tc = typed.commit
         // PERF: cid delegates to the commit getter (see note above).
-        const putEvt = {
-          did: typed.did,
+        const putEvt: PutEvent<never> = {
+          did,
           seq: typed.seq,
           operation: tc.operation,
           collection: tc.collection,
           rkey: tc.rkey,
           rev: tc.rev,
-          uri: eventUri(typed),
-          record: tc.record,
-        } as PutEvent<never>
-        Object.defineProperty(putEvt, 'cid', {
-          enumerable: true,
-          configurable: true,
-          get(): string {
+          get uri(): string {
+            return lazyUri(this, did, tc)
+          },
+          get cid(): string {
             return tc.cid
           },
-        })
+          record: tc.record as never,
+        }
         return handlers.put(putEvt, hctx)
       }
       return undefined
@@ -402,6 +428,10 @@ export class LexIndexer implements JetstreamConsumer {
     // dispatched event), fail-fast without acking the failed event. The async
     // fallback below is the original chain semantics.
     const dispatch = (evt: RawEventV1): void => {
+      // NOTE: keyOf is deliberately NOT guarded — a key-computation failure is
+      // an implementer bug (broken custom keyOf) and should throw hard out of
+      // run() rather than be settled like a handler error. The default
+      // (eventUri) is plain string concatenation and cannot throw.
       const key = keyOf(evt)
       const prev = keyTails.get(key)
       if (prev === undefined) {

--- a/packages/jetstream/src/lex-indexer.ts
+++ b/packages/jetstream/src/lex-indexer.ts
@@ -377,7 +377,7 @@ export class LexIndexer implements JetstreamConsumer {
             get uri(): AtUriString {
               return lazyUri(this, did, tc)
             },
-            get cid(): string {
+            get cid(): CidString {
               return tc.cid
             },
             error,
@@ -404,7 +404,7 @@ export class LexIndexer implements JetstreamConsumer {
           get uri(): AtUriString {
             return lazyUri(this, did, tc)
           },
-          get cid(): string {
+          get cid(): CidString {
             return tc.cid
           },
           record: tc.record,

--- a/packages/jetstream/src/lex-indexer.ts
+++ b/packages/jetstream/src/lex-indexer.ts
@@ -1,10 +1,12 @@
 import {
+  type AtIdentifierString,
   type InferOutput,
   type Main,
+  type NsidString,
   type RecordSchema,
+  atUri,
   getMain,
 } from '@atproto/lex-schema'
-import { AtUri } from '@atproto/syntax'
 import { type ConsumerContext, type JetstreamConsumer } from './consumer.js'
 import { typedEventFromRaw } from './decode-typed.js'
 import { type CollectionFilter } from './engine/collections.js'
@@ -93,22 +95,23 @@ const isThenable = (v: unknown): v is PromiseLike<unknown> =>
 const kUri = Symbol('jetstream.uri')
 
 // Lazily builds and caches the validated at:// URI of a commit event. PERF:
-// most handlers never read `uri`; AtUri.make validates (and can throw on
-// mangled wire components), so the cost — and the throw — happen only on
-// first read, inside the handler's guarded execution. `self` is the event
-// object (`this` inside its getter); the cast adds the symbol slot the event
-// types deliberately don't declare.
+// most handlers never read `uri`; atUri validates (and can throw on mangled
+// wire components), so the cost — and the throw — happen only on first read,
+// inside the handler's guarded execution. The wire carries plain strings; the
+// runtime assertions inside atUri are what make the branded casts honest.
+// `self` is the event object (`this` inside its getter); the cast adds the
+// symbol slot the event types deliberately don't declare.
 function lazyUri(
   self: object,
   did: string,
   commit: { collection: string; rkey: string },
 ): string {
   const cache = self as { [kUri]?: string }
-  return (cache[kUri] ??= AtUri.make(
-    did,
-    commit.collection,
+  return (cache[kUri] ??= atUri(
+    did as AtIdentifierString,
+    commit.collection as NsidString,
     commit.rkey,
-  ).toString())
+  ))
 }
 
 // Internal, type-erased handler record stored per commit-collection NSID.
@@ -383,8 +386,12 @@ export class LexIndexer implements JetstreamConsumer {
       if (handlers.put) {
         const did = typed.did
         const tc = typed.commit
-        // PERF: cid delegates to the commit getter (see note above).
-        const putEvt: PutEvent<never> = {
+        // PERF: cid delegates to the commit getter (see note above). The
+        // record is defined here — its static type is unknown at this
+        // type-erased site (handlers are stored as PutEvent<unknown>); the
+        // commit() overloads guarantee the runtime shape matches what the
+        // registered handler expects.
+        const putEvt: PutEvent<unknown> = {
           did,
           seq: typed.seq,
           operation: tc.operation,
@@ -397,7 +404,7 @@ export class LexIndexer implements JetstreamConsumer {
           get cid(): string {
             return tc.cid
           },
-          record: tc.record as never,
+          record: tc.record,
         }
         return handlers.put(putEvt, hctx)
       }

--- a/packages/jetstream/src/lex-indexer.ts
+++ b/packages/jetstream/src/lex-indexer.ts
@@ -8,7 +8,11 @@ import {
 import { type ConsumerContext, type JetstreamConsumer } from './consumer.js'
 import { typedEventFromRaw } from './decode-typed.js'
 import { type CollectionFilter } from './engine/collections.js'
-import { type EventBatch, type RawEventV1 } from './event.js'
+import {
+  type EventBatch,
+  type RawEventV1,
+  type UnvalidatedRecord,
+} from './event.js'
 import { eventUri } from './event.js'
 
 // Shared per-run context handed to every handler as the second arg. Allocated
@@ -74,12 +78,6 @@ export interface CommitHandlers<R> {
   del?: (e: DelEvent, ctx: HandlerContext) => unknown | Promise<unknown>
 }
 
-// Record shape delivered to `put` when a collection is registered with
-// `validateRecord: false`: schema validation is skipped, so the only guarantee
-// is the `$type` structural floor (an object with a string `$type`) enforced in
-// run(). Everything else is untyped.
-export type UnvalidatedRecord = { $type: string } & Record<string, unknown>
-
 export interface LexIndexerOpts {
   concurrency?: number
   keyOf?: (evt: RawEventV1) => string
@@ -138,11 +136,11 @@ export class LexIndexer implements JetstreamConsumer {
     validateRecord?: true
   }): this
   // Options form, non-validating. The literal `false` selects the
-  // UnvalidatedRecord handler typing: schema validation is skipped and only the
-  // $type floor is guaranteed.
+  // UnvalidatedRecord handler typing: no runtime record checks — the $type
+  // floor is trusted from the server's collection routing, not verified.
   commit<S extends RecordSchema>(opts: {
     collection: Main<S>
-    handlers: CommitHandlers<UnvalidatedRecord>
+    handlers: CommitHandlers<UnvalidatedRecord<S['$type']>>
     validateRecord: false
   }): this
   commit<S extends RecordSchema>(
@@ -350,48 +348,6 @@ export class LexIndexer implements JetstreamConsumer {
           return this.#validationErrorHandler(errEvt, hctx)
         }
         return undefined
-      }
-      // validateRecord: false floor — the promised UnvalidatedRecord type
-      // guarantees an object with a string $type; nothing else checks it when
-      // schema validation is skipped (the collection was omitted from
-      // schemasByNsid). Failures route to onValidationError exactly like a
-      // validation failure (never reach put), or ack-and-skip when no handler
-      // is registered.
-      if (!handlers.validateRecord) {
-        const rec = typed.commit.record as
-          { $type?: unknown } | null | undefined
-        if (
-          rec === null ||
-          typeof rec !== 'object' ||
-          typeof rec.$type !== 'string'
-        ) {
-          if (this.#validationErrorHandler) {
-            const tc = typed.commit
-            const floorError = new Error(
-              `record missing string $type (validateRecord: false floor) for ${tc.collection}`,
-            )
-            // PERF: cid delegates to the commit getter (see note above).
-            const errEvt = {
-              did: typed.did,
-              seq: typed.seq,
-              operation: tc.operation,
-              collection: tc.collection,
-              rkey: tc.rkey,
-              rev: tc.rev,
-              uri: eventUri(typed),
-              error: floorError,
-            } as ValidationErrorEvent
-            Object.defineProperty(errEvt, 'cid', {
-              enumerable: true,
-              configurable: true,
-              get(): string {
-                return tc.cid
-              },
-            })
-            return this.#validationErrorHandler(errEvt, hctx)
-          }
-          return undefined
-        }
       }
       if (handlers.put) {
         const tc = typed.commit

--- a/packages/jetstream/src/lex-indexer.ts
+++ b/packages/jetstream/src/lex-indexer.ts
@@ -1,0 +1,530 @@
+// src/lex-indexer.ts
+import {
+  type InferOutput,
+  type Main,
+  type RecordSchema,
+  getMain,
+} from '@atproto/lex-schema'
+import { type ConsumerContext, type JetstreamConsumer } from './consumer.js'
+import { typedEventFromRaw } from './decode-typed.js'
+import { type CollectionFilter } from './engine/collections.js'
+import { type EventBatch, type RawEventV1 } from './event.js'
+import { eventUri } from './event.js'
+
+// Shared per-run context handed to every handler as the second arg. Allocated
+// once per run (NOT per event). `signal` is REQUIRED: LexIndexer always
+// provides one and guarantees it fires at least when the run winds down (stream
+// end, error, or caller abort), so handlers can pass it to cancellable work
+// (fetch, etc.) unconditionally. See LexIndexer.run for how it is synthesized
+// from the optional seam ConsumerContext.signal.
+export interface HandlerContext {
+  signal: AbortSignal
+}
+
+export type PutEvent<R> = {
+  did: string
+  seq: number
+  operation: 'create' | 'update'
+  collection: string
+  rkey: string
+  rev: string
+  cid: string
+  uri: string
+  record: R
+}
+export type DelEvent = {
+  did: string
+  seq: number
+  operation: 'delete'
+  collection: string
+  rkey: string
+  rev: string
+  uri: string
+}
+// Same flat shape as PutEvent but carries the decode/validation `error` instead
+// of a decoded `record`. Routed here (not to `put`) when a create/update record
+// fails to schema-validate, so `put`'s `record` is always a valid decoded R.
+export type ValidationErrorEvent = {
+  did: string
+  seq: number
+  operation: 'create' | 'update'
+  collection: string
+  rkey: string
+  rev: string
+  cid: string
+  uri: string
+  error: Error
+}
+export type IdentityEvent = {
+  did: string
+  handle?: string
+  time?: string
+  seq: number
+}
+export type AccountEvent = {
+  did: string
+  active: boolean
+  status?: string
+  time?: string
+  seq: number
+}
+
+export interface CommitHandlers<R> {
+  put?: (e: PutEvent<R>, ctx: HandlerContext) => unknown | Promise<unknown>
+  del?: (e: DelEvent, ctx: HandlerContext) => unknown | Promise<unknown>
+}
+
+// Record shape delivered to `put` when a collection is registered with
+// `validateRecord: false`: schema validation is skipped, so the only guarantee
+// is the `$type` structural floor (an object with a string `$type`) enforced in
+// run(). Everything else is untyped.
+export type UnvalidatedRecord = { $type: string } & Record<string, unknown>
+
+export interface LexIndexerOpts {
+  concurrency?: number
+  keyOf?: (evt: RawEventV1) => string
+}
+
+// Internal, type-erased handler record stored per commit-collection NSID.
+// Retains the resolved schema so run() can build the schemasByNsid map needed
+// for typed record decode.
+interface AnyCommitHandlers {
+  schema: RecordSchema
+  validateRecord: boolean
+  put?: (
+    e: PutEvent<unknown>,
+    ctx: HandlerContext,
+  ) => unknown | Promise<unknown>
+  del?: (e: DelEvent, ctx: HandlerContext) => unknown | Promise<unknown>
+}
+
+export class LexIndexer implements JetstreamConsumer {
+  readonly concurrency: number
+  readonly #keyOf: ((evt: RawEventV1) => string) | undefined
+  readonly #collections = new Map<string, AnyCommitHandlers>()
+  #identityHandler:
+    | ((e: IdentityEvent, ctx: HandlerContext) => unknown | Promise<unknown>)
+    | undefined
+  #accountHandler:
+    | ((e: AccountEvent, ctx: HandlerContext) => unknown | Promise<unknown>)
+    | undefined
+  #validationErrorHandler:
+    | ((
+        e: ValidationErrorEvent,
+        ctx: HandlerContext,
+      ) => unknown | Promise<unknown>)
+    | undefined
+
+  constructor(opts: LexIndexerOpts = {}) {
+    this.concurrency = opts.concurrency ?? 16
+    this.#keyOf = opts.keyOf
+  }
+
+  get collections(): CollectionFilter[] {
+    return [...this.#collections.keys()]
+  }
+
+  // Simple form: register a collection with schema-validated records
+  // (validateRecord defaults to true).
+  commit<S extends RecordSchema>(
+    collection: Main<S>,
+    handlers: CommitHandlers<InferOutput<S>>,
+  ): this
+  // Options form, validating (default). The literal `true` (or omission) keeps
+  // the schema-inferred record typing.
+  commit<S extends RecordSchema>(opts: {
+    collection: Main<S>
+    handlers: CommitHandlers<InferOutput<S>>
+    validateRecord?: true
+  }): this
+  // Options form, non-validating. The literal `false` selects the
+  // UnvalidatedRecord handler typing: schema validation is skipped and only the
+  // $type floor is guaranteed.
+  commit<S extends RecordSchema>(opts: {
+    collection: Main<S>
+    handlers: CommitHandlers<UnvalidatedRecord>
+    validateRecord: false
+  }): this
+  commit<S extends RecordSchema>(
+    collectionOrOpts:
+      | Main<S>
+      | {
+          collection: Main<S>
+          handlers: CommitHandlers<never>
+          validateRecord?: boolean
+        },
+    maybeHandlers?: CommitHandlers<InferOutput<S>>,
+  ): this {
+    // Overload discrimination: a lex Main<S> schema is itself an object, but it
+    // never carries BOTH `collection` and `handlers` keys (its keys are
+    // key/$type/schema/type/keySchema), so requiring both cleanly selects the
+    // opts form.
+    const isOptsForm =
+      typeof collectionOrOpts === 'object' &&
+      collectionOrOpts !== null &&
+      'collection' in collectionOrOpts &&
+      'handlers' in collectionOrOpts
+    const collection = isOptsForm
+      ? (collectionOrOpts as { collection: Main<S> }).collection
+      : (collectionOrOpts as Main<S>)
+    const handlers = (
+      isOptsForm
+        ? (collectionOrOpts as { handlers: unknown }).handlers
+        : maybeHandlers
+    ) as CommitHandlers<unknown>
+    const validateRecord = isOptsForm
+      ? ((collectionOrOpts as { validateRecord?: boolean }).validateRecord ??
+        true)
+      : true
+    const resolved = getMain(collection) as RecordSchema
+    this.#collections.set(resolved.$type, {
+      schema: resolved,
+      validateRecord,
+      put: handlers.put as AnyCommitHandlers['put'],
+      del: handlers.del as AnyCommitHandlers['del'],
+    })
+    return this
+  }
+
+  identity(
+    fn: (e: IdentityEvent, ctx: HandlerContext) => unknown | Promise<unknown>,
+  ): this {
+    this.#identityHandler = fn
+    return this
+  }
+
+  account(
+    fn: (e: AccountEvent, ctx: HandlerContext) => unknown | Promise<unknown>,
+  ): this {
+    this.#accountHandler = fn
+    return this
+  }
+
+  onValidationError(
+    fn: (
+      e: ValidationErrorEvent,
+      ctx: HandlerContext,
+    ) => unknown | Promise<unknown>,
+  ): this {
+    this.#validationErrorHandler = fn
+    return this
+  }
+
+  async run(
+    stream: AsyncIterable<EventBatch<RawEventV1>>,
+    ctx: ConsumerContext,
+  ): Promise<void> {
+    const concurrency = Math.max(1, this.concurrency)
+    const keyOf = this.#keyOf ?? ((evt: RawEventV1) => eventUri(evt))
+    // schemasByNsid drives typedEventFromRaw's validation; a collection
+    // registered with validateRecord: false is deliberately OMITTED so its
+    // records skip schema.safeValidate (routing is unaffected — handlers are
+    // looked up in #collections, not this map).
+    const schemasByNsid = new Map<string, RecordSchema>()
+    for (const [nsid, h] of this.#collections) {
+      if (h.validateRecord) schemasByNsid.set(nsid, h.schema)
+    }
+
+    // Guaranteed handler signal: synthesized from the optional seam signal so
+    // ctx.signal is ALWAYS present for handlers and fires at least on wind-down.
+    // Chain the caller's signal in; abort in the finally (stream end / error /
+    // completion). Allocated once per run, shared by every handler call.
+    const runAbort = new AbortController()
+    const onSeamAbort = () => runAbort.abort()
+    if (ctx.signal) {
+      if (ctx.signal.aborted) runAbort.abort()
+      else ctx.signal.addEventListener('abort', onSeamAbort, { once: true })
+    }
+    const hctx: HandlerContext = { signal: runAbort.signal }
+
+    const keyTails = new Map<string, Promise<void>>()
+    let inFlight = 0
+    let stopped = false
+    let firstError: Error | undefined
+    const slotWaiters: Array<() => void> = []
+    const releaseSlot = () => {
+      inFlight--
+      const w = slotWaiters.shift()
+      if (w) w()
+    }
+    // PERF: returns undefined (no promise) when a slot is free — the common
+    // case. Only allocates a waiter when at capacity. The inFlight++ pairing
+    // with releaseSlot() must hold on BOTH branches.
+    const acquireSlot = (): Promise<void> | undefined => {
+      if (inFlight < concurrency) {
+        inFlight++
+        return undefined
+      }
+      return new Promise<void>((res) => slotWaiters.push(res)).then(() => {
+        inFlight++
+      })
+    }
+
+    // Runs the matching handler (if any). Returning without calling a handler
+    // means "handled-and-skipped" — the caller then acks.
+    // PERF: plain function (not async) — a sync user handler completes without
+    // any promise allocation; the CALLER inspects the return for a thenable.
+    // Each branch returns the handler's result directly (may be a thenable).
+    const handle = (evt: RawEventV1): unknown => {
+      if (evt.kind === 'identity') {
+        if (this.#identityHandler) {
+          return this.#identityHandler(
+            {
+              did: evt.identity.did,
+              handle: evt.identity.handle,
+              time: evt.identity.time,
+              seq: evt.seq,
+            },
+            hctx,
+          )
+        }
+        return undefined
+      }
+      if (evt.kind === 'account') {
+        if (this.#accountHandler) {
+          return this.#accountHandler(
+            {
+              did: evt.account.did,
+              active: evt.account.active,
+              status: evt.account.status,
+              time: evt.account.time,
+              seq: evt.seq,
+            },
+            hctx,
+          )
+        }
+        return undefined
+      }
+      if (evt.kind !== 'commit') return undefined
+      const handlers = this.#collections.get(evt.commit.collection)
+      if (!handlers) return undefined // unregistered collection: skip
+      if (evt.commit.operation === 'delete') {
+        if (handlers.del) {
+          return handlers.del(
+            {
+              did: evt.did,
+              seq: evt.seq,
+              operation: 'delete',
+              collection: evt.commit.collection,
+              rkey: evt.commit.rkey,
+              rev: evt.commit.rev,
+              uri: eventUri(evt),
+            },
+            hctx,
+          )
+        }
+        return undefined
+      }
+      // create / update: upgrade to typed, then either route an invalid record
+      // to onValidationError (handled-and-skipped, never put) or dispatch put
+      // with the now-guaranteed-defined record.
+      const typed = typedEventFromRaw(evt, schemasByNsid)
+      if (typed.kind !== 'commit' || typed.commit.operation === 'delete')
+        return undefined
+      if (typed.commit.validationError !== undefined) {
+        // Invalid record: fails schema-validation. Never reaches put; route to
+        // the optional handler, otherwise ack-and-skip.
+        if (this.#validationErrorHandler) {
+          const tc = typed.commit
+          // PERF: cid delegates to the commit getter — do not inline
+          // `cid: tc.cid` here; the source package's v2 path computes it
+          // lazily and the delegation keeps both ports identical. Cast is
+          // local because the object is completed by defineProperty below.
+          const errEvt = {
+            did: typed.did,
+            seq: typed.seq,
+            operation: tc.operation,
+            collection: tc.collection,
+            rkey: tc.rkey,
+            rev: tc.rev,
+            uri: eventUri(typed),
+            error: tc.validationError,
+          } as ValidationErrorEvent
+          Object.defineProperty(errEvt, 'cid', {
+            enumerable: true,
+            configurable: true,
+            get(): string {
+              return tc.cid
+            },
+          })
+          return this.#validationErrorHandler(errEvt, hctx)
+        }
+        return undefined
+      }
+      // validateRecord: false floor — the promised UnvalidatedRecord type
+      // guarantees an object with a string $type; nothing else checks it when
+      // schema validation is skipped (the collection was omitted from
+      // schemasByNsid). Failures route to onValidationError exactly like a
+      // validation failure (never reach put), or ack-and-skip when no handler
+      // is registered.
+      if (!handlers.validateRecord) {
+        const rec = typed.commit.record as
+          { $type?: unknown } | null | undefined
+        if (
+          rec === null ||
+          typeof rec !== 'object' ||
+          typeof rec.$type !== 'string'
+        ) {
+          if (this.#validationErrorHandler) {
+            const tc = typed.commit
+            const floorError = new Error(
+              `record missing string $type (validateRecord: false floor) for ${tc.collection}`,
+            )
+            // PERF: cid delegates to the commit getter (see note above).
+            const errEvt = {
+              did: typed.did,
+              seq: typed.seq,
+              operation: tc.operation,
+              collection: tc.collection,
+              rkey: tc.rkey,
+              rev: tc.rev,
+              uri: eventUri(typed),
+              error: floorError,
+            } as ValidationErrorEvent
+            Object.defineProperty(errEvt, 'cid', {
+              enumerable: true,
+              configurable: true,
+              get(): string {
+                return tc.cid
+              },
+            })
+            return this.#validationErrorHandler(errEvt, hctx)
+          }
+          return undefined
+        }
+      }
+      if (handlers.put) {
+        const tc = typed.commit
+        // PERF: cid delegates to the commit getter (see note above).
+        const putEvt = {
+          did: typed.did,
+          seq: typed.seq,
+          operation: tc.operation,
+          collection: tc.collection,
+          rkey: tc.rkey,
+          rev: tc.rev,
+          uri: eventUri(typed),
+          record: tc.record,
+        } as PutEvent<never>
+        Object.defineProperty(putEvt, 'cid', {
+          enumerable: true,
+          configurable: true,
+          get(): string {
+            return tc.cid
+          },
+        })
+        return handlers.put(putEvt, hctx)
+      }
+      return undefined
+    }
+
+    const isThenable = (v: unknown): v is PromiseLike<unknown> =>
+      v !== null &&
+      (typeof v === 'object' || typeof v === 'function') &&
+      typeof (v as { then?: unknown }).then === 'function'
+
+    // Centralized settle: on success (err === undefined && !skipAck) ack the
+    // event; on error record firstError once and set stopped (never ack); a
+    // stopped-skip passes skipAck=true so the slot is released WITHOUT acking
+    // (acking a skipped event would advance the watermark past unprocessed
+    // events). Always releases the slot exactly once.
+    const settle = (evt: RawEventV1, err: unknown, skipAck = false): void => {
+      if (err === undefined) {
+        if (!skipAck) ctx.ack(evt)
+      } else {
+        const e = err instanceof Error ? err : new Error(String(err))
+        if (!firstError) firstError = e
+        stopped = true
+        // do NOT ack: watermark holds below this seq
+      }
+      releaseSlot()
+    }
+
+    // PERF: sync fast path — when the event's key has no pending tail AND the
+    // handler completes synchronously, the event is acked and its slot released
+    // inline with ZERO promise allocations. Preserve exactly: per-key ordering
+    // when a tail exists, acquire/release pairing (settle runs once per
+    // dispatched event), fail-fast without acking the failed event. The async
+    // fallback below is the original chain semantics.
+    const dispatch = (evt: RawEventV1): void => {
+      const key = keyOf(evt)
+      const prev = keyTails.get(key)
+      if (prev === undefined) {
+        // No pending tail: run inline.
+        if (stopped) {
+          settle(evt, undefined, true) // stopped-skip: release, no ack
+          return
+        }
+        let result: unknown
+        try {
+          result = handle(evt)
+        } catch (err) {
+          settle(evt, err) // sync throw
+          return
+        }
+        if (!isThenable(result)) {
+          settle(evt, undefined) // sync completion: zero promises
+          return
+        }
+        // Async completion: register the tail.
+        const run = Promise.resolve(result).then(
+          () => settle(evt, undefined),
+          (err) => settle(evt, err),
+        )
+        keyTails.set(key, run)
+        void run.finally(() => {
+          if (keyTails.get(key) === run) keyTails.delete(key)
+        })
+        return
+      }
+      // Pending tail: enqueue behind it (original semantics).
+      const run = prev
+        .catch(() => {})
+        .then(() => {
+          if (stopped) {
+            settle(evt, undefined, true) // stopped-skip: release, no ack
+            return
+          }
+          let result: unknown
+          try {
+            result = handle(evt)
+          } catch (err) {
+            settle(evt, err)
+            return
+          }
+          if (!isThenable(result)) {
+            settle(evt, undefined)
+            return
+          }
+          return Promise.resolve(result).then(
+            () => settle(evt, undefined),
+            (err) => settle(evt, err),
+          )
+        })
+      keyTails.set(key, run)
+      void run.finally(() => {
+        if (keyTails.get(key) === run) keyTails.delete(key)
+      })
+    }
+
+    try {
+      outer: for await (const batch of stream) {
+        for (const evt of batch.events) {
+          if (stopped) break outer
+          const p = acquireSlot()
+          if (p) await p
+          if (stopped) {
+            releaseSlot()
+            break outer
+          }
+          dispatch(evt)
+        }
+      }
+      await Promise.allSettled([...keyTails.values()])
+      if (firstError) throw firstError
+    } finally {
+      if (ctx.signal) ctx.signal.removeEventListener('abort', onSeamAbort)
+      runAbort.abort() // guarantee hctx.signal fires on wind-down
+    }
+  }
+}

--- a/packages/jetstream/src/lex-indexer.ts
+++ b/packages/jetstream/src/lex-indexer.ts
@@ -1,9 +1,15 @@
 import {
-  type AtIdentifierString,
+  type AtUriString,
+  type CidString,
+  type DatetimeString,
+  type DidString,
+  type HandleString,
   type InferOutput,
   type Main,
   type NsidString,
+  type RecordKeyString,
   type RecordSchema,
+  type TidString,
   atUri,
   getMain,
 } from '@atproto/lex-schema'
@@ -28,50 +34,50 @@ export interface HandlerContext {
 }
 
 export type PutEvent<R> = {
-  did: string
+  did: DidString
   seq: number
   operation: 'create' | 'update'
-  collection: string
-  rkey: string
-  rev: string
-  cid: string
-  uri: string
+  collection: NsidString
+  rkey: RecordKeyString
+  rev: TidString
+  cid: CidString
+  uri: AtUriString
   record: R
 }
 export type DelEvent = {
-  did: string
+  did: DidString
   seq: number
   operation: 'delete'
-  collection: string
-  rkey: string
-  rev: string
-  uri: string
+  collection: NsidString
+  rkey: RecordKeyString
+  rev: TidString
+  uri: AtUriString
 }
 // Same flat shape as PutEvent but carries the decode/validation `error` instead
 // of a decoded `record`. Routed here (not to `put`) when a create/update record
 // fails to schema-validate, so `put`'s `record` is always a valid decoded R.
 export type ValidationErrorEvent = {
-  did: string
+  did: DidString
   seq: number
   operation: 'create' | 'update'
-  collection: string
-  rkey: string
-  rev: string
-  cid: string
-  uri: string
+  collection: NsidString
+  rkey: RecordKeyString
+  rev: TidString
+  cid: CidString
+  uri: AtUriString
   error: Error
 }
 export type IdentityEvent = {
-  did: string
-  handle?: string
-  time?: string
+  did: DidString
+  handle?: HandleString
+  time?: DatetimeString
   seq: number
 }
 export type AccountEvent = {
-  did: string
+  did: DidString
   active: boolean
   status?: string
-  time?: string
+  time?: DatetimeString
   seq: number
 }
 
@@ -97,21 +103,18 @@ const kUri = Symbol('jetstream.uri')
 // Lazily builds and caches the validated at:// URI of a commit event. PERF:
 // most handlers never read `uri`; atUri validates (and can throw on mangled
 // wire components), so the cost — and the throw — happen only on first read,
-// inside the handler's guarded execution. The wire carries plain strings; the
-// runtime assertions inside atUri are what make the branded casts honest.
+// inside the handler's guarded execution. The wire carries branded values
+// earned at the decode boundary; atUri's runtime assertions guard against
+// mangled wire data.
 // `self` is the event object (`this` inside its getter); the cast adds the
 // symbol slot the event types deliberately don't declare.
 function lazyUri(
   self: object,
-  did: string,
-  commit: { collection: string; rkey: string },
-): string {
-  const cache = self as { [kUri]?: string }
-  return (cache[kUri] ??= atUri(
-    did as AtIdentifierString,
-    commit.collection as NsidString,
-    commit.rkey,
-  ))
+  did: DidString,
+  commit: { collection: NsidString; rkey: RecordKeyString },
+): AtUriString {
+  const cache = self as { [kUri]?: AtUriString }
+  return (cache[kUri] ??= atUri(did, commit.collection, commit.rkey))
 }
 
 // Internal, type-erased handler record stored per commit-collection NSID.
@@ -130,7 +133,7 @@ interface AnyCommitHandlers {
 export class LexIndexer implements JetstreamConsumer {
   readonly concurrency: number
   readonly #keyOf: ((evt: RawEventV1) => string) | undefined
-  readonly #collections = new Map<string, AnyCommitHandlers>()
+  readonly #collections = new Map<NsidString, AnyCommitHandlers>()
   #identityHandler:
     | ((e: IdentityEvent, ctx: HandlerContext) => unknown | Promise<unknown>)
     | undefined
@@ -339,7 +342,7 @@ export class LexIndexer implements JetstreamConsumer {
               collection: c.collection,
               rkey: c.rkey,
               rev: c.rev,
-              get uri(): string {
+              get uri(): AtUriString {
                 return lazyUri(this, did, c)
               },
             },
@@ -371,7 +374,7 @@ export class LexIndexer implements JetstreamConsumer {
             collection: tc.collection,
             rkey: tc.rkey,
             rev: tc.rev,
-            get uri(): string {
+            get uri(): AtUriString {
               return lazyUri(this, did, tc)
             },
             get cid(): string {
@@ -398,7 +401,7 @@ export class LexIndexer implements JetstreamConsumer {
           collection: tc.collection,
           rkey: tc.rkey,
           rev: tc.rev,
-          get uri(): string {
+          get uri(): AtUriString {
             return lazyUri(this, did, tc)
           },
           get cid(): string {

--- a/packages/jetstream/src/live/decode-v1.ts
+++ b/packages/jetstream/src/live/decode-v1.ts
@@ -1,3 +1,4 @@
+import { type InferOutput, l } from '@atproto/lex-schema'
 import { MalformedError } from '../errors.js'
 import { type Account, type Identity, type RawEventV1 } from '../event.js'
 import { SKIP_FRAME } from './decode.js'
@@ -10,59 +11,116 @@ import { SKIP_FRAME } from './decode.js'
 // monotonic.Clock guarantees now > last), so it maps directly onto seq.
 // Prototype-era short codes (type: "com", commit.type: "c") are not deployed
 // and not supported — such frames fall out as unknown kinds (SKIP_FRAME).
-interface WireV1Commit {
-  rev?: string
-  operation?: string
-  collection?: string
-  rkey?: string
-  record?: unknown
-  cid?: string
+// The schema below is the single wire contract: WireV1Frame is inferred from
+// it, the `as WireV1Frame` cast is the single optimistic boundary, and
+// validateWire strict mode safeValidates the SAME schema.
+const wireV1Envelope = {
+  did: l.string({ format: 'did' }),
+  // time_us IS the v1 cursor (strictly monotonic, unique) — required.
+  time_us: l.integer(),
 }
-interface WireV1Frame {
-  did?: string
-  time_us?: number
+const wireV1CommitFrame = l.object({
+  ...wireV1Envelope,
+  kind: l.literal('commit'),
+  commit: l.union([
+    l.object({
+      operation: l.union([l.literal('create'), l.literal('update')]),
+      collection: l.string({ format: 'nsid' }),
+      rkey: l.string({ format: 'record-key' }),
+      rev: l.string({ format: 'tid' }),
+      cid: l.string({ format: 'cid' }), // the v1 wire cid IS checked
+      record: l.unknown(), // parsed JSON body — never format-checked
+    }),
+    l.object({
+      operation: l.literal('delete'),
+      collection: l.string({ format: 'nsid' }),
+      rkey: l.string({ format: 'record-key' }),
+      rev: l.string({ format: 'tid' }),
+    }),
+  ]),
+})
+const wireV1IdentityFrame = l.object({
+  ...wireV1Envelope,
+  kind: l.literal('identity'),
+  identity: l.object({
+    did: l.string({ format: 'did' }),
+    handle: l.optional(l.string({ format: 'handle' })),
+    time: l.optional(l.string({ format: 'datetime' })),
+  }),
+})
+const wireV1AccountFrame = l.object({
+  ...wireV1Envelope,
+  kind: l.literal('account'),
+  account: l.object({
+    did: l.string({ format: 'did' }),
+    active: l.optional(l.boolean()),
+    status: l.optional(l.string()),
+    time: l.optional(l.string({ format: 'datetime' })),
+  }),
+})
+const wireV1Frame = l.union([
+  wireV1CommitFrame,
+  wireV1IdentityFrame,
+  wireV1AccountFrame,
+])
+type WireV1Frame = InferOutput<typeof wireV1Frame>
+
+// Pre-discrimination peek: error frames and unknown/control kinds are handled
+// before the WireV1Frame cast (l.union rejects unknown discriminants by design).
+interface PeekFrame {
   kind?: string
-  commit?: WireV1Commit
-  identity?: { did?: string; handle?: string; time?: string }
-  account?: { did?: string; active?: boolean; status?: string; time?: string }
   error?: string
   message?: string
 }
 
 const td = new TextDecoder()
 
-const KINDS = new Set(['commit', 'identity', 'account'])
-const OPS = new Set(['create', 'update', 'delete'])
-
 export function decodeLiveFrameV1(
-  data: Uint8Array | string,
+  data: Uint8Array,
+  validateWire?: boolean,
 ): RawEventV1 | typeof SKIP_FRAME {
-  const text = typeof data === 'string' ? data : td.decode(data)
-  let f: WireV1Frame
+  const text = td.decode(data)
+  let parsed: unknown
   try {
-    f = JSON.parse(text) as WireV1Frame
+    parsed = JSON.parse(text)
   } catch (err) {
     throw new MalformedError(`decode v1 live frame: ${(err as Error).message}`)
   }
-  if (f.error) {
+  const peek = parsed as PeekFrame
+  if (peek.error) {
     throw new MalformedError(
-      `v1 live error frame: ${f.error}: ${f.message ?? ''}`,
+      `v1 live error frame: ${peek.error}: ${peek.message ?? ''}`,
     )
   }
-  const kind = f.kind
-  if (!kind || !KINDS.has(kind)) return SKIP_FRAME
-
-  const seq = f.time_us ?? 0
-  const did = f.did ?? ''
+  if (
+    peek.kind !== 'commit' &&
+    peek.kind !== 'identity' &&
+    peek.kind !== 'account'
+  ) {
+    // Unknown or control kind (prototype short codes, etc.): skip.
+    return SKIP_FRAME
+  }
+  // PERF: strict mode only — one predictable branch on the hot path.
+  if (validateWire) {
+    const result = wireV1Frame.safeValidate(parsed)
+    if (!result.success) {
+      throw new MalformedError(
+        `wire validation failed: ${String(result.reason)}`,
+      )
+    }
+  }
+  const f = parsed as WireV1Frame // the single optimistic boundary
+  const seq = f.time_us
+  const did = f.did
   const base = { did, seq, timeUs: seq }
 
-  switch (kind) {
+  switch (f.kind) {
     case 'commit': {
       const c = f.commit
       if (!c)
         throw new MalformedError(`v1 commit frame missing payload (seq=${seq})`)
       const op = c.operation
-      if (!op || !OPS.has(op))
+      if (op !== 'create' && op !== 'update' && op !== 'delete')
         throw new MalformedError(`v1 commit unknown operation (seq=${seq})`)
       if (op === 'delete') {
         return {
@@ -70,9 +128,9 @@ export function decodeLiveFrameV1(
           kind: 'commit',
           commit: {
             operation: 'delete',
-            collection: c.collection ?? '',
-            rkey: c.rkey ?? '',
-            rev: c.rev ?? '',
+            collection: c.collection,
+            rkey: c.rkey,
+            rev: c.rev,
           },
         }
       }
@@ -85,10 +143,10 @@ export function decodeLiveFrameV1(
         ...base,
         kind: 'commit',
         commit: {
-          operation: op as 'create' | 'update',
-          collection: c.collection ?? '',
-          rkey: c.rkey ?? '',
-          rev: c.rev ?? '',
+          operation: op,
+          collection: c.collection,
+          rkey: c.rkey,
+          rev: c.rev,
           cid: c.cid,
           record: c.record,
         },
@@ -119,7 +177,5 @@ export function decodeLiveFrameV1(
       }
       return { ...base, kind: 'account', account }
     }
-    default:
-      return SKIP_FRAME
   }
 }

--- a/packages/jetstream/src/live/decode-v1.ts
+++ b/packages/jetstream/src/live/decode-v1.ts
@@ -35,9 +35,9 @@ const KINDS = new Set(['commit', 'identity', 'account'])
 const OPS = new Set(['create', 'update', 'delete'])
 
 export function decodeLiveFrameV1(
-  data: Uint8Array,
+  data: Uint8Array | string,
 ): RawEventV1 | typeof SKIP_FRAME {
-  const text = td.decode(data)
+  const text = typeof data === 'string' ? data : td.decode(data)
   let f: WireV1Frame
   try {
     f = JSON.parse(text) as WireV1Frame

--- a/packages/jetstream/src/live/decode-v1.ts
+++ b/packages/jetstream/src/live/decode-v1.ts
@@ -1,0 +1,125 @@
+import { MalformedError } from '../errors.js'
+import { type Account, type Identity, type RawEventV1 } from '../event.js'
+import { SKIP_FRAME } from './decode.js'
+
+// v1 wire frame — the authoritative jetstream-legacy shape
+// (bluesky-social/jetstream-legacy pkg/models/models.go): kind:
+// "commit"|"identity"|"account", commit.operation:
+// "create"|"update"|"delete". record is parsed JSON (never CBOR); cid is a
+// wire string. time_us is the cursor: strictly monotonic and unique (v1's
+// monotonic.Clock guarantees now > last), so it maps directly onto seq.
+// Prototype-era short codes (type: "com", commit.type: "c") are not deployed
+// and not supported — such frames fall out as unknown kinds (SKIP_FRAME).
+interface WireV1Commit {
+  rev?: string
+  operation?: string
+  collection?: string
+  rkey?: string
+  record?: unknown
+  cid?: string
+}
+interface WireV1Frame {
+  did?: string
+  time_us?: number
+  kind?: string
+  commit?: WireV1Commit
+  identity?: { did?: string; handle?: string; time?: string }
+  account?: { did?: string; active?: boolean; status?: string; time?: string }
+  error?: string
+  message?: string
+}
+
+const td = new TextDecoder()
+
+const KINDS = new Set(['commit', 'identity', 'account'])
+const OPS = new Set(['create', 'update', 'delete'])
+
+export function decodeLiveFrameV1(
+  data: Uint8Array,
+): RawEventV1 | typeof SKIP_FRAME {
+  const text = td.decode(data)
+  let f: WireV1Frame
+  try {
+    f = JSON.parse(text) as WireV1Frame
+  } catch (err) {
+    throw new MalformedError(`decode v1 live frame: ${(err as Error).message}`)
+  }
+  if (f.error) {
+    throw new MalformedError(
+      `v1 live error frame: ${f.error}: ${f.message ?? ''}`,
+    )
+  }
+  const kind = f.kind
+  if (!kind || !KINDS.has(kind)) return SKIP_FRAME
+
+  const seq = f.time_us ?? 0
+  const did = f.did ?? ''
+  const base = { did, seq, timeUs: seq }
+
+  switch (kind) {
+    case 'commit': {
+      const c = f.commit
+      if (!c)
+        throw new MalformedError(`v1 commit frame missing payload (seq=${seq})`)
+      const op = c.operation
+      if (!op || !OPS.has(op))
+        throw new MalformedError(`v1 commit unknown operation (seq=${seq})`)
+      if (op === 'delete') {
+        return {
+          ...base,
+          kind: 'commit',
+          commit: {
+            operation: 'delete',
+            collection: c.collection ?? '',
+            rkey: c.rkey ?? '',
+            rev: c.rev ?? '',
+          },
+        }
+      }
+      if (c.record === undefined || !c.cid) {
+        throw new MalformedError(
+          `v1 ${op} commit missing record/cid (collection=${c.collection} rkey=${c.rkey})`,
+        )
+      }
+      return {
+        ...base,
+        kind: 'commit',
+        commit: {
+          operation: op as 'create' | 'update',
+          collection: c.collection ?? '',
+          rkey: c.rkey ?? '',
+          rev: c.rev ?? '',
+          cid: c.cid,
+          record: c.record,
+        },
+      }
+    }
+    case 'identity': {
+      if (!f.identity)
+        throw new MalformedError(
+          `v1 identity frame missing payload (seq=${seq})`,
+        )
+      const identity: Identity = {
+        did: f.identity.did || did,
+        handle: f.identity.handle,
+        time: f.identity.time,
+      }
+      return { ...base, kind: 'identity', identity }
+    }
+    case 'account': {
+      if (!f.account)
+        throw new MalformedError(
+          `v1 account frame missing payload (seq=${seq})`,
+        )
+      const account: Account = {
+        did: f.account.did || did,
+        active: f.account.active ?? false,
+        status: f.account.status,
+        time: f.account.time,
+      }
+      return { ...base, kind: 'account', account }
+    }
+    default:
+      return SKIP_FRAME
+  }
+}

--- a/packages/jetstream/src/live/decode-v1.ts
+++ b/packages/jetstream/src/live/decode-v1.ts
@@ -84,7 +84,7 @@ export function decodeLiveFrameV1(
   try {
     parsed = JSON.parse(text)
   } catch (err) {
-    throw new MalformedError(`decode v1 live frame: ${(err as Error).message}`)
+    throw new MalformedError('decode v1 live frame', { cause: err })
   }
   const peek = parsed as PeekFrame
   if (peek.error) {
@@ -104,13 +104,21 @@ export function decodeLiveFrameV1(
   if (validateWire) {
     const result = wireV1Frame.safeValidate(parsed)
     if (!result.success) {
-      throw new MalformedError(
-        `wire validation failed: ${String(result.reason)}`,
-      )
+      throw new MalformedError('wire validation failed', {
+        cause: result.reason,
+      })
     }
   }
   const f = parsed as WireV1Frame // the single optimistic boundary
   const seq = f.time_us
+  // seq IS the cursor (dedup, resume, watermark) — a lossy or non-integer
+  // time_us silently corrupts all of them, so this is checked in EVERY mode,
+  // not just validateWire.
+  if (!Number.isSafeInteger(seq)) {
+    throw new MalformedError(
+      `v1 time_us is not a safe integer (got ${String(seq)})`,
+    )
+  }
   const did = f.did
   const base = { did, seq, timeUs: seq }
 

--- a/packages/jetstream/src/live/decode-v1.ts
+++ b/packages/jetstream/src/live/decode-v1.ts
@@ -76,10 +76,10 @@ interface PeekFrame {
 const td = new TextDecoder()
 
 export function decodeLiveFrameV1(
-  data: Uint8Array,
+  data: Uint8Array | string,
   validateWire?: boolean,
 ): RawEventV1 | typeof SKIP_FRAME {
-  const text = td.decode(data)
+  const text = typeof data === 'string' ? data : td.decode(data)
   let parsed: unknown
   try {
     parsed = JSON.parse(text)

--- a/packages/jetstream/src/live/decode.ts
+++ b/packages/jetstream/src/live/decode.ts
@@ -1,0 +1,3 @@
+// Shared decoder sentinel. The v2 live-frame decoder that accompanies it in
+// jetstream-sdk is not part of the v1-live subset; it lands here with v2.
+export const SKIP_FRAME = Symbol('jetstream.skipFrame')

--- a/packages/jetstream/src/live/source.ts
+++ b/packages/jetstream/src/live/source.ts
@@ -1,4 +1,4 @@
-import { type EventBatch, type RawEventV1, type SeqEvent } from '../event.js'
+import { type RawEventV1 } from '../event.js'
 import { decodeLiveFrameV1 } from './decode-v1.js'
 import { SKIP_FRAME } from './decode.js'
 import { type LiveTransport, wsKeepAliveTransport } from './transport.js'
@@ -60,21 +60,4 @@ export async function* liveEvents(
     lastSeq = ev.seq
     yield ev
   }
-}
-
-export async function* batchEvents<E extends SeqEvent>(
-  src: AsyncGenerator<E>,
-  batchSize: number,
-): AsyncGenerator<EventBatch<E>> {
-  let events: E[] = []
-  let lastCursor = 0
-  for await (const ev of src) {
-    events.push(ev)
-    if (ev.seq > lastCursor) lastCursor = ev.seq
-    if (events.length >= batchSize) {
-      yield { events, lastCursor }
-      events = []
-    }
-  }
-  if (events.length > 0) yield { events, lastCursor }
 }

--- a/packages/jetstream/src/live/source.ts
+++ b/packages/jetstream/src/live/source.ts
@@ -1,0 +1,80 @@
+import { type EventBatch, type RawEventV1, type SeqEvent } from '../event.js'
+import { decodeLiveFrameV1 } from './decode-v1.js'
+import { SKIP_FRAME } from './decode.js'
+import { type LiveTransport, wsKeepAliveTransport } from './transport.js'
+
+export { type LiveTransport } from './transport.js'
+
+export interface LiveEventsOpts {
+  host: string
+  collections?: string[]
+  dids?: string[]
+  cursor?: number // undefined = live from tip; 0 = replay from start
+  dedupFloor?: number // undefined = nothing delivered (seq 0 passes); else drop seq <= floor
+  transport?: LiveTransport
+  signal?: AbortSignal
+  onError?: (err: Error) => void
+}
+
+function wsScheme(host: string): string {
+  const u = new URL(host)
+  if (u.protocol === 'http:') u.protocol = 'ws:'
+  else if (u.protocol === 'https:') u.protocol = 'wss:'
+  return u.origin
+}
+
+export async function* liveEvents(
+  opts: LiveEventsOpts,
+): AsyncGenerator<RawEventV1> {
+  const origin = wsScheme(opts.host)
+  const transport = opts.transport ?? wsKeepAliveTransport
+  const signal = opts.signal ?? new AbortController().signal
+  // lastSeq is the highest DELIVERED seq = reconnect cursor + dedup floor.
+  // undefined means nothing delivered yet (seq 0 passes).
+  let lastSeq: number | undefined = opts.dedupFloor
+
+  const getUrl = (): string => {
+    const u = new URL('/subscribe', origin)
+    // Resume from highest-delivered once anything has been delivered; otherwise
+    // fall back to the initial wire cursor (which may be 0 = replay from start).
+    const wire = lastSeq ?? opts.cursor
+    if (wire !== undefined) u.searchParams.set('cursor', String(wire))
+    for (const c of opts.collections ?? [])
+      u.searchParams.append('wantedCollections', c)
+    for (const d of opts.dids ?? []) u.searchParams.append('wantedDids', d)
+    return u.toString()
+  }
+
+  for await (const chunk of transport.stream(getUrl, signal)) {
+    let ev: RawEventV1 | typeof SKIP_FRAME
+    try {
+      ev = decodeLiveFrameV1(chunk)
+    } catch (err) {
+      opts.onError?.(err instanceof Error ? err : new Error(String(err)))
+      continue // skip malformed / error frames; never fatal
+    }
+    if (ev === SKIP_FRAME) continue
+    // v1 note: seq is time_us from v1's monotonic clock (strictly increasing,
+    // unique — verified in the v1 source), so the inclusive dedup is exact.
+    if (lastSeq !== undefined && ev.seq <= lastSeq) continue // dedup inclusive overlap
+    lastSeq = ev.seq
+    yield ev
+  }
+}
+
+export async function* batchEvents<E extends SeqEvent>(
+  src: AsyncGenerator<E>,
+  batchSize: number,
+): AsyncGenerator<EventBatch<E>> {
+  let events: E[] = []
+  let lastCursor = 0
+  for await (const ev of src) {
+    events.push(ev)
+    if (ev.seq > lastCursor) lastCursor = ev.seq
+    if (events.length >= batchSize) {
+      yield { events, lastCursor }
+      events = []
+    }
+  }
+  if (events.length > 0) yield { events, lastCursor }
+}

--- a/packages/jetstream/src/live/source.ts
+++ b/packages/jetstream/src/live/source.ts
@@ -2,7 +2,7 @@ import { type DidString } from '@atproto/lex-schema'
 import { type RawEventV1 } from '../event.js'
 import { decodeLiveFrameV1 } from './decode-v1.js'
 import { SKIP_FRAME } from './decode.js'
-import { type LiveTransport, wsKeepAliveTransport } from './transport.js'
+import { type LiveTransport, websocketTransport } from './transport.js'
 
 export { type LiveTransport } from './transport.js'
 
@@ -29,7 +29,7 @@ export async function* liveEvents(
   opts: LiveEventsOpts,
 ): AsyncGenerator<RawEventV1> {
   const origin = wsScheme(opts.host)
-  const transport = opts.transport ?? wsKeepAliveTransport
+  const transport = opts.transport ?? websocketTransport()
   const signal = opts.signal ?? new AbortController().signal
   // lastSeq is the highest DELIVERED seq = reconnect cursor + dedup floor.
   // undefined means nothing delivered yet (seq 0 passes).

--- a/packages/jetstream/src/live/source.ts
+++ b/packages/jetstream/src/live/source.ts
@@ -47,16 +47,10 @@ export async function* liveEvents(
     return u.toString()
   }
 
-  const te = new TextEncoder()
-
   for await (const chunk of transport.stream(getUrl, signal)) {
-    // NOTE: wsKeepAliveTransport yields strings for websocket text frames even
-    // though the type declares Uint8Array. Coerce here so the decoder stays
-    // Uint8Array-only.
-    const bytes = typeof chunk === 'string' ? te.encode(chunk as string) : chunk
     let ev: RawEventV1 | typeof SKIP_FRAME
     try {
-      ev = decodeLiveFrameV1(bytes, opts.validateWire)
+      ev = decodeLiveFrameV1(chunk, opts.validateWire)
     } catch (err) {
       // Strict-mode violations are fatal by contract (the flag asserts the
       // data source) — rethrow past the malformed-frame skip.

--- a/packages/jetstream/src/live/source.ts
+++ b/packages/jetstream/src/live/source.ts
@@ -1,3 +1,4 @@
+import { type DidString } from '@atproto/lex-schema'
 import { type RawEventV1 } from '../event.js'
 import { decodeLiveFrameV1 } from './decode-v1.js'
 import { SKIP_FRAME } from './decode.js'
@@ -8,12 +9,13 @@ export { type LiveTransport } from './transport.js'
 export interface LiveEventsOpts {
   host: string
   collections?: string[]
-  dids?: string[]
+  dids?: DidString[]
   cursor?: number // undefined = live from tip; 0 = replay from start
   dedupFloor?: number // undefined = nothing delivered (seq 0 passes); else drop seq <= floor
   transport?: LiveTransport
   signal?: AbortSignal
   onError?: (err: Error) => void
+  validateWire?: boolean // strict wire validation: throws MalformedError (fatal), never routed to onError
 }
 
 function wsScheme(host: string): string {
@@ -45,13 +47,22 @@ export async function* liveEvents(
     return u.toString()
   }
 
+  const te = new TextEncoder()
+
   for await (const chunk of transport.stream(getUrl, signal)) {
+    // NOTE: wsKeepAliveTransport yields strings for websocket text frames even
+    // though the type declares Uint8Array. Coerce here so the decoder stays
+    // Uint8Array-only.
+    const bytes = typeof chunk === 'string' ? te.encode(chunk as string) : chunk
     let ev: RawEventV1 | typeof SKIP_FRAME
     try {
-      ev = decodeLiveFrameV1(chunk)
+      ev = decodeLiveFrameV1(bytes, opts.validateWire)
     } catch (err) {
+      // Strict-mode violations are fatal by contract (the flag asserts the
+      // data source) — rethrow past the malformed-frame skip.
+      if (opts.validateWire) throw err
       opts.onError?.(err instanceof Error ? err : new Error(String(err)))
-      continue // skip malformed / error frames; never fatal
+      continue // skip malformed / error frames; never fatal in default mode
     }
     if (ev === SKIP_FRAME) continue
     // v1 note: seq is time_us from v1's monotonic clock (strictly increasing,

--- a/packages/jetstream/src/live/transport.ts
+++ b/packages/jetstream/src/live/transport.ts
@@ -8,19 +8,15 @@ export interface LiveTransport {
   stream(getUrl: () => string, signal: AbortSignal): AsyncIterable<Uint8Array>
 }
 
-const te = new TextEncoder()
-
+// NOTE: WebSocketKeepAlive declares AsyncGenerator<Uint8Array> but actually
+// yields strings for websocket text frames — and jetstream sends JSON as
+// text. This is why the decoders accept Uint8Array | string.
+// tests/live/transport.test.ts pins the behavior over a real websocket.
 export const wsKeepAliveTransport: LiveTransport = {
-  async *stream(getUrl, signal) {
-    const ka = new WebSocketKeepAlive({
+  stream(getUrl, signal) {
+    return new WebSocketKeepAlive({
       getUrl: async () => getUrl(),
       signal,
     })
-    // Jetstream v1 sends WebSocket TEXT frames, which ws (in object mode)
-    // yields as strings; binary frames arrive as bytes. The LiveTransport
-    // contract is bytes, so normalize here.
-    for await (const chunk of ka) {
-      yield typeof chunk === 'string' ? te.encode(chunk) : chunk
-    }
   },
 }

--- a/packages/jetstream/src/live/transport.ts
+++ b/packages/jetstream/src/live/transport.ts
@@ -1,23 +1,79 @@
-import { WebSocketKeepAlive } from '@atproto/ws-client'
+import {
+  CloseCode,
+  CloseError,
+  type WebSocketOptions,
+  defaultShouldReconnect,
+  websocket,
+} from '@atproto/ws-client'
 
 export interface LiveTransport {
-  // Yields raw frame bytes. getUrl() is called once per (re)connection so the
-  // resume cursor reflects the highest-delivered seq at connect time. The
-  // returned iterable should reconnect internally and end only on signal abort
-  // or a non-reconnectable error.
-  stream(getUrl: () => string, signal: AbortSignal): AsyncIterable<Uint8Array>
+  // Yields raw frames (bytes or text). getUrl() is called once per
+  // (re)connection so the resume cursor reflects the highest-delivered seq at
+  // connect time. The returned iterable should reconnect internally and end
+  // only on signal abort or a non-reconnectable error.
+  stream(
+    getUrl: () => string,
+    signal: AbortSignal,
+  ): AsyncIterable<Uint8Array | string>
 }
 
-// NOTE: WebSocketKeepAlive declares AsyncGenerator<Uint8Array> but actually
-// yields strings for websocket text frames — and jetstream sends JSON as
-// text. This is why the decoder accepts Uint8Array | string; once ws-client
-// fixes its frame typing this can tighten to Uint8Array-only.
-// tests/live/transport.test.ts pins the behavior over a real websocket.
-export const wsKeepAliveTransport: LiveTransport = {
-  stream(getUrl, signal) {
-    return new WebSocketKeepAlive({
-      getUrl: async () => getUrl(),
-      signal,
-    })
-  },
+// Jetstream frames are JSON text: dataMode 'text' types the stream as string
+// and makes a binary frame a fatal DataModeError (crash over silent
+// misinterpretation). The decoder still accepts Uint8Array | string for
+// custom transports.
+export type WebsocketTransportOptions = Omit<
+  WebSocketOptions<'text'>,
+  'signal' | 'dataMode' | 'idleTimeoutMs'
+> & {
+  /**
+   * End (and redial) the connection when no message arrives within this
+   * window. Default 60_000: jetstream is a firehose that normally never goes
+   * quiet, and in the browser this is the only dead-connection detector.
+   * `false` disables idle detection.
+   */
+  idleTimeoutMs?: number | false
+}
+
+// A jetstream server closing 1000 (restart, load-shed) should not end the
+// consumer's stream — the resume cursor makes the redial seamless. Everything
+// else keeps ws-client's classification: protocol closes
+// (1002/1003/1007/1009), DataModeError, and local resource errors stay fatal.
+export function jetstreamShouldReconnect(error: unknown): boolean {
+  return (
+    (error instanceof CloseError && error.code === CloseCode.Normal) ||
+    defaultShouldReconnect(error)
+  )
+}
+
+// Jetstream's defaults over the caller's options. Kept pure (no socket) so
+// the defaults are unit-testable; websocketTransport() adds only the
+// per-stream wiring (url, signal).
+export function resolveWebsocketOptions(
+  options: WebsocketTransportOptions = {},
+): WebSocketOptions<'text'> & { dataMode: 'text' } {
+  const {
+    idleTimeoutMs = 60_000,
+    shouldReconnect = jetstreamShouldReconnect,
+    ...rest
+  } = options
+  return {
+    ...rest,
+    shouldReconnect,
+    idleTimeoutMs: idleTimeoutMs === false ? undefined : idleTimeoutMs,
+    dataMode: 'text',
+  }
+}
+
+export function websocketTransport(
+  options?: WebsocketTransportOptions,
+): LiveTransport {
+  const resolved = resolveWebsocketOptions(options)
+  return {
+    stream(getUrl, signal) {
+      // getUrl is passed straight through: websocket() re-resolves a function
+      // url on every (re)connection, which is exactly the resume-cursor
+      // contract stream() requires.
+      return websocket(getUrl, { ...resolved, signal })
+    },
+  }
 }

--- a/packages/jetstream/src/live/transport.ts
+++ b/packages/jetstream/src/live/transport.ts
@@ -29,7 +29,10 @@ export type WebsocketTransportOptions = Omit<
    * End (and redial) the connection when no message arrives within this
    * window. Default 60_000: jetstream is a firehose that normally never goes
    * quiet, and in the browser this is the only dead-connection detector.
-   * `false` disables idle detection.
+   * `false` disables idle detection. Must be > 0 when a number: ws-client
+   * runs the idle timer on a plain `setInterval`, so 0 (or negative) would
+   * silently clamp to a ~1ms timer and redial in a tight loop; use `false`
+   * to disable idle detection instead.
    */
   idleTimeoutMs?: number | false
 }
@@ -56,6 +59,11 @@ export function resolveWebsocketOptions(
     shouldReconnect = jetstreamShouldReconnect,
     ...rest
   } = options
+  if (idleTimeoutMs !== false && idleTimeoutMs <= 0) {
+    throw new RangeError(
+      'idleTimeoutMs must be > 0; use false to disable idle detection',
+    )
+  }
   return {
     ...rest,
     shouldReconnect,

--- a/packages/jetstream/src/live/transport.ts
+++ b/packages/jetstream/src/live/transport.ts
@@ -8,11 +8,19 @@ export interface LiveTransport {
   stream(getUrl: () => string, signal: AbortSignal): AsyncIterable<Uint8Array>
 }
 
+const te = new TextEncoder()
+
 export const wsKeepAliveTransport: LiveTransport = {
-  stream(getUrl, signal) {
-    return new WebSocketKeepAlive({
+  async *stream(getUrl, signal) {
+    const ka = new WebSocketKeepAlive({
       getUrl: async () => getUrl(),
       signal,
     })
+    // Jetstream v1 sends WebSocket TEXT frames, which ws (in object mode)
+    // yields as strings; binary frames arrive as bytes. The LiveTransport
+    // contract is bytes, so normalize here.
+    for await (const chunk of ka) {
+      yield typeof chunk === 'string' ? te.encode(chunk) : chunk
+    }
   },
 }

--- a/packages/jetstream/src/live/transport.ts
+++ b/packages/jetstream/src/live/transport.ts
@@ -1,0 +1,18 @@
+import { WebSocketKeepAlive } from '@atproto/ws-client'
+
+export interface LiveTransport {
+  // Yields raw frame bytes. getUrl() is called once per (re)connection so the
+  // resume cursor reflects the highest-delivered seq at connect time. The
+  // returned iterable should reconnect internally and end only on signal abort
+  // or a non-reconnectable error.
+  stream(getUrl: () => string, signal: AbortSignal): AsyncIterable<Uint8Array>
+}
+
+export const wsKeepAliveTransport: LiveTransport = {
+  stream(getUrl, signal) {
+    return new WebSocketKeepAlive({
+      getUrl: async () => getUrl(),
+      signal,
+    })
+  },
+}

--- a/packages/jetstream/src/live/transport.ts
+++ b/packages/jetstream/src/live/transport.ts
@@ -10,8 +10,8 @@ export interface LiveTransport {
 
 // NOTE: WebSocketKeepAlive declares AsyncGenerator<Uint8Array> but actually
 // yields strings for websocket text frames — and jetstream sends JSON as
-// text. source.ts coerces those strings to Uint8Array before the decoder,
-// which is Uint8Array-only.
+// text. This is why the decoder accepts Uint8Array | string; once ws-client
+// fixes its frame typing this can tighten to Uint8Array-only.
 // tests/live/transport.test.ts pins the behavior over a real websocket.
 export const wsKeepAliveTransport: LiveTransport = {
   stream(getUrl, signal) {

--- a/packages/jetstream/src/live/transport.ts
+++ b/packages/jetstream/src/live/transport.ts
@@ -10,7 +10,8 @@ export interface LiveTransport {
 
 // NOTE: WebSocketKeepAlive declares AsyncGenerator<Uint8Array> but actually
 // yields strings for websocket text frames — and jetstream sends JSON as
-// text. This is why the decoders accept Uint8Array | string.
+// text. source.ts coerces those strings to Uint8Array before the decoder,
+// which is Uint8Array-only.
 // tests/live/transport.test.ts pins the behavior over a real websocket.
 export const wsKeepAliveTransport: LiveTransport = {
   stream(getUrl, signal) {

--- a/packages/jetstream/src/run-tracker.ts
+++ b/packages/jetstream/src/run-tracker.ts
@@ -1,0 +1,38 @@
+// src/run-tracker.ts
+import { type Ack } from './consumer.js'
+import { type EventBatch, type SeqEvent } from './event.js'
+import { CommitTracker } from './execute/commit-tracker.js'
+import { type CursorStore } from './execute/cursor-store.js'
+
+export interface TrackedStream<E extends SeqEvent> {
+  stream: AsyncGenerator<EventBatch<E>>
+  ack: Ack
+  flush(): Promise<void>
+}
+
+/**
+ * Wraps a raw-batch source with a CommitTracker. Each pulled event's seq is
+ * registered (in ascending pull order) before the batch reaches the consumer;
+ * ack(evt) marks that seq done. The tracker advances the saved cursor only to
+ * the highest contiguous acked seq and coalesces persistence. ack retains only
+ * evt.seq (a number), never the event object.
+ */
+export function trackedStream<E extends SeqEvent>(
+  src: AsyncIterable<EventBatch<E>>,
+  store?: CursorStore,
+): TrackedStream<E> {
+  const tracker = new CommitTracker(store)
+
+  async function* gen(): AsyncGenerator<EventBatch<E>> {
+    for await (const batch of src) {
+      for (const e of batch.events) tracker.track(e.seq)
+      yield batch
+    }
+  }
+
+  const ack: Ack = (evt) => {
+    tracker.done(evt.seq)
+  }
+
+  return { stream: gen(), ack, flush: () => tracker.flush() }
+}

--- a/packages/jetstream/src/run-tracker.ts
+++ b/packages/jetstream/src/run-tracker.ts
@@ -1,4 +1,3 @@
-// src/run-tracker.ts
 import { type Ack } from './consumer.js'
 import { type EventBatch, type SeqEvent } from './event.js'
 import { CommitTracker } from './execute/commit-tracker.js'

--- a/packages/jetstream/src/runner.ts
+++ b/packages/jetstream/src/runner.ts
@@ -11,7 +11,6 @@ export interface RunnerLiveOpts {
   signal?: AbortSignal
   onError?: (err: Error) => void
   liveTransport?: LiveTransport
-  liveBatchSize?: number
 }
 
 /**

--- a/packages/jetstream/src/runner.ts
+++ b/packages/jetstream/src/runner.ts
@@ -1,0 +1,55 @@
+// src/runner.ts
+import { type JetstreamConsumer } from './consumer.js'
+import { type EventBatch, type RawEventV1 } from './event.js'
+import { type CursorStore } from './execute/cursor-store.js'
+import { type Jetstream } from './jetstream.js'
+import { type LiveTransport } from './live/transport.js'
+import { trackedStream } from './run-tracker.js'
+
+export interface RunnerLiveOpts {
+  cursor?: CursorStore
+  signal?: AbortSignal
+  onError?: (err: Error) => void
+  liveTransport?: LiveTransport
+  liveBatchSize?: number
+}
+
+/**
+ * Drives a JetstreamConsumer from a Jetstream source with cursor tracking:
+ * builds the live raw batch stream (filtered by the consumer's static
+ * collections/dids), registers each event's seq with a CommitTracker before
+ * the consumer sees it, and persists the contiguous acked watermark via the
+ * CursorStore. flush() runs even when the consumer throws.
+ */
+export class JetstreamRunner {
+  readonly #jetstream: Jetstream
+  readonly #consumer: JetstreamConsumer
+
+  constructor(jetstream: Jetstream, consumer: JetstreamConsumer) {
+    this.#jetstream = jetstream
+    this.#consumer = consumer
+  }
+
+  async live(opts: RunnerLiveOpts = {}): Promise<void> {
+    const src = this.#jetstream.liveRawBatches({
+      ...opts,
+      collections: this.#consumer.collections,
+      dids: this.#consumer.dids,
+    })
+    await this.#drive(src, opts)
+  }
+
+  async #drive(
+    src: AsyncGenerator<EventBatch<RawEventV1>>,
+    opts: { cursor?: CursorStore; signal?: AbortSignal },
+  ): Promise<void> {
+    const ts = trackedStream(src, opts.cursor)
+    try {
+      // Forward the caller's signal (if any) to the seam ctx. The seam's signal
+      // is optional; LexIndexer synthesizes its own guaranteed handler signal.
+      await this.#consumer.run(ts.stream, { ack: ts.ack, signal: opts.signal })
+    } finally {
+      await ts.flush()
+    }
+  }
+}

--- a/packages/jetstream/src/runner.ts
+++ b/packages/jetstream/src/runner.ts
@@ -1,4 +1,3 @@
-// src/runner.ts
 import { type JetstreamConsumer } from './consumer.js'
 import { type EventBatch, type RawEventV1 } from './event.js'
 import { type CursorStore } from './execute/cursor-store.js'

--- a/packages/jetstream/src/shape.ts
+++ b/packages/jetstream/src/shape.ts
@@ -3,6 +3,35 @@ import { type RecordSchema } from '@atproto/lex-schema'
 import { typedEventFromRaw } from './decode-typed.js'
 import { type EventBatch, type RawEventV1, type TypedEvent } from './event.js'
 
+/**
+ * Reported through the per-call onError when a put commit's record fails
+ * schema validation for a validating schema filter and the event is skipped.
+ * Distinguishable from transport errors via instanceof.
+ */
+export class RecordValidationError extends Error {
+  readonly did: string
+  readonly collection: string
+  readonly rkey: string
+  readonly seq: number
+  constructor(opts: {
+    did: string
+    collection: string
+    rkey: string
+    seq: number
+    cause: unknown
+  }) {
+    super(
+      `record validation failed for ${opts.collection} (at://${opts.did}/${opts.collection}/${opts.rkey} seq=${opts.seq})`,
+      { cause: opts.cause },
+    )
+    this.name = 'RecordValidationError'
+    this.did = opts.did
+    this.collection = opts.collection
+    this.rkey = opts.rkey
+    this.seq = opts.seq
+  }
+}
+
 export interface ShapeFlags {
   raw?: boolean
 }
@@ -11,13 +40,42 @@ export async function* shape(
   src: AsyncIterable<EventBatch<RawEventV1>>,
   flags: ShapeFlags,
   schemasByNsid: Map<string, RecordSchema>,
+  onError?: (err: Error) => void,
 ): AsyncGenerator<RawEventV1 | TypedEvent> {
   const raw = flags.raw === true
   for await (const batch of src) {
     if (raw) {
       for (const e of batch.events) yield e
     } else {
-      for (const e of batch.events) yield typedEventFromRaw(e, schemasByNsid)
+      for (const e of batch.events) {
+        const t = typedEventFromRaw(e, schemasByNsid)
+        if (skipInvalid(t, schemasByNsid, onError)) continue
+        yield t
+      }
     }
   }
+}
+
+// True (skip) only for put commits whose collection has a VALIDATING schema
+// and whose record failed validation. Collections without a registered schema
+// (string filters, validateRecord: false) flow through — exactly the pre-skip
+// behavior.
+function skipInvalid(
+  t: TypedEvent,
+  schemasByNsid: Map<string, RecordSchema>,
+  onError?: (err: Error) => void,
+): boolean {
+  if (t.kind !== 'commit' || t.commit.operation === 'delete') return false
+  if (t.commit.validationError === undefined) return false
+  if (!schemasByNsid.has(t.commit.collection)) return false
+  onError?.(
+    new RecordValidationError({
+      did: t.did,
+      collection: t.commit.collection,
+      rkey: t.commit.rkey,
+      seq: t.seq,
+      cause: t.commit.validationError,
+    }),
+  )
+  return true
 }

--- a/packages/jetstream/src/shape.ts
+++ b/packages/jetstream/src/shape.ts
@@ -1,4 +1,3 @@
-// src/shape.ts
 import { type RecordSchema } from '@atproto/lex-schema'
 import { typedEventFromRaw } from './decode-typed.js'
 import { type EventBatch, type RawEventV1, type TypedEvent } from './event.js'

--- a/packages/jetstream/src/shape.ts
+++ b/packages/jetstream/src/shape.ts
@@ -1,0 +1,23 @@
+// src/shape.ts
+import { type RecordSchema } from '@atproto/lex-schema'
+import { typedEventFromRaw } from './decode-typed.js'
+import { type EventBatch, type RawEventV1, type TypedEvent } from './event.js'
+
+export interface ShapeFlags {
+  raw?: boolean
+}
+
+export async function* shape(
+  src: AsyncIterable<EventBatch<RawEventV1>>,
+  flags: ShapeFlags,
+  schemasByNsid: Map<string, RecordSchema>,
+): AsyncGenerator<RawEventV1 | TypedEvent> {
+  const raw = flags.raw === true
+  for await (const batch of src) {
+    if (raw) {
+      for (const e of batch.events) yield e
+    } else {
+      for (const e of batch.events) yield typedEventFromRaw(e, schemasByNsid)
+    }
+  }
+}

--- a/packages/jetstream/src/version.ts
+++ b/packages/jetstream/src/version.ts
@@ -1,0 +1,3 @@
+// The published package name. Keep references here so a rename is a one-line
+// change.
+export const PACKAGE_NAME = '@bsky.app/jetstream'

--- a/packages/jetstream/src/version.ts
+++ b/packages/jetstream/src/version.ts
@@ -1,3 +1,0 @@
-// The published package name. Keep references here so a rename is a one-line
-// change.
-export const PACKAGE_NAME = '@bsky.app/jetstream'

--- a/packages/jetstream/tests/engine/collections-filter.test.ts
+++ b/packages/jetstream/tests/engine/collections-filter.test.ts
@@ -1,0 +1,60 @@
+import { l, record } from '@atproto/lex-schema'
+import { describe, expect, it } from 'vitest'
+import { resolveNsids } from '../../src/engine/collections.js'
+import { RecordValidationError } from '../../src/shape.js'
+
+const likeSchema = record(
+  'tid',
+  'app.test.like',
+  l.object({ subject: l.string() }),
+)
+
+describe('resolveNsids options form', () => {
+  it('options form resolves the NSID and registers the schema by default', () => {
+    const { nsids, schemasByNsid } = resolveNsids([{ collection: likeSchema }])
+    expect(nsids).toEqual(['app.test.like'])
+    expect(schemasByNsid.has('app.test.like')).toBe(true)
+  })
+
+  it('validateRecord: false contributes the NSID but omits the schema', () => {
+    const { nsids, schemasByNsid } = resolveNsids([
+      { collection: likeSchema, validateRecord: false },
+    ])
+    expect(nsids).toEqual(['app.test.like'])
+    expect(schemasByNsid.size).toBe(0)
+  })
+
+  it('mixed filter forms resolve together', () => {
+    const { nsids, schemasByNsid } = resolveNsids([
+      likeSchema,
+      'app.test.post',
+      { collection: likeSchema, validateRecord: false },
+    ])
+    expect(nsids).toEqual(['app.test.like', 'app.test.post', 'app.test.like'])
+    // the bare-schema form registered it; the validateRecord: false form
+    // must not UNregister it
+    expect(schemasByNsid.has('app.test.like')).toBe(true)
+  })
+})
+
+describe('RecordValidationError', () => {
+  it('carries did/collection/rkey/seq and cause', () => {
+    const cause = new Error('bad subject')
+    const err = new RecordValidationError({
+      did: 'did:plc:a',
+      collection: 'app.test.like',
+      rkey: 'rk1',
+      seq: 42,
+      cause,
+    })
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('RecordValidationError')
+    expect(err.did).toBe('did:plc:a')
+    expect(err.collection).toBe('app.test.like')
+    expect(err.rkey).toBe('rk1')
+    expect(err.seq).toBe(42)
+    expect(err.cause).toBe(cause)
+    expect(err.message).toContain('app.test.like')
+    expect(err.message).toContain('42')
+  })
+})

--- a/packages/jetstream/tests/engine/collections-filter.test.ts
+++ b/packages/jetstream/tests/engine/collections-filter.test.ts
@@ -1,6 +1,6 @@
 import { l, record } from '@atproto/lex-schema'
 import { describe, expect, it } from 'vitest'
-import { resolveNsids } from '../../src/engine/collections.js'
+import { parseCollectionFilters } from '../../src/engine/collections.js'
 import { RecordValidationError } from '../../src/shape.js'
 
 const likeSchema = record(
@@ -9,15 +9,17 @@ const likeSchema = record(
   l.object({ subject: l.string() }),
 )
 
-describe('resolveNsids options form', () => {
+describe('parseCollectionFilters options form', () => {
   it('options form resolves the NSID and registers the schema by default', () => {
-    const { nsids, schemasByNsid } = resolveNsids([{ collection: likeSchema }])
+    const { nsids, schemasByNsid } = parseCollectionFilters([
+      { collection: likeSchema },
+    ])
     expect(nsids).toEqual(['app.test.like'])
     expect(schemasByNsid.has('app.test.like')).toBe(true)
   })
 
   it('validateRecord: false contributes the NSID but omits the schema', () => {
-    const { nsids, schemasByNsid } = resolveNsids([
+    const { nsids, schemasByNsid } = parseCollectionFilters([
       { collection: likeSchema, validateRecord: false },
     ])
     expect(nsids).toEqual(['app.test.like'])
@@ -25,7 +27,7 @@ describe('resolveNsids options form', () => {
   })
 
   it('mixed filter forms resolve together', () => {
-    const { nsids, schemasByNsid } = resolveNsids([
+    const { nsids, schemasByNsid } = parseCollectionFilters([
       likeSchema,
       'app.test.post',
       { collection: likeSchema, validateRecord: false },

--- a/packages/jetstream/tests/event-brands.test.ts
+++ b/packages/jetstream/tests/event-brands.test.ts
@@ -1,0 +1,58 @@
+import type {
+  AtUriString,
+  DatetimeString,
+  DidString,
+  HandleString,
+  NsidString,
+} from '@atproto/lex-schema'
+import { expectTypeOf, test } from 'vitest'
+import type { CollectionFilter } from '../src/engine/collections.js'
+import type {
+  Identity,
+  RawEventV1,
+  RawPutCommitV1,
+  TypedEvent,
+} from '../src/event.js'
+import type { LiveOpts } from '../src/jetstream.js'
+import type { IdentityEvent, PutEvent } from '../src/lex-indexer.js'
+
+test('event envelope fields carry lex string format brands', () => {
+  expectTypeOf<RawEventV1['did']>().toEqualTypeOf<DidString>()
+  expectTypeOf<RawPutCommitV1['collection']>().toEqualTypeOf<NsidString>()
+  expectTypeOf<Identity['handle']>().toEqualTypeOf<HandleString | undefined>()
+  expectTypeOf<Identity['time']>().toEqualTypeOf<DatetimeString | undefined>()
+})
+
+test('typed commits inherit the branded collection default', () => {
+  type Commit = Extract<TypedEvent, { kind: 'commit' }>['commit']
+  expectTypeOf<Commit['collection']>().toEqualTypeOf<NsidString>()
+})
+
+test('a plain string does not satisfy the branded fields', () => {
+  expectTypeOf<string>().not.toMatchTypeOf<DidString>()
+  expectTypeOf<string>().not.toMatchTypeOf<NsidString>()
+  // free aliases intentionally accept plain string
+  expectTypeOf<string>().toMatchTypeOf<RawPutCommitV1['cid']>()
+  expectTypeOf<string>().toMatchTypeOf<RawPutCommitV1['rkey']>()
+})
+
+test('indexer handler events carry brands', () => {
+  expectTypeOf<PutEvent<unknown>['uri']>().toEqualTypeOf<AtUriString>()
+  expectTypeOf<PutEvent<unknown>['did']>().toEqualTypeOf<DidString>()
+  expectTypeOf<PutEvent<unknown>['collection']>().toEqualTypeOf<NsidString>()
+  expectTypeOf<IdentityEvent['handle']>().toEqualTypeOf<
+    HandleString | undefined
+  >()
+})
+
+test('dids input demands DidString; literals satisfy it structurally', () => {
+  expectTypeOf<['did:plc:abc']>().toMatchTypeOf<NonNullable<LiveOpts['dids']>>()
+  expectTypeOf<string[]>().not.toMatchTypeOf<NonNullable<LiveOpts['dids']>>()
+})
+
+test('collection filter string arm: NSIDs and wildcards pass, junk rejected', () => {
+  expectTypeOf<'app.bsky.feed.like'>().toMatchTypeOf<CollectionFilter>()
+  expectTypeOf<'app.bsky.feed.*'>().toMatchTypeOf<CollectionFilter>()
+  expectTypeOf<'foo.bar'>().not.toMatchTypeOf<CollectionFilter>()
+  expectTypeOf<string>().not.toMatchTypeOf<CollectionFilter>()
+})

--- a/packages/jetstream/tests/execute/commit-tracker.test.ts
+++ b/packages/jetstream/tests/execute/commit-tracker.test.ts
@@ -1,0 +1,208 @@
+import { expect, test } from 'vitest'
+import { CommitTracker } from '../../src/execute/commit-tracker.js'
+import { MemoryCursorStore } from '../../src/execute/cursor-store.js'
+
+test('watermark only advances past the contiguous completed prefix', async () => {
+  const store = new MemoryCursorStore()
+  const t = new CommitTracker(store)
+  t.track(1)
+  t.track(2)
+  t.track(3)
+  t.done(2) // 1 still pending -> watermark stays 0
+  expect(t.watermark()).toBe(0)
+  t.done(1) // now 1,2 contiguous -> watermark 2
+  expect(t.watermark()).toBe(2)
+  t.done(3) // 3 -> watermark 3
+  expect(t.watermark()).toBe(3)
+  await t.flush()
+  expect(await store.load()).toBe(3)
+})
+
+test('out-of-order completion across gaps holds the watermark', () => {
+  const t = new CommitTracker()
+  for (const s of [10, 11, 12, 13]) t.track(s)
+  t.done(11)
+  t.done(12)
+  t.done(13)
+  expect(t.watermark()).toBe(0) // 10 never done
+  t.done(10)
+  expect(t.watermark()).toBe(13)
+})
+
+// ---------------------------------------------------------------------------
+// Helper: a store whose save() hangs until manually released.
+// ---------------------------------------------------------------------------
+interface DeferredStore {
+  calls: number[]
+  resolve: () => void
+  save: (seq: number) => Promise<void>
+}
+
+function makeDeferredStore(): DeferredStore {
+  let resolve: () => void = () => {}
+  let waitPromise: Promise<void> = new Promise((r) => {
+    resolve = r
+  })
+  const store: DeferredStore = {
+    calls: [],
+    resolve: () => {},
+    save: async (seq: number) => {
+      store.calls.push(seq)
+      await waitPromise
+      // After the current gate opens, reset so next save also blocks.
+      waitPromise = new Promise((r) => {
+        resolve = r
+        store.resolve = r
+      })
+    },
+  }
+  store.resolve = resolve
+  return store
+}
+
+test('coalescing: multiple done() while a save is in-flight only trigger one further save', async () => {
+  const ds = makeDeferredStore()
+  const t = new CommitTracker(
+    ds as unknown as import('../../src/execute/cursor-store.js').CursorStore,
+  )
+
+  t.track(1)
+  t.track(2)
+  t.track(3)
+  t.track(4)
+
+  // Complete seq 1 — this starts the first in-flight save(1)
+  t.done(1)
+  // Let the microtask queue run so the save loop fires and reaches await store.save()
+  await Promise.resolve()
+  await Promise.resolve()
+
+  expect(ds.calls).toEqual([1]) // one save started, not resolved yet
+
+  // While the first save is in-flight, advance the watermark further
+  t.done(2)
+  t.done(3)
+  t.done(4)
+  // No additional saves should have started yet
+  expect(ds.calls).toEqual([1])
+
+  // Release the first in-flight save
+  ds.resolve()
+  // Let the save loop tick: it sees pendingSave=true and does one more save
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+
+  expect(ds.calls).toEqual([1, 4]) // coalesced: exactly one follow-up save with latest mark
+
+  // Unblock the second save so we don't leave a dangling promise
+  ds.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+})
+
+test('flush() resolves only after the current watermark is durably saved', async () => {
+  const ds = makeDeferredStore()
+  const t = new CommitTracker(
+    ds as unknown as import('../../src/execute/cursor-store.js').CursorStore,
+  )
+
+  t.track(1)
+  t.track(2)
+  t.done(1)
+  // Let the save loop start
+  await Promise.resolve()
+  await Promise.resolve()
+
+  t.done(2) // mark advances to 2 but save is still in-flight
+
+  let flushed = false
+  const flushPromise = t.flush().then(() => {
+    flushed = true
+  })
+
+  // flush should not resolve yet — first save is still blocked
+  await Promise.resolve()
+  await Promise.resolve()
+  expect(flushed).toBe(false)
+
+  // Release the first in-flight save; the loop will do one more save(2)
+  ds.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+
+  // Still waiting: the second save (for mark=2) is now in-flight
+  expect(flushed).toBe(false)
+
+  // Release the second save
+  ds.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+
+  await flushPromise
+  expect(flushed).toBe(true)
+  expect(ds.calls).toEqual([1, 2])
+})
+
+test('flush() with no store resolves immediately without error', async () => {
+  const t = new CommitTracker()
+  t.track(1)
+  t.done(1)
+  await expect(t.flush()).resolves.toBeUndefined()
+})
+
+test('flush() does not issue a concurrent save while one is in-flight', async () => {
+  // Track concurrent saves using a counter
+  let concurrentSaves = 0
+  let maxConcurrentSaves = 0
+  const savedSeqs: number[] = []
+  let releaseCurrentSave: () => void = () => {}
+
+  const controlledStore = {
+    save: async (seq: number): Promise<void> => {
+      concurrentSaves++
+      maxConcurrentSaves = Math.max(maxConcurrentSaves, concurrentSaves)
+      savedSeqs.push(seq)
+      await new Promise<void>((resolve) => {
+        releaseCurrentSave = resolve
+      })
+      concurrentSaves--
+    },
+  }
+
+  const t = new CommitTracker(
+    controlledStore as unknown as import('../../src/execute/cursor-store.js').CursorStore,
+  )
+
+  t.track(1)
+  t.done(1)
+  // Let first save start
+  await Promise.resolve()
+  await Promise.resolve()
+  expect(savedSeqs).toEqual([1])
+  expect(concurrentSaves).toBe(1)
+
+  // Call flush() while first save is in-flight
+  const flushPromise = t.flush()
+  await Promise.resolve()
+  await Promise.resolve()
+
+  // Still only one in-flight save (flush is waiting, not starting a new one)
+  expect(concurrentSaves).toBe(1)
+  expect(maxConcurrentSaves).toBe(1)
+
+  // Release the first save; the loop will coalesce and do one more save(1)
+  releaseCurrentSave()
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+
+  // Release the coalesced save
+  releaseCurrentSave()
+  await flushPromise
+
+  // Never more than one concurrent save
+  expect(maxConcurrentSaves).toBe(1)
+})

--- a/packages/jetstream/tests/filter-types.test.ts
+++ b/packages/jetstream/tests/filter-types.test.ts
@@ -1,4 +1,9 @@
-import { type InferOutput, l, record } from '@atproto/lex-schema'
+import {
+  type InferOutput,
+  type NsidString,
+  l,
+  record,
+} from '@atproto/lex-schema'
 import { expectTypeOf, test } from 'vitest'
 import {
   type DeleteCommit,
@@ -61,10 +66,12 @@ test('wildcard filter maps to a template-literal collection', () => {
   >()
 })
 
-test('non-literal string filter degrades to string/UnvalidatedRecord', () => {
-  type Commit = TypedCommitFor<string>
-  expectTypeOf<Commit['collection']>().toEqualTypeOf<string>()
-  expectTypeOf<PutOf<Commit>['record']>().toEqualTypeOf<UnvalidatedRecord>()
+test('a bare NsidString filter (no literal) floor-types with the brand', () => {
+  type Commit = TypedCommitFor<NsidString>
+  expectTypeOf<Commit['collection']>().toEqualTypeOf<NsidString>()
+  expectTypeOf<PutOf<Commit>['record']>().toEqualTypeOf<
+    UnvalidatedRecord<NsidString>
+  >()
 })
 
 test('empty filter tuple falls back to plain TypedEvent', () => {

--- a/packages/jetstream/tests/filter-types.test.ts
+++ b/packages/jetstream/tests/filter-types.test.ts
@@ -1,0 +1,111 @@
+import { type InferOutput, l, record } from '@atproto/lex-schema'
+import { expectTypeOf, test } from 'vitest'
+import {
+  type DeleteCommit,
+  type TypedEvent,
+  type UnvalidatedRecord,
+} from '../src/event.js'
+import { type TypedCommitFor, type TypedEventFor } from '../src/filter-types.js'
+
+// likeSchema is consumed only via `typeof likeSchema`; the runtime value is
+// required for that type query, so eslint's no-unused-vars is a false positive.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const likeSchema = record(
+  'tid',
+  'app.test.like',
+  l.object({ subject: l.string() }),
+)
+type Like = InferOutput<typeof likeSchema>
+
+type PutOf<C> = Exclude<C, { operation: 'delete' }>
+
+test('validating schema filter narrows collection and record; no validationError', () => {
+  type Commit = TypedCommitFor<typeof likeSchema>
+  expectTypeOf<Commit['collection']>().toEqualTypeOf<'app.test.like'>()
+  expectTypeOf<PutOf<Commit>['record']>().toEqualTypeOf<Like>()
+  expectTypeOf<PutOf<Commit>>().not.toHaveProperty('validationError')
+  // the delete variant narrows collection too
+  expectTypeOf<Extract<Commit, { operation: 'delete' }>>().toEqualTypeOf<
+    DeleteCommit<'app.test.like'>
+  >()
+})
+
+test('validateRecord: false keeps the collection literal, floor-types the record', () => {
+  type Commit = TypedCommitFor<{
+    collection: typeof likeSchema
+    validateRecord: false
+  }>
+  expectTypeOf<Commit['collection']>().toEqualTypeOf<'app.test.like'>()
+  expectTypeOf<PutOf<Commit>['record']>().toEqualTypeOf<
+    UnvalidatedRecord<'app.test.like'>
+  >()
+  // unvalidated commits keep validationError (decode failures flow through)
+  expectTypeOf<PutOf<Commit>>().toHaveProperty('validationError')
+})
+
+test('string literal filter floor-types the record with its literal', () => {
+  type Commit = TypedCommitFor<'app.test.post'>
+  expectTypeOf<Commit['collection']>().toEqualTypeOf<'app.test.post'>()
+  expectTypeOf<PutOf<Commit>['record']>().toEqualTypeOf<
+    UnvalidatedRecord<'app.test.post'>
+  >()
+  // string filters are unvalidated: validationError stays available
+  expectTypeOf<PutOf<Commit>>().toHaveProperty('validationError')
+})
+
+test('wildcard filter maps to a template-literal collection', () => {
+  type Commit = TypedCommitFor<'app.test.*'>
+  expectTypeOf<Commit['collection']>().toEqualTypeOf<`app.test.${string}`>()
+  expectTypeOf<PutOf<Commit>['record']>().toEqualTypeOf<
+    UnvalidatedRecord<`app.test.${string}`>
+  >()
+})
+
+test('non-literal string filter degrades to string/UnvalidatedRecord', () => {
+  type Commit = TypedCommitFor<string>
+  expectTypeOf<Commit['collection']>().toEqualTypeOf<string>()
+  expectTypeOf<PutOf<Commit>['record']>().toEqualTypeOf<UnvalidatedRecord>()
+})
+
+test('empty filter tuple falls back to plain TypedEvent', () => {
+  expectTypeOf<TypedEventFor<readonly []>>().toEqualTypeOf<TypedEvent>()
+})
+
+test('mixed filters form a correlated union narrowed by collection', () => {
+  type Ev = TypedEventFor<readonly [typeof likeSchema, 'app.test.post']>
+  const ev = {} as Ev
+  if (ev.kind === 'commit' && ev.commit.operation !== 'delete') {
+    if (ev.commit.collection === 'app.test.like') {
+      expectTypeOf(ev.commit.record).toEqualTypeOf<Like>()
+    }
+    if (ev.commit.collection === 'app.test.post') {
+      expectTypeOf(ev.commit.record).toEqualTypeOf<
+        UnvalidatedRecord<'app.test.post'>
+      >()
+    }
+  }
+})
+
+test('namespace (Main) form narrows like the bare schema', () => {
+  type Commit = TypedCommitFor<{ main: typeof likeSchema }>
+  expectTypeOf<Commit['collection']>().toEqualTypeOf<'app.test.like'>()
+  expectTypeOf<PutOf<Commit>['record']>().toEqualTypeOf<Like>()
+})
+
+test('opts form with validateRecord omitted behaves like the bare schema', () => {
+  type Commit = TypedCommitFor<{ collection: typeof likeSchema }>
+  expectTypeOf<Commit['collection']>().toEqualTypeOf<'app.test.like'>()
+  expectTypeOf<PutOf<Commit>['record']>().toEqualTypeOf<Like>()
+  expectTypeOf<PutOf<Commit>>().not.toHaveProperty('validationError')
+})
+
+test('non-commit event kinds are unaffected by the filter generic', () => {
+  type Ev = TypedEventFor<readonly [typeof likeSchema]>
+  type Identity = Extract<Ev, { kind: 'identity' }>
+  expectTypeOf<Identity>().toEqualTypeOf<
+    Extract<TypedEvent, { kind: 'identity' }>
+  >()
+  expectTypeOf<Extract<Ev, { kind: 'account' }>>().toEqualTypeOf<
+    Extract<TypedEvent, { kind: 'account' }>
+  >()
+})

--- a/packages/jetstream/tests/indexer/indexer-type.test.ts
+++ b/packages/jetstream/tests/indexer/indexer-type.test.ts
@@ -1,0 +1,45 @@
+// tests/indexer/indexer-type.test.ts
+import { describe, expect, it } from 'vitest'
+import { type Ack, type JetstreamConsumer } from '../../src/consumer.js'
+import { type EventBatch, type RawEventV1 } from '../../src/event.js'
+
+function rawDelete(seq: number): RawEventV1 {
+  return {
+    did: 'did:plc:a',
+    seq,
+    timeUs: 0,
+    kind: 'commit',
+    commit: {
+      operation: 'delete',
+      collection: 'app.test.rec',
+      rkey: 'r' + seq,
+      rev: 'v',
+    },
+  }
+}
+
+async function* batches(...bs: EventBatch<RawEventV1>[]) {
+  for (const b of bs) yield b
+}
+
+describe('JetstreamConsumer seam', () => {
+  it('a minimal consumer satisfies the interface, pulls batches, and acks', async () => {
+    const acked: number[] = []
+    const ack: Ack = (evt) => acked.push(evt.seq)
+
+    const indexer: JetstreamConsumer = {
+      collections: ['app.test.rec'],
+      async run(stream, ctx) {
+        for await (const batch of stream) {
+          for (const evt of batch.events) ctx.ack(evt)
+        }
+      },
+    }
+
+    await indexer.run(
+      batches({ events: [rawDelete(1), rawDelete(2)], lastCursor: 2 }),
+      { ack }, // signal optional at the seam
+    )
+    expect(acked).toEqual([1, 2])
+  })
+})

--- a/packages/jetstream/tests/indexer/indexer-type.test.ts
+++ b/packages/jetstream/tests/indexer/indexer-type.test.ts
@@ -1,4 +1,3 @@
-// tests/indexer/indexer-type.test.ts
 import { describe, expect, it } from 'vitest'
 import { type Ack, type JetstreamConsumer } from '../../src/consumer.js'
 import { type EventBatch, type RawEventV1 } from '../../src/event.js'

--- a/packages/jetstream/tests/indexer/lex-indexer-register.test.ts
+++ b/packages/jetstream/tests/indexer/lex-indexer-register.test.ts
@@ -1,0 +1,38 @@
+import { l, record } from '@atproto/lex-schema'
+import { describe, expect, it } from 'vitest'
+import { LexIndexer } from '../../src/lex-indexer.js'
+
+const likeSchema = record(
+  'tid',
+  'app.test.like',
+  l.object({ subject: l.string() }),
+)
+
+describe('LexIndexer registration', () => {
+  it('accumulates registered commit-collection NSIDs into `collections`', () => {
+    const ix = new LexIndexer().commit(likeSchema, {
+      put: (e) => {
+        // type-level: e.record.subject is a string; e.uri/did/cid present
+        void (e.record.subject satisfies string)
+        void e.uri
+      },
+      del: (e) => void e.uri,
+    })
+    expect(ix.collections).toEqual(['app.test.like'])
+  })
+
+  it('.commit / .identity / .account are chainable and return the same instance', () => {
+    const ix = new LexIndexer()
+    const r1 = ix.commit(likeSchema, { put: () => {} })
+    const r2 = r1.identity(() => {})
+    const r3 = r2.account(() => {})
+    expect(r1).toBe(ix)
+    expect(r2).toBe(ix)
+    expect(r3).toBe(ix)
+  })
+
+  it('exposes concurrency from opts (default 16)', () => {
+    expect(new LexIndexer().concurrency).toBe(16)
+    expect(new LexIndexer({ concurrency: 4 }).concurrency).toBe(4)
+  })
+})

--- a/packages/jetstream/tests/indexer/lex-indexer-run.test.ts
+++ b/packages/jetstream/tests/indexer/lex-indexer-run.test.ts
@@ -131,6 +131,27 @@ describe('LexIndexer.run', () => {
     expect(acked).toEqual([5]) // acked despite no handler
   })
 
+  it('a keyOf failure throws hard out of run (implementer bug, not a settled handler error)', async () => {
+    const acked: number[] = []
+    const ix = new LexIndexer({
+      keyOf: (evt) => {
+        if (evt.seq === 2) throw new Error('bad key')
+        return String(evt.seq)
+      },
+    }).commit(likeSchema, { put: () => {} })
+    await expect(
+      ix.run(
+        batches({
+          events: [rawPut(1, 'ok'), rawPut(2, 'ok'), rawPut(3, 'ok')],
+          lastCursor: 3,
+        }),
+        { ack: (evt) => acked.push(evt.seq), signal: SIG() },
+      ),
+    ).rejects.toThrow('bad key')
+    expect(acked).toContain(1)
+    expect(acked).not.toContain(2) // failed event never acked: watermark holds
+  })
+
   it('fails fast: first handler error rejects run and the failed event is not acked', async () => {
     const acked: number[] = []
     const ix = new LexIndexer({ concurrency: 1 }).commit(likeSchema, {

--- a/packages/jetstream/tests/indexer/lex-indexer-run.test.ts
+++ b/packages/jetstream/tests/indexer/lex-indexer-run.test.ts
@@ -1,3 +1,4 @@
+import { setTimeout as delay } from 'node:timers/promises'
 import { l, record } from '@atproto/lex-schema'
 import { describe, expect, it } from 'vitest'
 import { type EventBatch, type RawEventV1 } from '../../src/event.js'
@@ -322,7 +323,7 @@ describe('LexIndexer.run', () => {
     const ix = new LexIndexer({ keyOf: () => 'same-key' }).commit(likeSchema, {
       put: async (e) => {
         if (e.seq === 1) {
-          await new Promise((r) => setTimeout(r, 10))
+          await delay(10)
           order.push('slow-1')
         } else {
           order.push(`fast-${e.seq}`) // enqueued behind seq 1's pending tail
@@ -367,7 +368,7 @@ describe('LexIndexer.run', () => {
         { ack: () => {}, signal: SIG() },
       )
       // Let both handlers start before either completes.
-      await new Promise((r) => setTimeout(r, 0))
+      await delay(0)
       expect(started.sort()).toEqual([
         'at://did:plc:a/app.test.like/r1',
         'at://did:plc:a/app.test.like/r2',
@@ -410,10 +411,10 @@ describe('LexIndexer.run', () => {
         batches({ events: [sameKey(1), sameKey(2)], lastCursor: 2 }),
         { ack: () => {}, signal: SIG() },
       )
-      await new Promise((r) => setTimeout(r, 0))
+      await delay(0)
       expect(started).toEqual([1]) // second blocked until first resolves
       gates[1].resolve()
-      await new Promise((r) => setTimeout(r, 0))
+      await delay(0)
       expect(started).toEqual([1, 2]) // second starts only after first completed
       expect(completed).toEqual([1])
       gates[2].resolve()

--- a/packages/jetstream/tests/indexer/lex-indexer-run.test.ts
+++ b/packages/jetstream/tests/indexer/lex-indexer-run.test.ts
@@ -1,0 +1,424 @@
+import { l, record } from '@atproto/lex-schema'
+import { describe, expect, it } from 'vitest'
+import { type EventBatch, type RawEventV1 } from '../../src/event.js'
+import { LexIndexer } from '../../src/lex-indexer.js'
+
+const likeSchema = record(
+  'tid',
+  'app.test.like',
+  l.object({ subject: l.string() }),
+)
+
+function rawPut(seq: number, subject: string): RawEventV1 {
+  return {
+    did: 'did:plc:a',
+    seq,
+    timeUs: 0,
+    kind: 'commit',
+    commit: {
+      operation: 'create',
+      collection: 'app.test.like',
+      rkey: 'r' + seq,
+      rev: 'v',
+      cid: 'cid' + seq,
+      record: { $type: 'app.test.like', subject },
+    },
+  }
+}
+// A create commit whose record is missing the required `subject` (typed as a
+// number), so likeSchema.safeValidate fails => typed.commit.validationError set.
+function rawInvalidPut(seq: number): RawEventV1 {
+  return {
+    did: 'did:plc:a',
+    seq,
+    timeUs: 0,
+    kind: 'commit',
+    commit: {
+      operation: 'create',
+      collection: 'app.test.like',
+      rkey: 'r' + seq,
+      rev: 'v',
+      cid: 'cid' + seq,
+      record: { $type: 'app.test.like', subject: 123 },
+    },
+  }
+}
+function rawDel(seq: number): RawEventV1 {
+  return {
+    did: 'did:plc:a',
+    seq,
+    timeUs: 0,
+    kind: 'commit',
+    commit: {
+      operation: 'delete',
+      collection: 'app.test.like',
+      rkey: 'r' + seq,
+      rev: 'v',
+    },
+  }
+}
+function rawUnregistered(seq: number): RawEventV1 {
+  return {
+    did: 'did:plc:a',
+    seq,
+    timeUs: 0,
+    kind: 'commit',
+    commit: {
+      operation: 'delete',
+      collection: 'app.other.thing',
+      rkey: 'x',
+      rev: 'v',
+    },
+  }
+}
+
+async function* batches(...bs: EventBatch<RawEventV1>[]) {
+  for (const b of bs) yield b
+}
+
+const SIG = () => new AbortController().signal
+
+describe('LexIndexer.run', () => {
+  it('dispatches typed put/del with operation+seq+uri and acks each handled event', async () => {
+    const puts: Array<{
+      uri: string
+      subject: string
+      op: string
+      seq: number
+    }> = []
+    const dels: Array<{ uri: string; op: string; seq: number }> = []
+    const acked: number[] = []
+    const ix = new LexIndexer().commit(likeSchema, {
+      put: (e, ctx) => {
+        expect(ctx.signal).toBeInstanceOf(AbortSignal) // ctx always present
+        puts.push({
+          uri: e.uri,
+          subject: e.record.subject,
+          op: e.operation,
+          seq: e.seq,
+        })
+      },
+      del: (e) => {
+        dels.push({ uri: e.uri, op: e.operation, seq: e.seq })
+      },
+    })
+    await ix.run(
+      batches({ events: [rawPut(1, 'at://s1'), rawDel(2)], lastCursor: 2 }),
+      { ack: (evt) => acked.push(evt.seq), signal: SIG() },
+    )
+    expect(puts).toEqual([
+      {
+        uri: 'at://did:plc:a/app.test.like/r1',
+        subject: 'at://s1',
+        op: 'create',
+        seq: 1,
+      },
+    ])
+    expect(dels).toEqual([
+      { uri: 'at://did:plc:a/app.test.like/r2', op: 'delete', seq: 2 },
+    ])
+    expect(acked.sort((a, b) => a - b)).toEqual([1, 2])
+  })
+
+  it('acks and skips unregistered collections (no handler)', async () => {
+    const acked: number[] = []
+    const ix = new LexIndexer().commit(likeSchema, { put: () => {} })
+    await ix.run(batches({ events: [rawUnregistered(5)], lastCursor: 5 }), {
+      ack: (evt) => acked.push(evt.seq),
+      signal: SIG(),
+    })
+    expect(acked).toEqual([5]) // acked despite no handler
+  })
+
+  it('fails fast: first handler error rejects run and the failed event is not acked', async () => {
+    const acked: number[] = []
+    const ix = new LexIndexer({ concurrency: 1 }).commit(likeSchema, {
+      put: (e) => {
+        if (e.record.subject === 'boom') throw new Error('handler failed')
+      },
+    })
+    await expect(
+      ix.run(
+        batches({
+          events: [rawPut(1, 'ok'), rawPut(2, 'boom'), rawPut(3, 'ok')],
+          lastCursor: 3,
+        }),
+        { ack: (evt) => acked.push(evt.seq), signal: SIG() },
+      ),
+    ).rejects.toThrow('handler failed')
+    expect(acked).toContain(1) // 1 acked before failure
+    expect(acked).not.toContain(2) // failed event never acked
+  })
+
+  it('calls identity and account handlers', async () => {
+    const ids: string[] = []
+    const accts: Array<{ did: string; active: boolean }> = []
+    const ix = new LexIndexer()
+      .identity((e) => ids.push(e.did))
+      .account((e) => accts.push({ did: e.did, active: e.active }))
+    const idEvt: RawEventV1 = {
+      did: 'did:plc:b',
+      seq: 1,
+      timeUs: 0,
+      kind: 'identity',
+      identity: { did: 'did:plc:b', handle: 'h.test' },
+    }
+    const acctEvt: RawEventV1 = {
+      did: 'did:plc:c',
+      seq: 2,
+      timeUs: 0,
+      kind: 'account',
+      account: { did: 'did:plc:c', active: true },
+    }
+    await ix.run(batches({ events: [idEvt, acctEvt], lastCursor: 2 }), {
+      ack: () => {},
+      signal: SIG(),
+    })
+    expect(ids).toEqual(['did:plc:b'])
+    expect(accts).toEqual([{ did: 'did:plc:c', active: true }])
+  })
+
+  it('provides a handler signal even when the seam passes none, and fires it on wind-down', async () => {
+    let observed: AbortSignal | undefined
+    let abortedDuringHandler = false
+    const ix = new LexIndexer().commit(likeSchema, {
+      put: (_e, ctx) => {
+        observed = ctx.signal
+        abortedDuringHandler = ctx.signal.aborted
+      },
+    })
+    // NOTE: seam ctx has NO signal — LexIndexer must synthesize one.
+    await ix.run(batches({ events: [rawPut(1, 'x')], lastCursor: 1 }), {
+      ack: () => {},
+    })
+    expect(observed).toBeInstanceOf(AbortSignal)
+    expect(abortedDuringHandler).toBe(false) // live while handler ran
+    expect(observed?.aborted).toBe(true) // fired on wind-down (finally)
+  })
+
+  it('aborts the handler signal when the seam signal aborts', async () => {
+    const ac = new AbortController()
+    let observed: AbortSignal | undefined
+    const ix = new LexIndexer().commit(likeSchema, {
+      put: (_e, ctx) => {
+        observed = ctx.signal
+        ac.abort() // simulate caller cancellation mid-handler
+      },
+    })
+    await ix.run(batches({ events: [rawPut(1, 'x')], lastCursor: 1 }), {
+      ack: () => {},
+      signal: ac.signal,
+    })
+    expect(observed?.aborted).toBe(true)
+  })
+
+  it('handler can consume ctx.signal to cancel in-flight work', async () => {
+    // A handler that awaits an abortable operation (mimics fetch(...,{signal})).
+    // The caller aborts; the operation must reject via ctx.signal, and that
+    // rejection propagates as the run's fail-fast error.
+    const ac = new AbortController()
+    const abortable = (signal: AbortSignal) =>
+      new Promise<void>((_resolve, reject) => {
+        if (signal.aborted) return reject(new Error('aborted'))
+        signal.addEventListener('abort', () => reject(new Error('aborted')), {
+          once: true,
+        })
+      })
+    const ix = new LexIndexer({ concurrency: 1 }).commit(likeSchema, {
+      put: async (_e, ctx) => {
+        // schedule the caller's cancellation, then block on the abortable op
+        setTimeout(() => ac.abort(), 0)
+        await abortable(ctx.signal) // rejects when ctx.signal fires
+      },
+    })
+    await expect(
+      ix.run(batches({ events: [rawPut(1, 'x')], lastCursor: 1 }), {
+        ack: () => {},
+        signal: ac.signal,
+      }),
+    ).rejects.toThrow('aborted')
+  })
+
+  it('routes invalid records to onValidationError (never put) and still acks', async () => {
+    const puts: string[] = []
+    const errs: Array<{ uri: string; isError: boolean }> = []
+    const acked: number[] = []
+    const ix = new LexIndexer()
+      .commit(likeSchema, {
+        put: (e) => {
+          puts.push(e.uri)
+        },
+      })
+      .onValidationError((e) => {
+        errs.push({ uri: e.uri, isError: e.error instanceof Error })
+      })
+    await ix.run(batches({ events: [rawInvalidPut(7)], lastCursor: 7 }), {
+      ack: (evt) => acked.push(evt.seq),
+      signal: SIG(),
+    })
+    expect(puts).toEqual([]) // put never called for invalid record
+    expect(errs).toEqual([
+      { uri: 'at://did:plc:a/app.test.like/r7', isError: true },
+    ])
+    expect(acked).toEqual([7]) // acked => watermark advances
+  })
+
+  it('acks and skips invalid records when no onValidationError is registered (no reject)', async () => {
+    const puts: string[] = []
+    const acked: number[] = []
+    const ix = new LexIndexer().commit(likeSchema, {
+      put: (e) => {
+        puts.push(e.uri)
+      },
+    })
+    await expect(
+      ix.run(batches({ events: [rawInvalidPut(8)], lastCursor: 8 }), {
+        ack: (evt) => acked.push(evt.seq),
+        signal: SIG(),
+      }),
+    ).resolves.toBeUndefined()
+    expect(puts).toEqual([]) // put never called
+    expect(acked).toEqual([8]) // ack-and-skip
+  })
+
+  it('sync handlers complete inline: all events processed, all acked, order preserved', async () => {
+    const seen: number[] = []
+    const acked: number[] = []
+    const ix = new LexIndexer().commit(likeSchema, {
+      put: (e) => {
+        seen.push(e.seq)
+      }, // synchronous
+    })
+    const events = [1, 2, 3, 4, 5].map((seq) => rawPut(seq, 's'))
+    await ix.run(batches({ events, lastCursor: 5 }), {
+      ack: (e) => acked.push(e.seq),
+      signal: SIG(),
+    })
+    expect(seen).toEqual([1, 2, 3, 4, 5])
+    expect(acked).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it('a synchronous throw fails fast and does not ack the failed event', async () => {
+    const acked: number[] = []
+    const ix = new LexIndexer({ concurrency: 1 }).commit(likeSchema, {
+      put: (e) => {
+        if (e.seq === 3) throw new Error('boom')
+      },
+    })
+    const events = [1, 2, 3, 4].map((seq) => rawPut(seq, 's'))
+    await expect(
+      ix.run(batches({ events, lastCursor: 4 }), {
+        ack: (e) => acked.push(e.seq),
+        signal: SIG(),
+      }),
+    ).rejects.toThrow('boom')
+    expect(acked).toContain(1)
+    expect(acked).toContain(2)
+    expect(acked).not.toContain(3)
+  })
+
+  it('mixed sync/async handlers on the SAME key preserve per-key order', async () => {
+    const order: string[] = []
+    const ix = new LexIndexer({ keyOf: () => 'same-key' }).commit(likeSchema, {
+      put: async (e) => {
+        if (e.seq === 1) {
+          await new Promise((r) => setTimeout(r, 10))
+          order.push('slow-1')
+        } else {
+          order.push(`fast-${e.seq}`) // enqueued behind seq 1's pending tail
+        }
+      },
+    })
+    await ix.run(
+      batches({ events: [rawPut(1, 's'), rawPut(2, 's')], lastCursor: 2 }),
+      {
+        ack: () => {},
+        signal: SIG(),
+      },
+    )
+    expect(order).toEqual(['slow-1', 'fast-2'])
+  })
+
+  it('runs different-key events concurrently and serializes same-key events', async () => {
+    // Deferred helper for deterministic overlap/serialization observation.
+    const defer = () => {
+      let resolve!: () => void
+      const promise = new Promise<void>((res) => {
+        resolve = res
+      })
+      return { promise, resolve }
+    }
+
+    // (a) different keys overlap under concurrency >= 2
+    {
+      const started: string[] = []
+      const gates = new Map<string, ReturnType<typeof defer>>()
+      const ix = new LexIndexer({ concurrency: 2 }).commit(likeSchema, {
+        put: async (e) => {
+          started.push(e.uri)
+          const g = defer()
+          gates.set(e.uri, g)
+          await g.promise
+        },
+      })
+      // Two creates on different rkeys => different default keys (eventUri).
+      const runP = ix.run(
+        batches({ events: [rawPut(1, 's1'), rawPut(2, 's2')], lastCursor: 2 }),
+        { ack: () => {}, signal: SIG() },
+      )
+      // Let both handlers start before either completes.
+      await new Promise((r) => setTimeout(r, 0))
+      expect(started.sort()).toEqual([
+        'at://did:plc:a/app.test.like/r1',
+        'at://did:plc:a/app.test.like/r2',
+      ]) // both started => overlapping
+      gates.get('at://did:plc:a/app.test.like/r1')!.resolve()
+      gates.get('at://did:plc:a/app.test.like/r2')!.resolve()
+      await runP
+    }
+
+    // (b) same key serializes strictly in order
+    {
+      const started: number[] = []
+      const completed: number[] = []
+      const gates: Array<ReturnType<typeof defer>> = []
+      const ix = new LexIndexer({ concurrency: 4 }).commit(likeSchema, {
+        put: async (e) => {
+          started.push(e.seq)
+          const g = defer()
+          gates[e.seq] = g
+          await g.promise
+          completed.push(e.seq)
+        },
+      })
+      // Same uri (same did/collection/rkey) for both events => same key.
+      const sameKey = (seq: number): RawEventV1 => ({
+        did: 'did:plc:a',
+        seq,
+        timeUs: 0,
+        kind: 'commit',
+        commit: {
+          operation: 'create',
+          collection: 'app.test.like',
+          rkey: 'shared',
+          rev: 'v',
+          cid: 'cid' + seq,
+          record: { $type: 'app.test.like', subject: 's' },
+        },
+      })
+      const runP = ix.run(
+        batches({ events: [sameKey(1), sameKey(2)], lastCursor: 2 }),
+        { ack: () => {}, signal: SIG() },
+      )
+      await new Promise((r) => setTimeout(r, 0))
+      expect(started).toEqual([1]) // second blocked until first resolves
+      gates[1].resolve()
+      await new Promise((r) => setTimeout(r, 0))
+      expect(started).toEqual([1, 2]) // second starts only after first completed
+      expect(completed).toEqual([1])
+      gates[2].resolve()
+      await runP
+      expect(completed).toEqual([1, 2])
+    }
+  })
+})

--- a/packages/jetstream/tests/indexer/lex-indexer-validate.test.ts
+++ b/packages/jetstream/tests/indexer/lex-indexer-validate.test.ts
@@ -1,0 +1,121 @@
+import { l, record } from '@atproto/lex-schema'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { type EventBatch, type RawEventV1 } from '../../src/event.js'
+import { LexIndexer, type UnvalidatedRecord } from '../../src/index.js'
+
+const likeSchema = record(
+  'tid',
+  'app.test.like',
+  l.object({ subject: l.string() }),
+)
+
+function putWithRecord(seq: number, rec: unknown): RawEventV1 {
+  return {
+    did: 'did:plc:a',
+    seq,
+    timeUs: 0,
+    kind: 'commit',
+    commit: {
+      operation: 'create',
+      collection: 'app.test.like',
+      rkey: 'r' + seq,
+      rev: 'v',
+      cid: 'cid' + seq,
+      record: rec,
+    },
+  }
+}
+
+function oneBatch(events: RawEventV1[]): AsyncIterable<EventBatch<RawEventV1>> {
+  return (async function* () {
+    yield { events, lastCursor: events[events.length - 1]?.seq ?? 0 }
+  })()
+}
+
+describe('commit validateRecord', () => {
+  it('options form with validation (default): invalid record -> onValidationError', async () => {
+    const puts: number[] = []
+    const invalid: number[] = []
+    const idx = new LexIndexer()
+      .commit({
+        collection: likeSchema,
+        handlers: { put: (e) => puts.push(e.seq) },
+      })
+      .onValidationError((e) => invalid.push(e.seq))
+    // subject: 123 fails l.string()
+    await idx.run(
+      oneBatch([
+        putWithRecord(1, { $type: 'app.test.like', subject: 'ok' }),
+        putWithRecord(2, { $type: 'app.test.like', subject: 123 }),
+      ]),
+      { ack: () => {} },
+    )
+    expect(puts).toEqual([1])
+    expect(invalid).toEqual([2])
+  })
+
+  it('validateRecord: false: schema-invalid record REACHES put; $type floor still enforced', async () => {
+    const puts: number[] = []
+    const invalid: number[] = []
+    const idx = new LexIndexer()
+      .commit({
+        collection: likeSchema,
+        validateRecord: false,
+        handlers: {
+          put: (e) => {
+            expectTypeOf(e.record).toEqualTypeOf<UnvalidatedRecord>()
+            puts.push(e.seq)
+          },
+        },
+      })
+      .onValidationError((e) => invalid.push(e.seq))
+    await idx.run(
+      oneBatch([
+        putWithRecord(1, { $type: 'app.test.like', subject: 123 }), // schema-invalid: now OK
+        putWithRecord(2, { hello: 'no $type' }), // fails the $type floor
+      ]),
+      { ack: () => {} },
+    )
+    expect(puts).toEqual([1])
+    expect(invalid).toEqual([2])
+  })
+
+  it('validateRecord: false still routes ONLY the registered collection', async () => {
+    const puts: number[] = []
+    const other: RawEventV1 = {
+      ...putWithRecord(3, { $type: 'app.test.other' }),
+    }
+    ;(other as { commit: { collection: string } }).commit.collection =
+      'app.test.other'
+    const idx = new LexIndexer().commit({
+      collection: likeSchema,
+      validateRecord: false,
+      handlers: { put: (e) => puts.push(e.seq) },
+    })
+    await idx.run(
+      oneBatch([putWithRecord(1, { $type: 'app.test.like' }), other]),
+      { ack: () => {} },
+    )
+    expect(puts).toEqual([1]) // app.test.other skipped (unregistered), not delivered
+  })
+
+  it('simple two-arg form still works and validates', async () => {
+    const puts: number[] = []
+    const idx = new LexIndexer().commit(likeSchema, {
+      put: (e) => {
+        // The simple form keeps the schema-inferred record type (which carries
+        // a branded $type plus the typed fields), NOT the loose
+        // UnvalidatedRecord. Assert the load-bearing distinction: the typed
+        // `subject: string` is present and the record is not UnvalidatedRecord.
+        expectTypeOf(e.record.subject).toEqualTypeOf<string>()
+        expectTypeOf(e.record).not.toEqualTypeOf<UnvalidatedRecord>()
+        puts.push(e.seq)
+      },
+    })
+    await idx.run(
+      oneBatch([putWithRecord(1, { $type: 'app.test.like', subject: 'ok' })]),
+      { ack: () => {} },
+    )
+    expect(puts).toEqual([1])
+  })
+})

--- a/packages/jetstream/tests/indexer/lex-indexer-validate.test.ts
+++ b/packages/jetstream/tests/indexer/lex-indexer-validate.test.ts
@@ -54,7 +54,7 @@ describe('commit validateRecord', () => {
     expect(invalid).toEqual([2])
   })
 
-  it('validateRecord: false: schema-invalid record REACHES put; $type floor still enforced', async () => {
+  it('validateRecord: false: no runtime checks — schema-invalid and $type-less records both reach put', async () => {
     const puts: number[] = []
     const invalid: number[] = []
     const idx = new LexIndexer()
@@ -63,7 +63,9 @@ describe('commit validateRecord', () => {
         validateRecord: false,
         handlers: {
           put: (e) => {
-            expectTypeOf(e.record).toEqualTypeOf<UnvalidatedRecord>()
+            expectTypeOf(e.record).toEqualTypeOf<
+              UnvalidatedRecord<'app.test.like'>
+            >()
             puts.push(e.seq)
           },
         },
@@ -71,13 +73,13 @@ describe('commit validateRecord', () => {
       .onValidationError((e) => invalid.push(e.seq))
     await idx.run(
       oneBatch([
-        putWithRecord(1, { $type: 'app.test.like', subject: 123 }), // schema-invalid: now OK
-        putWithRecord(2, { hello: 'no $type' }), // fails the $type floor
+        putWithRecord(1, { $type: 'app.test.like', subject: 123 }), // schema-invalid: OK
+        putWithRecord(2, { hello: 'no $type' }), // no floor check: also reaches put
       ]),
       { ack: () => {} },
     )
-    expect(puts).toEqual([1])
-    expect(invalid).toEqual([2])
+    expect(puts).toEqual([1, 2])
+    expect(invalid).toEqual([])
   })
 
   it('validateRecord: false still routes ONLY the registered collection', async () => {

--- a/packages/jetstream/tests/integration/lex-indexer-run.test.ts
+++ b/packages/jetstream/tests/integration/lex-indexer-run.test.ts
@@ -1,0 +1,60 @@
+// tests/integration/lex-indexer-run.test.ts
+import { l, record } from '@atproto/lex-schema'
+import { describe, expect, it } from 'vitest'
+import { Jetstream, LexIndexer, MemoryCursorStore } from '../../src/index.js'
+import { type LiveTransport } from '../../src/live/transport.js'
+
+const likeSchema = record(
+  'tid',
+  'app.test.like',
+  l.object({ subject: l.string() }),
+)
+
+function likeFrame(seq: number, subject: string): Uint8Array {
+  // v1 live frame carries the record as parsed JSON
+  return new TextEncoder().encode(
+    JSON.stringify({
+      did: 'did:plc:a',
+      kind: 'commit',
+      time_us: seq,
+      commit: {
+        operation: 'create',
+        collection: 'app.test.like',
+        rkey: 'r' + seq,
+        rev: 'v',
+        cid: 'cid' + seq,
+        record: { $type: 'app.test.like', subject },
+      },
+    }),
+  )
+}
+
+function fakeTransport(frames: Uint8Array[]): LiveTransport {
+  return {
+    async *stream() {
+      for (const f of frames) yield f
+    },
+  }
+}
+
+describe('integration: jetstream.runner(LexIndexer)', () => {
+  it('runs a LexIndexer over a live source, dispatches typed records, persists cursor', async () => {
+    const subjects: string[] = []
+    const store = new MemoryCursorStore()
+    const indexer = new LexIndexer().commit(likeSchema, {
+      put: (e, ctx) => {
+        // ctx.signal is always present; a real handler would thread it into
+        // fetch(...,{ signal: ctx.signal })
+        expect(ctx.signal).toBeInstanceOf(AbortSignal)
+        subjects.push(e.record.subject)
+      },
+    })
+    const js = new Jetstream({ service: 'https://js.example' })
+    await js.runner(indexer).live({
+      cursor: store,
+      liveTransport: fakeTransport([likeFrame(1, 's1'), likeFrame(2, 's2')]),
+    })
+    expect(subjects).toEqual(['s1', 's2'])
+    expect(await store.load()).toBe(2)
+  })
+})

--- a/packages/jetstream/tests/integration/lex-indexer-run.test.ts
+++ b/packages/jetstream/tests/integration/lex-indexer-run.test.ts
@@ -1,4 +1,3 @@
-// tests/integration/lex-indexer-run.test.ts
 import { l, record } from '@atproto/lex-schema'
 import { describe, expect, it } from 'vitest'
 import { Jetstream, LexIndexer, MemoryCursorStore } from '../../src/index.js'

--- a/packages/jetstream/tests/integration/live-real.test.ts
+++ b/packages/jetstream/tests/integration/live-real.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from 'vitest'
+import { Jetstream } from '../../src/jetstream.js'
+
+const HOST = process.env.JETSTREAM_LIVE_HOST // e.g. https://jetstream1.us-east.bsky.network
+const maybe = HOST ? test : test.skip
+
+maybe(
+  'live() decodes real frames from a running jetstream',
+  async () => {
+    const js = new Jetstream({ service: HOST! })
+    const ac = new AbortController()
+    const src = js.live({
+      collections: ['app.bsky.feed.post'],
+      signal: ac.signal,
+    })
+    const seen: string[] = []
+    const run = (async () => {
+      for await (const e of src) {
+        if (e.kind === 'commit' && e.commit.operation !== 'delete') {
+          expect(e.commit.cid).toMatch(/^bafy/)
+          seen.push(e.commit.collection)
+        }
+        if (seen.length >= 5) break
+      }
+    })()
+    const timeout = new Promise<void>((r) =>
+      setTimeout(() => {
+        ac.abort()
+        r()
+      }, 15000),
+    )
+    await Promise.race([run, timeout])
+    ac.abort()
+    expect(seen.length).toBeGreaterThan(0)
+  },
+  20000,
+)

--- a/packages/jetstream/tests/integration/live-real.test.ts
+++ b/packages/jetstream/tests/integration/live-real.test.ts
@@ -8,29 +8,18 @@ maybe(
   'live() decodes real frames from a running jetstream',
   async () => {
     const js = new Jetstream({ service: HOST! })
-    const ac = new AbortController()
-    const src = js.live({
-      collections: ['app.bsky.feed.post'],
-      signal: ac.signal,
-    })
+    const signal = AbortSignal.timeout(15000)
     const seen: string[] = []
-    const run = (async () => {
-      for await (const e of src) {
-        if (e.kind === 'commit' && e.commit.operation !== 'delete') {
-          expect(e.commit.cid).toMatch(/^bafy/)
-          seen.push(e.commit.collection)
-        }
-        if (seen.length >= 5) break
+    for await (const e of js.live({
+      collections: ['app.bsky.feed.post'],
+      signal,
+    })) {
+      if (e.kind === 'commit' && e.commit.operation !== 'delete') {
+        expect(e.commit.cid).toMatch(/^bafy/)
+        seen.push(e.commit.collection)
       }
-    })()
-    const timeout = new Promise<void>((r) =>
-      setTimeout(() => {
-        ac.abort()
-        r()
-      }, 15000),
-    )
-    await Promise.race([run, timeout])
-    ac.abort()
+      if (seen.length >= 5) break
+    }
     expect(seen.length).toBeGreaterThan(0)
   },
   20000,

--- a/packages/jetstream/tests/jetstream/exports.test.ts
+++ b/packages/jetstream/tests/jetstream/exports.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest'
+import * as api from '../../src/index.js'
+
+describe('public exports', () => {
+  it('exports Jetstream and typedEventFromRaw, not Client', () => {
+    expect(typeof api.Jetstream).toBe('function')
+    expect(typeof api.typedEventFromRaw).toBe('function')
+    expect('Client' in api).toBe(false)
+  })
+})

--- a/packages/jetstream/tests/jetstream/exports.test.ts
+++ b/packages/jetstream/tests/jetstream/exports.test.ts
@@ -7,4 +7,8 @@ describe('public exports', () => {
     expect(typeof api.typedEventFromRaw).toBe('function')
     expect('Client' in api).toBe(false)
   })
+
+  it('exports the websocketTransport factory', () => {
+    expect(typeof api.websocketTransport).toBe('function')
+  })
 })

--- a/packages/jetstream/tests/jetstream/filter-narrowing.test.ts
+++ b/packages/jetstream/tests/jetstream/filter-narrowing.test.ts
@@ -1,4 +1,10 @@
-import { type InferOutput, l, record } from '@atproto/lex-schema'
+import {
+  type DidString,
+  type InferOutput,
+  type NsidString,
+  l,
+  record,
+} from '@atproto/lex-schema'
 import { describe, expect, expectTypeOf, it } from 'vitest'
 import { Jetstream, type UnvalidatedRecord } from '../../src/index.js'
 import type { LiveTransport } from '../../src/live/transport.js'
@@ -50,7 +56,7 @@ describe('live() filter narrowing (public API)', () => {
       ]),
     })) {
       // collection narrows across the whole union
-      expectTypeOf(ev.did).toEqualTypeOf<string>()
+      expectTypeOf(ev.did).toEqualTypeOf<DidString>()
       if (ev.kind === 'commit' && ev.commit.operation !== 'delete') {
         if (ev.commit.collection === 'app.test.like') {
           expectTypeOf(ev.commit.record).toEqualTypeOf<Like>()
@@ -77,7 +83,7 @@ describe('live() filter narrowing (public API)', () => {
     })) {
       if (ev.kind === 'commit' && ev.commit.operation !== 'delete') {
         expectTypeOf(ev.commit.record).toEqualTypeOf<unknown>()
-        expectTypeOf(ev.commit.collection).toEqualTypeOf<string>()
+        expectTypeOf(ev.commit.collection).toEqualTypeOf<NsidString>()
       }
     }
   })

--- a/packages/jetstream/tests/jetstream/filter-narrowing.test.ts
+++ b/packages/jetstream/tests/jetstream/filter-narrowing.test.ts
@@ -1,0 +1,102 @@
+import { type InferOutput, l, record } from '@atproto/lex-schema'
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { Jetstream, type UnvalidatedRecord } from '../../src/index.js'
+import type { LiveTransport } from '../../src/live/transport.js'
+
+const likeSchema = record(
+  'tid',
+  'app.test.like',
+  l.object({ subject: l.string() }),
+)
+type Like = InferOutput<typeof likeSchema>
+
+function frame(seq: number, collection: string, rec: unknown): string {
+  return JSON.stringify({
+    did: 'did:plc:a',
+    time_us: seq,
+    kind: 'commit',
+    commit: {
+      rev: 'v',
+      operation: 'create',
+      collection,
+      rkey: 'r' + seq,
+      cid: 'cid' + seq,
+      record: rec,
+    },
+  })
+}
+
+function fakeTransport(frames: string[]): LiveTransport {
+  return {
+    stream() {
+      return (async function* () {
+        for (const f of frames) yield new TextEncoder().encode(f)
+      })()
+    },
+  }
+}
+
+describe('live() filter narrowing (public API)', () => {
+  it('mixed filters: correlated narrowing + validation skip, end to end', async () => {
+    const jetstream = new Jetstream({ service: 'https://js.example' })
+    const likes: Like[] = []
+    const posts: number[] = []
+    for await (const ev of jetstream.live({
+      collections: [likeSchema, 'app.test.post'],
+      liveTransport: fakeTransport([
+        frame(1, 'app.test.like', { $type: 'app.test.like', subject: 'ok' }),
+        frame(2, 'app.test.like', { $type: 'app.test.like', subject: 9 }), // invalid: skipped
+        frame(3, 'app.test.post', { $type: 'app.test.post', anything: 1 }),
+      ]),
+    })) {
+      // collection narrows across the whole union
+      expectTypeOf(ev.did).toEqualTypeOf<string>()
+      if (ev.kind === 'commit' && ev.commit.operation !== 'delete') {
+        if (ev.commit.collection === 'app.test.like') {
+          expectTypeOf(ev.commit.record).toEqualTypeOf<Like>()
+          likes.push(ev.commit.record)
+        }
+        if (ev.commit.collection === 'app.test.post') {
+          expectTypeOf(ev.commit.record).toEqualTypeOf<
+            UnvalidatedRecord<'app.test.post'>
+          >()
+          posts.push(ev.seq)
+        }
+      }
+    }
+    expect(likes.map((r) => r.subject)).toEqual(['ok'])
+    expect(posts).toEqual([3])
+  })
+
+  it('no collections filter still yields plain TypedEvent', async () => {
+    const jetstream = new Jetstream({ service: 'https://js.example' })
+    for await (const ev of jetstream.live({
+      liveTransport: fakeTransport([
+        frame(1, 'app.test.like', { $type: 'app.test.like', subject: 'ok' }),
+      ]),
+    })) {
+      if (ev.kind === 'commit' && ev.commit.operation !== 'delete') {
+        expectTypeOf(ev.commit.record).toEqualTypeOf<unknown>()
+        expectTypeOf(ev.commit.collection).toEqualTypeOf<string>()
+      }
+    }
+  })
+
+  it('raw mode is untouched by schema filters (no skip, RawEventV1 shape)', async () => {
+    const jetstream = new Jetstream({ service: 'https://js.example' })
+    const seqs: number[] = []
+    for await (const ev of jetstream.live({
+      raw: true,
+      collections: [likeSchema],
+      liveTransport: fakeTransport([
+        frame(1, 'app.test.like', { $type: 'app.test.like', subject: 9 }), // schema-invalid
+      ]),
+    })) {
+      seqs.push(ev.seq)
+      if (ev.kind === 'commit' && ev.commit.operation !== 'delete') {
+        expectTypeOf(ev.commit.record).toEqualTypeOf<unknown>()
+      }
+    }
+    expect(seqs).toEqual([1]) // invalid record NOT skipped in raw mode
+  })
+})

--- a/packages/jetstream/tests/jetstream/isomorphic.test.ts
+++ b/packages/jetstream/tests/jetstream/isomorphic.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// The package's isomorphism claim: nothing in src/ may import Node-only
+// modules. ws-client owns the platform split; this test keeps it that way.
+
+const SRC = join(import.meta.dirname, '../../src')
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name)
+    if (entry.isDirectory()) yield* walk(p)
+    else if (entry.name.endsWith('.ts')) yield p
+  }
+}
+
+const NODE_ONLY =
+  /from\s+['"](node:[^'"]*|ws|fs|path|os|crypto|stream|util|events|buffer|child_process|net|http|https)['"]/
+
+describe('isomorphism', () => {
+  it('src/ imports no Node-only modules', () => {
+    const offenders: string[] = []
+    for (const file of walk(SRC)) {
+      if (NODE_ONLY.test(readFileSync(file, 'utf8'))) offenders.push(file)
+    }
+    expect(offenders).toEqual([])
+  })
+})

--- a/packages/jetstream/tests/jetstream/live-validate.test.ts
+++ b/packages/jetstream/tests/jetstream/live-validate.test.ts
@@ -1,0 +1,58 @@
+import { l, record } from '@atproto/lex-schema'
+import { describe, expect, it } from 'vitest'
+import { Jetstream, RecordValidationError } from '../../src/index.js'
+import type { LiveTransport } from '../../src/live/transport.js'
+
+const likeSchema = record(
+  'tid',
+  'app.test.like',
+  l.object({ subject: l.string() }),
+)
+
+function frame(seq: number, rec: unknown): string {
+  return JSON.stringify({
+    did: 'did:plc:a',
+    time_us: seq,
+    kind: 'commit',
+    commit: {
+      rev: 'v',
+      operation: 'create',
+      collection: 'app.test.like',
+      rkey: 'r' + seq,
+      cid: 'cid' + seq,
+      record: rec,
+    },
+  })
+}
+
+function fakeTransport(frames: string[]): LiveTransport {
+  return {
+    stream() {
+      return (async function* () {
+        for (const f of frames) yield new TextEncoder().encode(f)
+      })()
+    },
+  }
+}
+
+describe('live() with a validating schema filter', () => {
+  it('yields only valid records; invalid ones go to onError as RecordValidationError', async () => {
+    const jetstream = new Jetstream({ service: 'https://js.example' })
+    const errors: Error[] = []
+    const seqs: number[] = []
+    for await (const ev of jetstream.live({
+      collections: [likeSchema],
+      liveTransport: fakeTransport([
+        frame(1, { $type: 'app.test.like', subject: 'ok' }),
+        frame(2, { $type: 'app.test.like', subject: 123 }), // invalid
+        frame(3, { $type: 'app.test.like', subject: 'ok' }),
+      ]),
+      onError: (err) => errors.push(err),
+    })) {
+      seqs.push(ev.seq)
+    }
+    expect(seqs).toEqual([1, 3])
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toBeInstanceOf(RecordValidationError)
+  })
+})

--- a/packages/jetstream/tests/jetstream/live.test.ts
+++ b/packages/jetstream/tests/jetstream/live.test.ts
@@ -1,4 +1,3 @@
-// tests/jetstream/live.test.ts
 import { describe, expect, it } from 'vitest'
 import { MemoryCursorStore } from '../../src/execute/cursor-store.js'
 import { Jetstream } from '../../src/jetstream.js'

--- a/packages/jetstream/tests/jetstream/live.test.ts
+++ b/packages/jetstream/tests/jetstream/live.test.ts
@@ -1,0 +1,58 @@
+// tests/jetstream/live.test.ts
+import { describe, expect, it } from 'vitest'
+import { MemoryCursorStore } from '../../src/execute/cursor-store.js'
+import { Jetstream } from '../../src/jetstream.js'
+import { type LiveTransport } from '../../src/live/transport.js'
+
+const te = new TextEncoder()
+
+// transport that emits v1 JSON commit frames then ends
+function fakeTransport(seqs: number[]): LiveTransport {
+  return {
+    async *stream() {
+      for (const seq of seqs) {
+        yield te.encode(
+          JSON.stringify({
+            did: 'did:plc:a',
+            kind: 'commit',
+            time_us: seq,
+            commit: {
+              operation: 'delete',
+              collection: 'app.test.rec',
+              rkey: 'r' + seq,
+              rev: 'rev',
+            },
+          }),
+        )
+      }
+    },
+  }
+}
+
+describe('Jetstream.live', () => {
+  it('typed yields one TypedEvent per frame', async () => {
+    const js = new Jetstream({ service: 'https://js.example' })
+    const out: number[] = []
+    for await (const evt of js.live({
+      liveTransport: fakeTransport([1, 2, 3]),
+    })) {
+      out.push(evt.seq)
+    }
+    expect(out).toEqual([1, 2, 3])
+  })
+
+  it('reads resume cursor from the store as the dedup floor', async () => {
+    const store = new MemoryCursorStore()
+    await store.save(2)
+    const js = new Jetstream({ service: 'https://js.example' })
+    const out: number[] = []
+    for await (const evt of js.live({
+      cursor: store,
+      liveTransport: fakeTransport([1, 2, 3]),
+    })) {
+      out.push(evt.seq)
+    }
+    // seq <= 2 deduped; only 3 survives
+    expect(out).toEqual([3])
+  })
+})

--- a/packages/jetstream/tests/jetstream/runner.test.ts
+++ b/packages/jetstream/tests/jetstream/runner.test.ts
@@ -1,4 +1,3 @@
-// tests/jetstream/runner.test.ts
 import { describe, expect, it } from 'vitest'
 import { type JetstreamConsumer } from '../../src/consumer.js'
 import { MemoryCursorStore } from '../../src/execute/cursor-store.js'

--- a/packages/jetstream/tests/jetstream/runner.test.ts
+++ b/packages/jetstream/tests/jetstream/runner.test.ts
@@ -1,0 +1,127 @@
+// tests/jetstream/runner.test.ts
+import { describe, expect, it } from 'vitest'
+import { type JetstreamConsumer } from '../../src/consumer.js'
+import { MemoryCursorStore } from '../../src/execute/cursor-store.js'
+import { Jetstream, JetstreamRunner } from '../../src/index.js'
+import { type LiveTransport } from '../../src/live/transport.js'
+
+// fake transport emitting v1 JSON delete-commit frames then ending
+function fakeTransport(seqs: number[]): LiveTransport {
+  const enc = new TextEncoder()
+  return {
+    async *stream() {
+      for (const seq of seqs) {
+        yield enc.encode(
+          JSON.stringify({
+            did: 'did:plc:a',
+            kind: 'commit',
+            time_us: seq,
+            commit: {
+              operation: 'delete',
+              collection: 'app.test.rec',
+              rkey: 'r' + seq,
+              rev: 'v',
+            },
+          }),
+        )
+      }
+    },
+  }
+}
+
+describe('JetstreamRunner', () => {
+  it('drives a live indexer end to end and persists the contiguous watermark', async () => {
+    const store = new MemoryCursorStore()
+    const seen: number[] = []
+    const indexer: JetstreamConsumer = {
+      collections: ['app.test.rec'],
+      async run(stream, { ack }) {
+        for await (const batch of stream) {
+          for (const evt of batch.events) {
+            seen.push(evt.seq)
+            ack(evt)
+          }
+        }
+      },
+    }
+    const js = new Jetstream({ service: 'https://js.example' })
+    await js.runner(indexer).live({
+      cursor: store,
+      liveTransport: fakeTransport([1, 2, 3]),
+    })
+    expect(seen).toEqual([1, 2, 3])
+    expect(await store.load()).toBe(3)
+  })
+
+  it('flushes the cursor even when the indexer throws (watermark holds at last contiguous ack)', async () => {
+    const store = new MemoryCursorStore()
+    const indexer: JetstreamConsumer = {
+      async run(stream, { ack }) {
+        for await (const batch of stream) {
+          for (const evt of batch.events) {
+            if (evt.seq === 2) throw new Error('boom') // ack 1, then fail on 2
+            ack(evt)
+          }
+        }
+      },
+    }
+    const js = new Jetstream({ service: 'https://js.example' })
+    await expect(
+      js.runner(indexer).live({
+        cursor: store,
+        liveTransport: fakeTransport([1, 2, 3]),
+      }),
+    ).rejects.toThrow('boom')
+    // seq 1 was acked before the throw; flush persisted it; 2/3 never acked
+    expect(await store.load()).toBe(1)
+  })
+
+  it('forwards the caller signal to the seam ctx (optional — undefined when not passed)', async () => {
+    const seen: Array<AbortSignal | undefined> = []
+    const indexer: JetstreamConsumer = {
+      async run(stream, ctx) {
+        seen.push(ctx.signal)
+        for await (const batch of stream) {
+          for (const evt of batch.events) ctx.ack(evt)
+        }
+      },
+    }
+    const js = new Jetstream({ service: 'https://js.example' })
+
+    // (a) no caller signal -> seam ctx.signal is undefined
+    await js.runner(indexer).live({ liveTransport: fakeTransport([1]) })
+    expect(seen[0]).toBeUndefined()
+
+    // (b) caller signal -> forwarded as the same instance
+    const ac = new AbortController()
+    await js.runner(indexer).live({
+      signal: ac.signal,
+      liveTransport: fakeTransport([2]),
+    })
+    expect(seen[1]).toBe(ac.signal)
+  })
+
+  it('explicit construction behaves like the factory', async () => {
+    const store = new MemoryCursorStore()
+    const seen: number[] = []
+    const indexer: JetstreamConsumer = {
+      collections: ['app.test.rec'],
+      async run(stream, { ack }) {
+        for await (const batch of stream) {
+          for (const evt of batch.events) {
+            seen.push(evt.seq)
+            ack(evt)
+          }
+        }
+      },
+    }
+    const js = new Jetstream({ service: 'https://js.example' })
+    const runner = new JetstreamRunner(js, indexer)
+    await runner.live({
+      cursor: store,
+      liveTransport: fakeTransport([1, 2, 3]),
+    })
+    expect(seen).toEqual([1, 2, 3])
+    expect(await store.load()).toBe(3)
+  })
+})

--- a/packages/jetstream/tests/jetstream/v1-types.test.ts
+++ b/packages/jetstream/tests/jetstream/v1-types.test.ts
@@ -1,0 +1,58 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type {
+  Ack,
+  EventBatch,
+  JetstreamConsumer,
+  RawEventV1,
+  SeqEvent,
+  TypedEvent,
+} from '../../src/index.js'
+import { Jetstream } from '../../src/index.js'
+import { liveEvents } from '../../src/live/source.js'
+
+describe('live() types', () => {
+  it('raw live yields RawEventV1; typed live yields TypedEvent', () => {
+    const js = new Jetstream('https://h')
+
+    expectTypeOf(js.live({ raw: true })).toEqualTypeOf<
+      AsyncGenerator<RawEventV1>
+    >()
+    expectTypeOf(js.live()).toEqualTypeOf<AsyncGenerator<TypedEvent>>()
+  })
+})
+
+describe('SeqEvent envelope', () => {
+  it('liveEvents declares RawEventV1', () => {
+    expectTypeOf(liveEvents({ host: 'https://h' })).toEqualTypeOf<
+      AsyncGenerator<RawEventV1>
+    >()
+  })
+
+  it('the consumer seam element is RawEventV1 and satisfies SeqEvent', () => {
+    type SeamStream = Parameters<JetstreamConsumer['run']>[0]
+    expectTypeOf<SeamStream>().toEqualTypeOf<
+      AsyncIterable<EventBatch<RawEventV1>>
+    >()
+    // Every seam element satisfies the minimal envelope.
+    expectTypeOf<RawEventV1>().toMatchTypeOf<SeqEvent>()
+  })
+
+  it('a consumer cannot read recordCbor (v1 carries parsed JSON records)', () => {
+    const readCbor = (ev: RawEventV1): Uint8Array | undefined => {
+      if (ev.kind !== 'commit') return undefined
+      // @ts-expect-error recordCbor is not present on v1 commits; reading it
+      // is a compile error — the honest surface.
+      return ev.commit.recordCbor
+    }
+    expectTypeOf(readCbor).toBeFunction()
+  })
+
+  it('Ack accepts any { seq: number }', () => {
+    // Ack only reads the cursor, so it takes the minimal SeqEvent — any object
+    // carrying a numeric seq is assignable.
+    expectTypeOf<Ack>().parameter(0).toEqualTypeOf<SeqEvent>()
+    const ack = ((_evt: SeqEvent) => {}) as Ack
+    ack({ seq: 1 }) // a bare { seq } — not a full RawEventV1
+    expectTypeOf(ack).toBeCallableWith({ seq: 42 })
+  })
+})

--- a/packages/jetstream/tests/jetstream/validate-wire.test.ts
+++ b/packages/jetstream/tests/jetstream/validate-wire.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import { MalformedError } from '../../src/errors.js'
+import { Jetstream } from '../../src/jetstream.js'
+import type { LiveTransport } from '../../src/live/transport.js'
+
+const TID = '3jzfcijpj2z2a'
+
+const frame = (did: string, time_us: number) =>
+  JSON.stringify({
+    did,
+    time_us,
+    kind: 'commit',
+    commit: {
+      operation: 'delete',
+      collection: 'app.bsky.feed.like',
+      rkey: TID,
+      rev: TID,
+    },
+  })
+
+function transportOf(frames: string[]): LiveTransport {
+  return {
+    async *stream() {
+      for (const f of frames) yield new TextEncoder().encode(f)
+    },
+  }
+}
+
+describe('validateWire strict mode', () => {
+  it('live: throws MalformedError on a mangled did (raw mode, fatal)', async () => {
+    const js = new Jetstream({
+      service: 'https://js.example',
+      validateWire: true,
+    })
+    const consume = async () => {
+      for await (const _ of js.live({
+        raw: true,
+        liveTransport: transportOf([frame('not-a-did', 1)]),
+      })) {
+        // unreachable
+      }
+    }
+    await expect(consume()).rejects.toThrow(MalformedError)
+  })
+
+  it('live: accepts well-formed frames and yields them', async () => {
+    const js = new Jetstream({
+      service: 'https://js.example',
+      validateWire: true,
+    })
+    const seqs: number[] = []
+    for await (const ev of js.live({
+      raw: true,
+      liveTransport: transportOf([
+        frame('did:plc:a', 1),
+        frame('did:plc:a', 2),
+      ]),
+    })) {
+      seqs.push(ev.seq)
+    }
+    expect(seqs).toEqual([1, 2])
+  })
+
+  it('default mode: the same mangled frame passes through untouched', async () => {
+    const js = new Jetstream({ service: 'https://js.example' })
+    const dids: string[] = []
+    for await (const ev of js.live({
+      raw: true,
+      liveTransport: transportOf([frame('not-a-did', 1)]),
+    })) {
+      dids.push(ev.did)
+    }
+    expect(dids).toEqual(['not-a-did']) // optimistic: brand means "server said so"
+  })
+
+  it('strict mode throws on a missing required field (commit without rev)', async () => {
+    const js = new Jetstream({
+      service: 'https://js.example',
+      validateWire: true,
+    })
+    const noRev = JSON.stringify({
+      did: 'did:plc:a',
+      time_us: 1,
+      kind: 'commit',
+      commit: {
+        operation: 'delete',
+        collection: 'app.bsky.feed.like',
+        rkey: TID,
+      },
+    })
+    const consume = async () => {
+      for await (const _ of js.live({
+        raw: true,
+        liveTransport: transportOf([noRev]),
+      })) {
+        // unreachable
+      }
+    }
+    await expect(consume()).rejects.toThrow(MalformedError)
+  })
+
+  it('unknown kinds still SKIP_FRAME in strict mode (pre-discrimination)', async () => {
+    const js = new Jetstream({
+      service: 'https://js.example',
+      validateWire: true,
+    })
+    const seqs: number[] = []
+    for await (const ev of js.live({
+      raw: true,
+      liveTransport: transportOf([
+        JSON.stringify({ did: 'did:plc:a', time_us: 1, kind: 'wat' }),
+        frame('did:plc:a', 2),
+      ]),
+    })) {
+      seqs.push(ev.seq)
+    }
+    expect(seqs).toEqual([2])
+  })
+})

--- a/packages/jetstream/tests/live/decode-v1.test.ts
+++ b/packages/jetstream/tests/live/decode-v1.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, test } from 'vitest'
 import { MalformedError } from '../../src/errors.js'
 import { decodeLiveFrameV1 } from '../../src/live/decode-v1.js'
 import { SKIP_FRAME } from '../../src/live/decode.js'
 
 const enc = (o: unknown) => new TextEncoder().encode(JSON.stringify(o))
+// string-first encoder for pre-serialized fixtures
+const encStr = (s: string): Uint8Array => new TextEncoder().encode(s)
 
 describe('decodeLiveFrameV1', () => {
   it('decodes a long-form commit create (deployed spelling)', () => {
@@ -147,4 +149,67 @@ describe('decodeLiveFrameV1', () => {
       ),
     ).toThrow(MalformedError)
   })
+})
+
+// --- validateWire strict mode tests (v1) ---
+
+const TID = '3jzfcijpj2z2a'
+const DID = 'did:plc:ewvi7nxzyoun6zhxrhs64oiz'
+const CID = 'bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a'
+
+const v1Put = (over: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    did: DID,
+    time_us: 9,
+    kind: 'commit',
+    commit: {
+      operation: 'create',
+      collection: 'app.bsky.feed.like',
+      rkey: TID,
+      rev: TID,
+      cid: CID,
+      record: { $type: 'app.bsky.feed.like' },
+      ...over,
+    },
+  })
+
+test('validateWire accepts a well-formed v1 put', () => {
+  expect(decodeLiveFrameV1(encStr(v1Put()), true)).not.toBe(SKIP_FRAME)
+})
+
+test('validateWire checks the v1 wire cid format', () => {
+  expect(() =>
+    decodeLiveFrameV1(encStr(v1Put({ cid: 'garbage' })), true),
+  ).toThrow(MalformedError)
+})
+
+test('validateWire throws on missing required time_us (the v1 cursor)', () => {
+  const frame = JSON.parse(v1Put()) as Record<string, unknown>
+  delete frame.time_us
+  expect(() => decodeLiveFrameV1(encStr(JSON.stringify(frame)), true)).toThrow(
+    MalformedError,
+  )
+})
+
+test('default mode passes a mangled v1 did through untouched', () => {
+  const ev = decodeLiveFrameV1(encStr(v1Put()), undefined)
+  expect(ev).not.toBe(SKIP_FRAME)
+  const bad = decodeLiveFrameV1(encStr(v1Put().replace(DID, 'not-a-did')))
+  expect(bad).not.toBe(SKIP_FRAME)
+})
+
+test('unknown v1 commit operation throws MalformedError in default mode', () => {
+  // Pins existing behavior: dispatch check throws before any record access.
+  const frame = JSON.stringify({
+    did: DID,
+    time_us: 9,
+    kind: 'commit',
+    commit: {
+      operation: 'frobnicate',
+      collection: 'app.bsky.feed.like',
+      rkey: TID,
+      rev: TID,
+    },
+  })
+  expect(() => decodeLiveFrameV1(encStr(frame))).toThrow(MalformedError)
 })

--- a/packages/jetstream/tests/live/decode-v1.test.ts
+++ b/packages/jetstream/tests/live/decode-v1.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest'
+import { MalformedError } from '../../src/errors.js'
+import { decodeLiveFrameV1 } from '../../src/live/decode-v1.js'
+import { SKIP_FRAME } from '../../src/live/decode.js'
+
+const enc = (o: unknown) => new TextEncoder().encode(JSON.stringify(o))
+
+describe('decodeLiveFrameV1', () => {
+  it('decodes a long-form commit create (deployed spelling)', () => {
+    const ev = decodeLiveFrameV1(
+      enc({
+        did: 'did:plc:abc',
+        time_us: 1725911162329308,
+        kind: 'commit',
+        commit: {
+          rev: '3l3qo2vutsw2b',
+          operation: 'create',
+          collection: 'app.bsky.feed.like',
+          rkey: '3l3qo2vuowo2b',
+          record: { $type: 'app.bsky.feed.like', subject: { uri: 'at://x' } },
+          cid: 'bafyreidc6sydkkbchcyg62v77wbhzvb2mvytlmsychqgwf2xdjyflo3kiq',
+        },
+      }),
+    )
+    if (ev === SKIP_FRAME) throw new Error('skipped')
+    expect(ev.kind).toBe('commit')
+    expect(ev.seq).toBe(1725911162329308)
+    expect(ev.timeUs).toBe(1725911162329308)
+    expect(ev.did).toBe('did:plc:abc')
+    if (ev.kind !== 'commit' || ev.commit.operation === 'delete')
+      throw new Error()
+    expect(ev.commit.collection).toBe('app.bsky.feed.like')
+    expect(ev.commit.cid).toMatch(/^bafyrei/)
+    expect(ev.commit.record).toEqual({
+      $type: 'app.bsky.feed.like',
+      subject: { uri: 'at://x' },
+    })
+  })
+
+  it('decodes a commit delete', () => {
+    const ev = decodeLiveFrameV1(
+      enc({
+        did: 'did:plc:abc',
+        time_us: 100,
+        kind: 'commit',
+        commit: {
+          rev: 'r',
+          operation: 'delete',
+          collection: 'app.bsky.feed.post',
+          rkey: 'rk',
+        },
+      }),
+    )
+    if (ev === SKIP_FRAME) throw new Error('skipped')
+    if (ev.kind !== 'commit') throw new Error()
+    expect(ev.commit.operation).toBe('delete')
+    expect(ev.commit.collection).toBe('app.bsky.feed.post')
+    expect(ev.seq).toBe(100)
+  })
+
+  it('decodes commit update', () => {
+    const ev = decodeLiveFrameV1(
+      enc({
+        did: 'd',
+        time_us: 1,
+        kind: 'commit',
+        commit: {
+          rev: 'r',
+          operation: 'update',
+          collection: 'c.o.l',
+          rkey: 'rk',
+          record: { $type: 'c.o.l' },
+          cid: 'cid1',
+        },
+      }),
+    )
+    if (
+      ev === SKIP_FRAME ||
+      ev.kind !== 'commit' ||
+      ev.commit.operation === 'delete'
+    )
+      throw new Error()
+    expect(ev.commit.operation).toBe('update')
+  })
+
+  it('decodes identity and account', () => {
+    const id = decodeLiveFrameV1(
+      enc({
+        did: 'd',
+        time_us: 2,
+        kind: 'identity',
+        identity: { did: 'd', handle: 'h.example' },
+      }),
+    )
+    if (id === SKIP_FRAME) throw new Error()
+    expect(id.kind).toBe('identity')
+    const acc = decodeLiveFrameV1(
+      enc({
+        did: 'd',
+        time_us: 3,
+        kind: 'account',
+        account: { did: 'd', active: true },
+      }),
+    )
+    if (acc === SKIP_FRAME) throw new Error()
+    if (acc.kind !== 'account') throw new Error()
+    expect(acc.account.active).toBe(true)
+  })
+
+  it('skips unknown kinds (incl. prototype short codes); throws on error frames and non-JSON', () => {
+    expect(decodeLiveFrameV1(enc({ did: 'd', time_us: 4, kind: 'wat' }))).toBe(
+      SKIP_FRAME,
+    )
+    // prototype-era short codes are NOT deployed and NOT supported -> skip
+    expect(
+      decodeLiveFrameV1(
+        enc({
+          did: 'd',
+          time_us: 5,
+          type: 'com',
+          commit: { rev: 'r', type: 'c' },
+        }),
+      ),
+    ).toBe(SKIP_FRAME)
+    expect(() =>
+      decodeLiveFrameV1(enc({ error: 'boom', message: 'm' })),
+    ).toThrow(MalformedError)
+    expect(() =>
+      decodeLiveFrameV1(new TextEncoder().encode('not json')),
+    ).toThrow(MalformedError)
+  })
+
+  it('put commit missing record or cid throws MalformedError', () => {
+    expect(() =>
+      decodeLiveFrameV1(
+        enc({
+          did: 'd',
+          time_us: 5,
+          kind: 'commit',
+          commit: {
+            rev: 'r',
+            operation: 'create',
+            collection: 'c',
+            rkey: 'rk',
+          },
+        }),
+      ),
+    ).toThrow(MalformedError)
+  })
+})

--- a/packages/jetstream/tests/live/decode-v1.test.ts
+++ b/packages/jetstream/tests/live/decode-v1.test.ts
@@ -191,6 +191,41 @@ test('validateWire throws on missing required time_us (the v1 cursor)', () => {
   )
 })
 
+test('unsafe time_us throws MalformedError in EVERY mode (seq is the cursor)', () => {
+  // 2^53 loses precision as a JS number — dedup/resume/watermark would corrupt.
+  const unsafe = (time_us: string) =>
+    v1Put().replace('"time_us":9', `"time_us":${time_us}`)
+  for (const bad of ['9007199254740992', '1.5', 'null']) {
+    expect(() => decodeLiveFrameV1(encStr(unsafe(bad)))).toThrow(MalformedError)
+    expect(() => decodeLiveFrameV1(encStr(unsafe(bad)), true)).toThrow(
+      MalformedError,
+    )
+  }
+  // largest safe integer still decodes
+  expect(
+    decodeLiveFrameV1(encStr(unsafe(String(Number.MAX_SAFE_INTEGER)))),
+  ).not.toBe(SKIP_FRAME)
+})
+
+test('MalformedError carries the underlying cause where one exists', () => {
+  // JSON parse failure -> SyntaxError cause
+  try {
+    decodeLiveFrameV1(encStr('not json'))
+    expect.unreachable()
+  } catch (err) {
+    expect(err).toBeInstanceOf(MalformedError)
+    expect((err as Error).cause).toBeInstanceOf(SyntaxError)
+  }
+  // strict-mode wire violation -> lex validation error cause
+  try {
+    decodeLiveFrameV1(encStr(v1Put({ cid: 'garbage' })), true)
+    expect.unreachable()
+  } catch (err) {
+    expect(err).toBeInstanceOf(MalformedError)
+    expect((err as Error).cause).toBeInstanceOf(Error)
+  }
+})
+
 test('default mode passes a mangled v1 did through untouched', () => {
   const ev = decodeLiveFrameV1(encStr(v1Put()), undefined)
   expect(ev).not.toBe(SKIP_FRAME)

--- a/packages/jetstream/tests/live/deps.test.ts
+++ b/packages/jetstream/tests/live/deps.test.ts
@@ -1,0 +1,8 @@
+import { WebSocketKeepAlive } from '@atproto/ws-client'
+import { expect, test } from 'vitest'
+
+test('ws-client WebSocketKeepAlive is importable and constructible', () => {
+  const ka = new WebSocketKeepAlive({ getUrl: async () => 'ws://localhost/' })
+  expect(ka).toBeInstanceOf(WebSocketKeepAlive)
+  expect(typeof ka[Symbol.asyncIterator]).toBe('function')
+})

--- a/packages/jetstream/tests/live/deps.test.ts
+++ b/packages/jetstream/tests/live/deps.test.ts
@@ -1,8 +1,0 @@
-import { WebSocketKeepAlive } from '@atproto/ws-client'
-import { expect, test } from 'vitest'
-
-test('ws-client WebSocketKeepAlive is importable and constructible', () => {
-  const ka = new WebSocketKeepAlive({ getUrl: async () => 'ws://localhost/' })
-  expect(ka).toBeInstanceOf(WebSocketKeepAlive)
-  expect(typeof ka[Symbol.asyncIterator]).toBe('function')
-})

--- a/packages/jetstream/tests/live/source.test.ts
+++ b/packages/jetstream/tests/live/source.test.ts
@@ -1,0 +1,152 @@
+import { expect, test } from 'vitest'
+import { type LiveTransport, liveEvents } from '../../src/live/source.js'
+
+const commitFrame = (time_us: number) =>
+  JSON.stringify({
+    did: 'did:plc:a',
+    time_us,
+    kind: 'commit',
+    commit: {
+      rev: 'r',
+      operation: 'create',
+      collection: 'app.bsky.feed.post',
+      rkey: `k${time_us}`,
+      record: { $type: 'app.bsky.feed.post', text: String(time_us) },
+      cid: 'cid1',
+    },
+  })
+
+// A transport that replays scripted "sessions": each session is a list of
+// frames; a new session begins on each getUrl() call (i.e. each reconnect).
+function scriptedTransport(sessions: string[][]): {
+  transport: LiveTransport
+  urls: string[]
+} {
+  const urls: string[] = []
+  let i = 0
+  const transport: LiveTransport = {
+    async *stream(getUrl) {
+      while (i < sessions.length) {
+        urls.push(getUrl())
+        const frames = sessions[i++]
+        for (const f of frames) yield new TextEncoder().encode(f)
+        // session ends -> loop calls getUrl again (simulates reconnect) until sessions exhausted
+      }
+    },
+  }
+  return { transport, urls }
+}
+
+test('yields decoded events and dedups across a reconnect', async () => {
+  // session 1: seqs 1,2 ; session 2 (reconnect, inclusive replay): 2,3,4
+  const { transport, urls } = scriptedTransport([
+    [commitFrame(1), commitFrame(2)],
+    [commitFrame(2), commitFrame(3), commitFrame(4)],
+  ])
+  const got: number[] = []
+  for await (const ev of liveEvents({ host: 'https://h', transport })) {
+    got.push(ev.seq)
+  }
+  expect(got).toEqual([1, 2, 3, 4]) // the replayed seq 2 is deduped
+  // second session's url resumes from the highest delivered seq (2)
+  expect(urls[1]).toContain('cursor=2')
+})
+
+test('builds the subscribe url with filters (no extended param)', async () => {
+  const { transport, urls } = scriptedTransport([[commitFrame(1)]])
+  for await (const _ of liveEvents({
+    host: 'https://h',
+    collections: ['app.bsky.feed.post'],
+    dids: ['did:plc:a'],
+    transport,
+  })) {
+    void _
+  }
+  expect(urls[0]).toContain('/subscribe')
+  expect(urls[0]).not.toContain('subscribe-v2')
+  expect(urls[0]).not.toContain('extended')
+  expect(urls[0]).toContain('wantedCollections=app.bsky.feed.post')
+  expect(urls[0]).toContain('wantedDids=did%3Aplc%3Aa')
+  expect(urls[0]).toMatch(/^wss:/) // https -> wss
+})
+
+test('cursor undefined omits the param (live from tip); 0 sends cursor=0', async () => {
+  const a = scriptedTransport([[commitFrame(1)]])
+  for await (const _ of liveEvents({
+    host: 'https://h',
+    transport: a.transport,
+  }))
+    void _
+  expect(a.urls[0]).not.toContain('cursor=')
+
+  const b = scriptedTransport([[commitFrame(1)]])
+  for await (const _ of liveEvents({
+    host: 'https://h',
+    cursor: 0,
+    transport: b.transport,
+  }))
+    void _
+  expect(b.urls[0]).toContain('cursor=0')
+})
+
+test('signal-driven teardown: aborting the signal stops iteration', async () => {
+  const ac = new AbortController()
+  // Transport that yields one frame, then checks the signal before yielding more.
+  // This keeps the test deterministic: no real timers, no races.
+  const transport: LiveTransport = {
+    async *stream(_getUrl, signal) {
+      yield new TextEncoder().encode(commitFrame(1))
+      // After the first frame is consumed the test aborts; honour it here.
+      if (signal.aborted) return
+      yield new TextEncoder().encode(commitFrame(2))
+    },
+  }
+  const got: number[] = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    transport,
+    signal: ac.signal,
+  })) {
+    got.push(ev.seq)
+    // Abort after the first event; the transport will see signal.aborted on next iteration.
+    ac.abort()
+  }
+  expect(got).toEqual([1]) // only the pre-abort frame was delivered; loop terminated
+})
+
+test('dedupFloor drops events at or below it; undefined lets seq 0 pass', async () => {
+  const a = scriptedTransport([[commitFrame(0), commitFrame(1)]])
+  const gotA: number[] = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    dedupFloor: undefined,
+    transport: a.transport,
+  }))
+    gotA.push(ev.seq)
+  expect(gotA).toEqual([0, 1]) // seq 0 passes when floor is undefined
+
+  const b = scriptedTransport([[commitFrame(0), commitFrame(1)]])
+  const gotB: number[] = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    dedupFloor: 0,
+    transport: b.transport,
+  }))
+    gotB.push(ev.seq)
+  expect(gotB).toEqual([1]) // seq 0 dropped when floor is 0
+})
+
+test('dedup on reconnect overlap is exact (unique monotonic time_us)', async () => {
+  const { transport } = scriptedTransport([
+    [commitFrame(100), commitFrame(101)],
+  ])
+  const events = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    dedupFloor: 100, // as if 100 already delivered
+    transport,
+  })) {
+    events.push(ev)
+  }
+  expect(events.map((e) => e.seq)).toEqual([101]) // 100 dropped (<= floor)
+})

--- a/packages/jetstream/tests/live/transport.test.ts
+++ b/packages/jetstream/tests/live/transport.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import { DataModeError } from '@atproto/ws-client'
+import { describe, expect, it, vi } from 'vitest'
 import { type WebSocket, WebSocketServer } from 'ws'
 import { liveEvents } from '../../src/live/source.js'
 import { websocketTransport } from '../../src/live/transport.js'
@@ -78,4 +79,129 @@ describe('websocketTransport (real websocket)', () => {
       await srv.close()
     }
   })
+
+  it('reconnects on a clean 1000 close by default, resuming from the cursor', async () => {
+    const srv = await serveScript([
+      (ws) => {
+        ws.send(v1Frame(100))
+        ws.close(1000)
+      },
+      (ws) => {
+        ws.send(v1Frame(200))
+        // stay open; the test ends by aborting
+      },
+    ])
+    try {
+      const ac = new AbortController()
+      const got: number[] = []
+      await expect(
+        (async () => {
+          // Default transport on purpose: pins that liveEvents' default IS
+          // websocketTransport() with the jetstream reconnect policy.
+          for await (const ev of liveEvents({
+            host: srv.host,
+            signal: ac.signal,
+          })) {
+            got.push(ev.seq)
+            if (ev.seq === 200) ac.abort(new Error('test done'))
+          }
+        })(),
+      ).rejects.toThrow('test done')
+      expect(got).toEqual([100, 200])
+      expect(srv.urls).toHaveLength(2)
+      expect(srv.urls[1]).toContain('cursor=100') // getUrl re-resolved with resume cursor
+    } finally {
+      await srv.close()
+    }
+  }, 10_000)
+
+  it('surfaces retried failures via onReconnect and redials after an abnormal drop', async () => {
+    const conns: WebSocket[] = []
+    const srv = await serveScript([
+      (ws) => {
+        conns.push(ws)
+        ws.send(v1Frame(100))
+        // terminated from the test body after the frame is observed —
+        // avoids racing the frame against the drop
+      },
+      (ws) => {
+        ws.send(v1Frame(200))
+      },
+    ])
+    try {
+      const onReconnect = vi.fn()
+      const ac = new AbortController()
+      const got: number[] = []
+      await expect(
+        (async () => {
+          for await (const ev of liveEvents({
+            host: srv.host,
+            signal: ac.signal,
+            transport: websocketTransport({ onReconnect }),
+          })) {
+            got.push(ev.seq)
+            if (ev.seq === 100) conns[0].terminate() // abnormal close, no close frame
+            if (ev.seq === 200) ac.abort(new Error('test done'))
+          }
+        })(),
+      ).rejects.toThrow('test done')
+      expect(got).toEqual([100, 200])
+      expect(onReconnect).toHaveBeenCalled()
+      expect(onReconnect.mock.calls[0][1]).toEqual({ attempt: 0 })
+    } finally {
+      await srv.close()
+    }
+  }, 10_000)
+
+  it('idle timeout redials a silent connection', async () => {
+    const srv = await serveScript([
+      () => {
+        // first connection: send nothing; the 50ms idle timeout should trip
+        // (IdleTimeoutError is retryable -> redial, not stream end)
+      },
+      (ws) => {
+        ws.send(v1Frame(100))
+      },
+    ])
+    try {
+      const ac = new AbortController()
+      const got: number[] = []
+      await expect(
+        (async () => {
+          for await (const ev of liveEvents({
+            host: srv.host,
+            signal: ac.signal,
+            transport: websocketTransport({ idleTimeoutMs: 50 }),
+          })) {
+            got.push(ev.seq)
+            ac.abort(new Error('test done'))
+          }
+        })(),
+      ).rejects.toThrow('test done')
+      expect(got).toEqual([100])
+      expect(srv.urls.length).toBeGreaterThanOrEqual(2)
+    } finally {
+      await srv.close()
+    }
+  }, 10_000)
+
+  it('a binary frame is fatal (DataModeError), not reconnected', async () => {
+    const srv = await serveScript([
+      (ws) => {
+        ws.send(Buffer.from(v1Frame(100))) // Buffer => binary frame on a text stream
+      },
+    ])
+    try {
+      await expect(
+        (async () => {
+          for await (const ev of liveEvents({ host: srv.host })) {
+            void ev // no events expected
+          }
+        })(),
+      ).rejects.toBeInstanceOf(DataModeError)
+      expect(srv.urls).toHaveLength(1) // fatal: no redial
+    } finally {
+      await srv.close()
+    }
+  }, 10_000)
 })

--- a/packages/jetstream/tests/live/transport.test.ts
+++ b/packages/jetstream/tests/live/transport.test.ts
@@ -9,7 +9,7 @@ import { websocketTransport } from '../../src/live/transport.js'
 // websocketTransport so the decoder's string handling can't regress even
 // when fake-transport tests pass.
 
-export const v1Frame = (time_us: number) =>
+const v1Frame = (time_us: number) =>
   JSON.stringify({
     did: 'did:plc:a',
     time_us,
@@ -27,7 +27,7 @@ export const v1Frame = (time_us: number) =>
 // Scripted server: one handler per expected connection, in order. Requests
 // beyond the script are dropped immediately (a reconnecting client retries
 // until the test aborts). urls records each connection's request path.
-export async function serveScript(script: Array<(ws: WebSocket) => void>) {
+async function serveScript(script: Array<(ws: WebSocket) => void>) {
   const wss = await new Promise<WebSocketServer>((resolve) => {
     const server: WebSocketServer = new WebSocketServer({ port: 0 }, () =>
       resolve(server),

--- a/packages/jetstream/tests/live/transport.test.ts
+++ b/packages/jetstream/tests/live/transport.test.ts
@@ -1,0 +1,35 @@
+import { once } from 'node:events'
+import { expect, test } from 'vitest'
+import { WebSocketServer } from 'ws'
+import { wsKeepAliveTransport } from '../../src/live/transport.js'
+
+// Jetstream v1 sends TEXT frames; ws yields those as strings, and the
+// transport must normalize them to bytes (regression: strings crashed
+// TextDecoder in the decoder downstream). Binary frames pass through.
+test('wsKeepAliveTransport yields bytes for both text and binary frames', async () => {
+  const wss = new WebSocketServer({ port: 0 })
+  await once(wss, 'listening')
+  const { port } = wss.address() as { port: number }
+  wss.on('connection', (ws) => {
+    ws.send('{"kind":"text-frame"}') // text frame -> string in object mode
+    ws.send(new TextEncoder().encode('{"kind":"binary-frame"}')) // binary frame
+  })
+
+  const ac = new AbortController()
+  const seen: string[] = []
+  try {
+    for await (const chunk of wsKeepAliveTransport.stream(
+      () => `ws://127.0.0.1:${port}/`,
+      ac.signal,
+    )) {
+      expect(chunk).toBeInstanceOf(Uint8Array)
+      seen.push(new TextDecoder().decode(chunk))
+      if (seen.length >= 2) ac.abort()
+    }
+  } catch (err) {
+    if (!ac.signal.aborted) throw err // abort-driven teardown is expected
+  } finally {
+    wss.close()
+  }
+  expect(seen).toEqual(['{"kind":"text-frame"}', '{"kind":"binary-frame"}'])
+})

--- a/packages/jetstream/tests/live/transport.test.ts
+++ b/packages/jetstream/tests/live/transport.test.ts
@@ -1,35 +1,54 @@
-import { once } from 'node:events'
-import { expect, test } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { WebSocketServer } from 'ws'
-import { wsKeepAliveTransport } from '../../src/live/transport.js'
+import { liveEvents } from '../../src/live/source.js'
 
-// Jetstream v1 sends TEXT frames; ws yields those as strings, and the
-// transport must normalize them to bytes (regression: strings crashed
-// TextDecoder in the decoder downstream). Binary frames pass through.
-test('wsKeepAliveTransport yields bytes for both text and binary frames', async () => {
-  const wss = new WebSocketServer({ port: 0 })
-  await once(wss, 'listening')
-  const { port } = wss.address() as { port: number }
-  wss.on('connection', (ws) => {
-    ws.send('{"kind":"text-frame"}') // text frame -> string in object mode
-    ws.send(new TextEncoder().encode('{"kind":"binary-frame"}')) // binary frame
+// End-to-end over a real websocket: jetstream frames are text frames, which
+// ws-client yields as strings, not Uint8Array — see the NOTE in
+// src/live/transport.ts. Exercises the real wsKeepAliveTransport so the
+// decoder's string handling can't regress even when fake-transport tests pass.
+
+const v1Frame = JSON.stringify({
+  did: 'did:plc:a',
+  time_us: 100,
+  kind: 'commit',
+  commit: {
+    rev: 'r',
+    operation: 'create',
+    collection: 'app.bsky.feed.like',
+    rkey: 'rk1',
+    record: { $type: 'app.bsky.feed.like' },
+    cid: 'cid1',
+  },
+})
+
+function serveFrames(frames: string[]): Promise<{ port: number }> {
+  return new Promise((resolve) => {
+    const wss = new WebSocketServer({ port: 0 }, () => {
+      const addr = wss.address()
+      if (addr === null || typeof addr === 'string')
+        throw new Error('no server port')
+      resolve({ port: addr.port })
+    })
+    wss.on('connection', (ws) => {
+      for (const f of frames) ws.send(f) // text frames, like jetstream
+      ws.close(1000) // clean close ends the keep-alive stream without reconnect
+      wss.close()
+    })
   })
+}
 
-  const ac = new AbortController()
-  const seen: string[] = []
-  try {
-    for await (const chunk of wsKeepAliveTransport.stream(
-      () => `ws://127.0.0.1:${port}/`,
-      ac.signal,
-    )) {
-      expect(chunk).toBeInstanceOf(Uint8Array)
-      seen.push(new TextDecoder().decode(chunk))
-      if (seen.length >= 2) ac.abort()
+describe('wsKeepAliveTransport (real websocket)', () => {
+  it('delivers v1 text frames through liveEvents', async () => {
+    const { port } = await serveFrames([v1Frame])
+    const events = []
+    const errors: Error[] = []
+    for await (const ev of liveEvents({
+      host: `http://127.0.0.1:${port}`,
+      onError: (err) => errors.push(err),
+    })) {
+      events.push(ev)
     }
-  } catch (err) {
-    if (!ac.signal.aborted) throw err // abort-driven teardown is expected
-  } finally {
-    wss.close()
-  }
-  expect(seen).toEqual(['{"kind":"text-frame"}', '{"kind":"binary-frame"}'])
+    expect(errors).toEqual([])
+    expect(events.map((e) => e.seq)).toEqual([100])
+  })
 })

--- a/packages/jetstream/tests/live/transport.test.ts
+++ b/packages/jetstream/tests/live/transport.test.ts
@@ -1,54 +1,81 @@
 import { describe, expect, it } from 'vitest'
-import { WebSocketServer } from 'ws'
+import { type WebSocket, WebSocketServer } from 'ws'
 import { liveEvents } from '../../src/live/source.js'
+import { websocketTransport } from '../../src/live/transport.js'
 
 // End-to-end over a real websocket: jetstream frames are text frames, which
-// ws-client yields as strings, not Uint8Array — see the NOTE in
-// src/live/transport.ts. Exercises the real wsKeepAliveTransport so the
-// decoder's string handling can't regress even when fake-transport tests pass.
+// the transport (dataMode 'text') yields as strings. Exercises the real
+// websocketTransport so the decoder's string handling can't regress even
+// when fake-transport tests pass.
 
-const v1Frame = JSON.stringify({
-  did: 'did:plc:a',
-  time_us: 100,
-  kind: 'commit',
-  commit: {
-    rev: 'r',
-    operation: 'create',
-    collection: 'app.bsky.feed.like',
-    rkey: 'rk1',
-    record: { $type: 'app.bsky.feed.like' },
-    cid: 'cid1',
-  },
-})
-
-function serveFrames(frames: string[]): Promise<{ port: number }> {
-  return new Promise((resolve) => {
-    const wss = new WebSocketServer({ port: 0 }, () => {
-      const addr = wss.address()
-      if (addr === null || typeof addr === 'string')
-        throw new Error('no server port')
-      resolve({ port: addr.port })
-    })
-    wss.on('connection', (ws) => {
-      for (const f of frames) ws.send(f) // text frames, like jetstream
-      ws.close(1000) // clean close ends the keep-alive stream without reconnect
-      wss.close()
-    })
+export const v1Frame = (time_us: number) =>
+  JSON.stringify({
+    did: 'did:plc:a',
+    time_us,
+    kind: 'commit',
+    commit: {
+      rev: 'r',
+      operation: 'create',
+      collection: 'app.bsky.feed.like',
+      rkey: `rk${time_us}`,
+      record: { $type: 'app.bsky.feed.like' },
+      cid: 'cid1',
+    },
   })
+
+// Scripted server: one handler per expected connection, in order. Requests
+// beyond the script are dropped immediately (a reconnecting client retries
+// until the test aborts). urls records each connection's request path.
+export async function serveScript(script: Array<(ws: WebSocket) => void>) {
+  const wss = await new Promise<WebSocketServer>((resolve) => {
+    const server: WebSocketServer = new WebSocketServer({ port: 0 }, () =>
+      resolve(server),
+    )
+  })
+  const addr = wss.address()
+  if (addr === null || typeof addr === 'string') throw new Error('no port')
+  const urls: string[] = []
+  let i = 0
+  wss.on('connection', (ws, req) => {
+    urls.push(req.url ?? '')
+    const session = script[i++]
+    if (session) session(ws)
+    else ws.terminate()
+  })
+  return {
+    host: `http://127.0.0.1:${addr.port}`,
+    urls,
+    close: () =>
+      new Promise<void>((resolve) => {
+        for (const c of wss.clients) c.terminate()
+        wss.close(() => resolve())
+      }),
+  }
 }
 
-describe('wsKeepAliveTransport (real websocket)', () => {
-  it('delivers v1 text frames through liveEvents', async () => {
-    const { port } = await serveFrames([v1Frame])
-    const events = []
-    const errors: Error[] = []
-    for await (const ev of liveEvents({
-      host: `http://127.0.0.1:${port}`,
-      onError: (err) => errors.push(err),
-    })) {
-      events.push(ev)
+describe('websocketTransport (real websocket)', () => {
+  it('delivers v1 text frames; shouldReconnect: false ends on clean close', async () => {
+    const srv = await serveScript([
+      (ws) => {
+        ws.send(v1Frame(100))
+        ws.close(1000)
+      },
+    ])
+    try {
+      const events = []
+      const errors: Error[] = []
+      for await (const ev of liveEvents({
+        host: srv.host,
+        transport: websocketTransport({ shouldReconnect: false }),
+        onError: (err) => errors.push(err),
+      })) {
+        events.push(ev)
+      }
+      expect(errors).toEqual([])
+      expect(events.map((e) => e.seq)).toEqual([100])
+      expect(srv.urls).toHaveLength(1) // no redial
+    } finally {
+      await srv.close()
     }
-    expect(errors).toEqual([])
-    expect(events.map((e) => e.seq)).toEqual([100])
   })
 })

--- a/packages/jetstream/tests/live/websocket-transport.test.ts
+++ b/packages/jetstream/tests/live/websocket-transport.test.ts
@@ -44,6 +44,16 @@ describe('resolveWebsocketOptions', () => {
       5000,
     )
   })
+  it('idleTimeoutMs: 0 throws (use false to disable)', () => {
+    expect(() => resolveWebsocketOptions({ idleTimeoutMs: 0 })).toThrow(
+      RangeError,
+    )
+  })
+  it('negative idleTimeoutMs throws', () => {
+    expect(() => resolveWebsocketOptions({ idleTimeoutMs: -1 })).toThrow(
+      RangeError,
+    )
+  })
   it('shouldReconnect override passes through (false = never)', () => {
     const o = resolveWebsocketOptions({ shouldReconnect: false })
     expect(o.shouldReconnect).toBe(false)

--- a/packages/jetstream/tests/live/websocket-transport.test.ts
+++ b/packages/jetstream/tests/live/websocket-transport.test.ts
@@ -1,0 +1,57 @@
+import { CloseError, HeartbeatTimeoutError } from '@atproto/ws-client'
+import { describe, expect, it } from 'vitest'
+import {
+  jetstreamShouldReconnect,
+  resolveWebsocketOptions,
+} from '../../src/live/transport.js'
+
+// The pure option/policy layer of websocketTransport. Timing behavior
+// (60s default idle, etc.) is untestable over a real socket in reasonable
+// time, so the defaults are pinned here; real-socket semantics live in
+// transport.test.ts.
+
+describe('jetstreamShouldReconnect', () => {
+  it('reconnects on a clean 1000 close (jetstream override)', () => {
+    expect(jetstreamShouldReconnect(new CloseError(1000, '', true))).toBe(true)
+  })
+  it('protocol closes stay fatal (ws-client classification)', () => {
+    expect(jetstreamShouldReconnect(new CloseError(1002, '', true))).toBe(false)
+  })
+  it('abnormal closes (1006) reconnect', () => {
+    expect(jetstreamShouldReconnect(new CloseError(1006, '', false))).toBe(true)
+  })
+  it('defers to typed-error self-classification', () => {
+    expect(jetstreamShouldReconnect(new HeartbeatTimeoutError())).toBe(true)
+  })
+  it('errors outside the taxonomy are fatal', () => {
+    expect(jetstreamShouldReconnect(new Error('nope'))).toBe(false)
+  })
+})
+
+describe('resolveWebsocketOptions', () => {
+  it('defaults: text dataMode, 60s idle timeout, jetstream reconnect policy', () => {
+    const o = resolveWebsocketOptions()
+    expect(o.dataMode).toBe('text')
+    expect(o.idleTimeoutMs).toBe(60_000)
+    expect(o.shouldReconnect).toBe(jetstreamShouldReconnect)
+  })
+  it('idleTimeoutMs: false disables idle detection (maps to unset)', () => {
+    const o = resolveWebsocketOptions({ idleTimeoutMs: false })
+    expect(o.idleTimeoutMs).toBeUndefined()
+  })
+  it('idleTimeoutMs override passes through', () => {
+    expect(resolveWebsocketOptions({ idleTimeoutMs: 5000 }).idleTimeoutMs).toBe(
+      5000,
+    )
+  })
+  it('shouldReconnect override passes through (false = never)', () => {
+    const o = resolveWebsocketOptions({ shouldReconnect: false })
+    expect(o.shouldReconnect).toBe(false)
+  })
+  it('other websocket options pass through verbatim', () => {
+    const onReconnect = () => {}
+    const o = resolveWebsocketOptions({ onReconnect, maxReconnectSeconds: 32 })
+    expect(o.onReconnect).toBe(onReconnect)
+    expect(o.maxReconnectSeconds).toBe(32)
+  })
+})

--- a/packages/jetstream/tests/run/run-tracker.test.ts
+++ b/packages/jetstream/tests/run/run-tracker.test.ts
@@ -1,4 +1,3 @@
-// tests/run/run-tracker.test.ts
 import { describe, expect, it } from 'vitest'
 import { type EventBatch, type RawEventV1 } from '../../src/event.js'
 import { type CursorStore } from '../../src/execute/cursor-store.js'

--- a/packages/jetstream/tests/run/run-tracker.test.ts
+++ b/packages/jetstream/tests/run/run-tracker.test.ts
@@ -1,0 +1,82 @@
+// tests/run/run-tracker.test.ts
+import { describe, expect, it } from 'vitest'
+import { type EventBatch, type RawEventV1 } from '../../src/event.js'
+import { type CursorStore } from '../../src/execute/cursor-store.js'
+import { trackedStream } from '../../src/run-tracker.js'
+
+function rawDelete(seq: number): RawEventV1 {
+  return {
+    did: 'did:plc:a',
+    seq,
+    timeUs: 0,
+    kind: 'commit',
+    commit: {
+      operation: 'delete',
+      collection: 'app.test.rec',
+      rkey: 'r' + seq,
+      rev: 'v',
+    },
+  }
+}
+
+async function* batches(...bs: EventBatch<RawEventV1>[]) {
+  for (const b of bs) yield b
+}
+
+class RecordingStore implements CursorStore {
+  saved: number[] = []
+  private v: number | undefined
+  async load() {
+    return this.v
+  }
+  async save(seq: number) {
+    this.v = seq
+    this.saved.push(seq)
+  }
+}
+
+describe('trackedStream', () => {
+  it('passes batches through unchanged', async () => {
+    const ts = trackedStream(
+      batches({ events: [rawDelete(1), rawDelete(2)], lastCursor: 2 }),
+    )
+    const seqs: number[] = []
+    for await (const batch of ts.stream) {
+      for (const e of batch.events) seqs.push(e.seq)
+    }
+    expect(seqs).toEqual([1, 2])
+  })
+
+  it('advances the saved cursor only to the highest CONTIGUOUS acked seq', async () => {
+    const store = new RecordingStore()
+    const ts = trackedStream(
+      batches({
+        events: [rawDelete(1), rawDelete(2), rawDelete(3)],
+        lastCursor: 3,
+      }),
+      store,
+    )
+    // Pull all (registers track(1),track(2),track(3) in order)
+    const events: RawEventV1[] = []
+    for await (const batch of ts.stream) events.push(...batch.events)
+
+    // Ack out of order: 1, then 3 (2 still pending) — watermark must stay at 1
+    ts.ack(events[0]) // seq 1
+    ts.ack(events[2]) // seq 3 — but 2 is a gap
+    await ts.flush()
+    expect(store.saved.at(-1)).toBe(1)
+
+    // Now ack 2 — contiguous prefix jumps to 3
+    ts.ack(events[1]) // seq 2
+    await ts.flush()
+    expect(store.saved.at(-1)).toBe(3)
+  })
+
+  it('flush with no store is a no-op (does not throw)', async () => {
+    const ts = trackedStream(batches({ events: [rawDelete(1)], lastCursor: 1 }))
+    for await (const _ of ts.stream) {
+      /* drain */
+    }
+    await ts.flush()
+  })
+})

--- a/packages/jetstream/tests/scaffold.test.ts
+++ b/packages/jetstream/tests/scaffold.test.ts
@@ -1,6 +1,0 @@
-import { expect, test } from 'vitest'
-import { PACKAGE_NAME } from '../src/version.js'
-
-test('package wiring resolves', () => {
-  expect(PACKAGE_NAME).toBe('@bsky.app/jetstream')
-})

--- a/packages/jetstream/tests/scaffold.test.ts
+++ b/packages/jetstream/tests/scaffold.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from 'vitest'
+import { PACKAGE_NAME } from '../src/version.js'
+
+test('package wiring resolves', () => {
+  expect(PACKAGE_NAME).toBe('@bsky.app/jetstream')
+})

--- a/packages/jetstream/tests/shape.test.ts
+++ b/packages/jetstream/tests/shape.test.ts
@@ -1,11 +1,13 @@
 // tests/shape.test.ts
-import { describe, expect, it } from 'vitest'
+import { l, record } from '@atproto/lex-schema'
+import { describe, expect, it, test } from 'vitest'
+import { resolveNsids } from '../src/engine/collections.js'
 import {
   type EventBatch,
   type RawEventV1,
   type TypedEvent,
 } from '../src/event.js'
-import { shape } from '../src/shape.js'
+import { RecordValidationError, shape } from '../src/shape.js'
 
 function rawCreate(seq: number, record: unknown): RawEventV1 {
   return {
@@ -32,6 +34,35 @@ async function collect<T>(src: AsyncIterable<T>): Promise<T[]> {
   const out: T[] = []
   for await (const x of src) out.push(x)
   return out
+}
+
+const likeSchema = record(
+  'tid',
+  'app.test.like',
+  l.object({ subject: l.string() }),
+)
+
+function putEvent(seq: number, rec: unknown): RawEventV1 {
+  return {
+    did: 'did:plc:a',
+    seq,
+    timeUs: 0,
+    kind: 'commit',
+    commit: {
+      operation: 'create',
+      collection: 'app.test.like',
+      rkey: 'r' + seq,
+      rev: 'v',
+      cid: 'cid' + seq,
+      record: rec,
+    },
+  }
+}
+
+function oneBatch(events: RawEventV1[]): AsyncIterable<EventBatch<RawEventV1>> {
+  return (async function* () {
+    yield { events, lastCursor: events[events.length - 1]?.seq ?? 0 }
+  })()
 }
 
 describe('shape', () => {
@@ -61,4 +92,61 @@ describe('shape', () => {
       expect(out[0].commit.record).toEqual({})
     }
   })
+})
+
+test('typed path skips schema-invalid records and reports RecordValidationError', async () => {
+  const { schemasByNsid } = resolveNsids([likeSchema])
+  const errors: Error[] = []
+  const out: TypedEvent[] = []
+  for await (const ev of shape(
+    oneBatch([
+      putEvent(1, { $type: 'app.test.like', subject: 'ok' }),
+      putEvent(2, { $type: 'app.test.like', subject: 123 }), // invalid
+    ]),
+    {},
+    schemasByNsid,
+    (err) => errors.push(err),
+  )) {
+    out.push(ev as TypedEvent)
+  }
+  expect(out.map((e) => e.seq)).toEqual([1])
+  expect(errors).toHaveLength(1)
+  const err = errors[0]
+  expect(err).toBeInstanceOf(RecordValidationError)
+  if (!(err instanceof RecordValidationError)) throw new Error('unreachable')
+  expect(err.seq).toBe(2)
+  expect(err.collection).toBe('app.test.like')
+  expect(err.rkey).toBe('r2')
+})
+
+test('unregistered collections are never skipped and never reported', async () => {
+  // no schema registered: same events must NOT be skipped
+  const errors: Error[] = []
+  const out: TypedEvent[] = []
+  for await (const ev of shape(
+    oneBatch([putEvent(1, { $type: 'app.test.like', subject: 123 })]),
+    {},
+    new Map(),
+    (err) => errors.push(err),
+  )) {
+    out.push(ev as TypedEvent)
+  }
+  expect(out.map((e) => e.seq)).toEqual([1])
+  expect(errors).toHaveLength(0)
+})
+
+test('raw paths never skip', async () => {
+  const { schemasByNsid } = resolveNsids([likeSchema])
+  const out: unknown[] = []
+  for await (const ev of shape(
+    oneBatch([putEvent(1, { $type: 'app.test.like', subject: 123 })]),
+    { raw: true },
+    schemasByNsid,
+    () => {
+      throw new Error('raw path must not report')
+    },
+  )) {
+    out.push(ev)
+  }
+  expect(out).toHaveLength(1)
 })

--- a/packages/jetstream/tests/shape.test.ts
+++ b/packages/jetstream/tests/shape.test.ts
@@ -1,7 +1,6 @@
-// tests/shape.test.ts
 import { l, record } from '@atproto/lex-schema'
 import { describe, expect, it, test } from 'vitest'
-import { resolveNsids } from '../src/engine/collections.js'
+import { parseCollectionFilters } from '../src/engine/collections.js'
 import {
   type EventBatch,
   type RawEventV1,
@@ -95,7 +94,7 @@ describe('shape', () => {
 })
 
 test('typed path skips schema-invalid records and reports RecordValidationError', async () => {
-  const { schemasByNsid } = resolveNsids([likeSchema])
+  const { schemasByNsid } = parseCollectionFilters([likeSchema])
   const errors: Error[] = []
   const out: TypedEvent[] = []
   for await (const ev of shape(
@@ -136,7 +135,7 @@ test('unregistered collections are never skipped and never reported', async () =
 })
 
 test('raw paths never skip', async () => {
-  const { schemasByNsid } = resolveNsids([likeSchema])
+  const { schemasByNsid } = parseCollectionFilters([likeSchema])
   const out: unknown[] = []
   for await (const ev of shape(
     oneBatch([putEvent(1, { $type: 'app.test.like', subject: 123 })]),

--- a/packages/jetstream/tests/shape.test.ts
+++ b/packages/jetstream/tests/shape.test.ts
@@ -1,0 +1,64 @@
+// tests/shape.test.ts
+import { describe, expect, it } from 'vitest'
+import {
+  type EventBatch,
+  type RawEventV1,
+  type TypedEvent,
+} from '../src/event.js'
+import { shape } from '../src/shape.js'
+
+function rawCreate(seq: number, record: unknown): RawEventV1 {
+  return {
+    did: 'did:plc:a',
+    seq,
+    timeUs: 0,
+    kind: 'commit',
+    commit: {
+      operation: 'create',
+      collection: 'app.test.rec',
+      rkey: 'r' + seq,
+      rev: 'rev',
+      cid: 'cid',
+      record,
+    },
+  }
+}
+
+async function* batches(...bs: EventBatch<RawEventV1>[]) {
+  for (const b of bs) yield b
+}
+
+async function collect<T>(src: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = []
+  for await (const x of src) out.push(x)
+  return out
+}
+
+describe('shape', () => {
+  const b1: EventBatch<RawEventV1> = {
+    events: [rawCreate(1, {}), rawCreate(2, {})],
+    lastCursor: 2,
+  }
+
+  it('raw: flattens batches to raw events', async () => {
+    const out = (await collect(
+      shape(batches(b1), { raw: true }, new Map()),
+    )) as RawEventV1[]
+    expect(out.map((e) => e.seq)).toEqual([1, 2])
+    expect(out[0].kind).toBe('commit')
+  })
+
+  it('typed: upgrades each raw event', async () => {
+    const out = (await collect(
+      shape(batches(b1), {}, new Map()),
+    )) as TypedEvent[]
+    expect(out).toHaveLength(2)
+    expect(out[0].kind).toBe('commit')
+    expect(out[0].kind === 'commit' && out[0].commit.operation).not.toBe(
+      'delete',
+    )
+    if (out[0].kind === 'commit' && out[0].commit.operation !== 'delete') {
+      expect(out[0].commit.record).toEqual({})
+    }
+  })
+})

--- a/packages/jetstream/tsconfig.build.json
+++ b/packages/jetstream/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig/isomorphic.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+  },
+  "include": ["./src"],
+}

--- a/packages/jetstream/tsconfig.json
+++ b/packages/jetstream/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.build.json" },
+    { "path": "./tsconfig.tests.json" },
+  ],
+}

--- a/packages/jetstream/tsconfig.tests.json
+++ b/packages/jetstream/tsconfig.tests.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig/tests.json",
+  "include": ["./src", "./tests"],
+}

--- a/packages/jetstream/vitest.config.ts
+++ b/packages/jetstream/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,8 +273,8 @@ importers:
         specifier: ^0.2.2
         version: 0.2.2
       '@atproto/ws-client':
-        specifier: ^0.1.1
-        version: 0.1.8
+        specifier: ^0.2.0
+        version: 0.2.0
     devDependencies:
       '@types/ws':
         specifier: ^8.18.1
@@ -482,8 +482,8 @@ packages:
     resolution: {integrity: sha512-7LU8Ra79L5wCqVAZZst2352VMMwkU4KNagVMm6pnURrY/uS7+HrJl3XCuA4V2Gy2dEpkt1r6DBxlsP43/VjDBw==}
     engines: {node: '>=22'}
 
-  '@atproto/ws-client@0.1.8':
-    resolution: {integrity: sha512-EX9SpoOJY4QhDKXe/olJw2h+Lj10SMd0ErDSE8pf3aFmg4MEEA+KBMg7HO8b9U6SNSS6n2nl7GPe37D3rIJ5zw==}
+  '@atproto/ws-client@0.2.0':
+    resolution: {integrity: sha512-qlrAa9d1AWhd3SoZ6dF/gqEpHKPJlXbieA8wrSEjx/hOJVKKR0gTPw3E/gajJ00pPtE88wPE5ARE4whUlOgAyw==}
     engines: {node: '>=22'}
 
   '@babel/helper-string-parser@7.29.7':
@@ -2614,9 +2614,8 @@ snapshots:
       iso-datestring-validator: 2.2.2
       tslib: 2.8.1
 
-  '@atproto/ws-client@0.1.8':
+  '@atproto/ws-client@0.2.0':
     dependencies:
-      '@atproto/common': 0.7.4
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,13 @@ importers:
       '@atproto/ws-client':
         specifier: ^0.1.1
         version: 0.1.8
+    devDependencies:
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
 
   packages/sdk:
     dependencies:
@@ -818,6 +825,9 @@ packages:
 
   '@types/node@26.1.0':
     resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.62.1':
     resolution: {integrity: sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==}
@@ -2999,6 +3009,10 @@ snapshots:
   '@types/node@26.1.0':
     dependencies:
       undici-types: 8.3.0
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 26.1.0
 
   '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(@typescript/typescript6@6.0.2)(eslint@10.6.0))(@typescript/typescript6@6.0.2)(eslint@10.6.0)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,8 +270,8 @@ importers:
   packages/jetstream:
     dependencies:
       '@atproto/lex-schema':
-        specifier: ^0.1.4
-        version: 0.1.6
+        specifier: ^0.2.2
+        version: 0.2.2
       '@atproto/ws-client':
         specifier: ^0.1.1
         version: 0.1.8
@@ -449,6 +449,10 @@ packages:
     resolution: {integrity: sha512-4AMwaB0HumrQuaXmYQDHeeZGKj8x6ACiIb8fX96Y0ZZaiM/JUmgZl0LTl/1kbQ7cGPfG+NoGsiuz1iJuFhTjxw==}
     engines: {node: '>=22'}
 
+  '@atproto/lex-schema@0.2.2':
+    resolution: {integrity: sha512-UFK0EH8pw31dvL27aoZ5K78z+UMiD3ybIgkCyd7Idm267KM1IpycerTDeABqo4CYP3/IAnzjGpQaUaVc12bELA==}
+    engines: {node: '>=22'}
+
   '@atproto/lex-schema@0.2.4':
     resolution: {integrity: sha512-60c4aiHVYJQfmLF397d/NUYgrl7XYsnpGZjVLthsLpyn6gBiiFVaL/Pd+azLf/Uztn5ydbGbCxHEsoHsvUZLIg==}
     engines: {node: '>=22'}
@@ -468,6 +472,10 @@ packages:
 
   '@atproto/syntax@0.6.4':
     resolution: {integrity: sha512-ELgpShRGMF65cvLXcoMCZFL0HBzy67yz/Nlhox3yOtTh120B09KjjvZYXhMysVog3nUJqv2EW5rf1VRYCeM/hw==}
+    engines: {node: '>=22'}
+
+  '@atproto/syntax@0.7.2':
+    resolution: {integrity: sha512-tZ1Tr0R9pK4bI4Zs69t29cjMlCFQvRNBeNkqJC5pGeNuCt64D0eoF7s/AlqeVmYppClmQ0xJquggGgsMDP6j7w==}
     engines: {node: '>=22'}
 
   '@atproto/syntax@0.7.3':
@@ -2544,6 +2552,13 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       tslib: 2.8.1
 
+  '@atproto/lex-schema@0.2.2':
+    dependencies:
+      '@atproto/lex-data': 0.1.7
+      '@atproto/syntax': 0.7.2
+      '@standard-schema/spec': 1.1.0
+      tslib: 2.8.1
+
   '@atproto/lex-schema@0.2.4':
     dependencies:
       '@atproto/lex-data': 0.1.7
@@ -2585,6 +2600,11 @@ snapshots:
       zod: 3.25.76
 
   '@atproto/syntax@0.6.4':
+    dependencies:
+      iso-datestring-validator: 2.2.2
+      tslib: 2.8.1
+
+  '@atproto/syntax@0.7.2':
     dependencies:
       iso-datestring-validator: 2.2.2
       tslib: 2.8.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,6 +272,9 @@ importers:
       '@atproto/lex-schema':
         specifier: ^0.1.4
         version: 0.1.6
+      '@atproto/syntax':
+        specifier: ^0.6.4
+        version: 0.6.4
       '@atproto/ws-client':
         specifier: ^0.1.1
         version: 0.1.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,6 +267,15 @@ importers:
 
   packages/internal-smoke-test: {}
 
+  packages/jetstream:
+    dependencies:
+      '@atproto/lex-schema':
+        specifier: ^0.1.4
+        version: 0.1.6
+      '@atproto/ws-client':
+        specifier: ^0.1.1
+        version: 0.1.8
+
   packages/sdk:
     dependencies:
       '@atproto-labs/handle-resolver':
@@ -377,10 +386,6 @@ packages:
     resolution: {integrity: sha512-9ONA6UR7b0cfbyxi4lA0M+a9PAg3nLCyKMLUmOA+oMoA+c912hFnlzsXszRT7Lh97R3q/mbZt2fj9ZQ9NNgtqg==}
     engines: {node: '>=22'}
 
-  '@atproto/lex-cbor@0.1.3':
-    resolution: {integrity: sha512-L9g6X8DAus+CrgrxwKehn5EUjsYuuySmUttkaHngXAT9+QOIsGqe7Bdcfd2FBZxomFjCamp5hFrN5M4hrGpdNA==}
-    engines: {node: '>=22'}
-
   '@atproto/lex-cbor@0.1.6':
     resolution: {integrity: sha512-PxLQy7jzV8u9zTGURNF8ZczLPk+ZH+WNx/2z/z7RacJbu7sWNpx26U2pC7cIkWtt4jyDaruaLhssw3w3atLotA==}
     engines: {node: '>=22'}
@@ -460,6 +465,10 @@ packages:
 
   '@atproto/syntax@0.7.3':
     resolution: {integrity: sha512-7LU8Ra79L5wCqVAZZst2352VMMwkU4KNagVMm6pnURrY/uS7+HrJl3XCuA4V2Gy2dEpkt1r6DBxlsP43/VjDBw==}
+    engines: {node: '>=22'}
+
+  '@atproto/ws-client@0.1.8':
+    resolution: {integrity: sha512-EX9SpoOJY4QhDKXe/olJw2h+Lj10SMd0ErDSE8pf3aFmg4MEEA+KBMg7HO8b9U6SNSS6n2nl7GPe37D3rIJ5zw==}
     engines: {node: '>=22'}
 
   '@babel/helper-string-parser@7.29.7':
@@ -2275,6 +2284,18 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -2354,8 +2375,8 @@ snapshots:
 
   '@atproto/common-web@0.5.3':
     dependencies:
-      '@atproto/lex-data': 0.1.4
-      '@atproto/lex-json': 0.1.3
+      '@atproto/lex-data': 0.1.7
+      '@atproto/lex-json': 0.1.6
       '@atproto/syntax': 0.6.4
       zod: 3.25.76
 
@@ -2369,8 +2390,8 @@ snapshots:
   '@atproto/common@0.6.5':
     dependencies:
       '@atproto/common-web': 0.5.3
-      '@atproto/lex-cbor': 0.1.3
-      '@atproto/lex-data': 0.1.4
+      '@atproto/lex-cbor': 0.1.6
+      '@atproto/lex-data': 0.1.7
       multiformats: 13.4.2
       pino: 10.3.1
 
@@ -2408,12 +2429,6 @@ snapshots:
       '@atproto/lex-schema': 0.2.4
       prettier: 3.9.6
       ts-morph: 27.0.2
-      tslib: 2.8.1
-
-  '@atproto/lex-cbor@0.1.3':
-    dependencies:
-      '@atproto/lex-data': 0.1.4
-      cborg: 4.5.8
       tslib: 2.8.1
 
   '@atproto/lex-cbor@0.1.6':
@@ -2474,7 +2489,7 @@ snapshots:
 
   '@atproto/lex-json@0.1.3':
     dependencies:
-      '@atproto/lex-data': 0.1.4
+      '@atproto/lex-data': 0.1.7
       tslib: 2.8.1
 
   '@atproto/lex-json@0.1.6':
@@ -2514,7 +2529,7 @@ snapshots:
 
   '@atproto/lex-schema@0.1.6':
     dependencies:
-      '@atproto/lex-data': 0.1.4
+      '@atproto/lex-data': 0.1.7
       '@atproto/syntax': 0.6.4
       '@standard-schema/spec': 1.1.0
       tslib: 2.8.1
@@ -2542,7 +2557,7 @@ snapshots:
       '@atproto/common': 0.6.5
       '@atproto/common-web': 0.5.3
       '@atproto/crypto': 0.5.3
-      '@atproto/lex-cbor': 0.1.3
+      '@atproto/lex-cbor': 0.1.6
       '@atproto/lex-data': 0.1.4
       '@atproto/syntax': 0.6.4
       varint: 6.0.0
@@ -2568,6 +2583,14 @@ snapshots:
     dependencies:
       iso-datestring-validator: 2.2.2
       tslib: 2.8.1
+
+  '@atproto/ws-client@0.1.8':
+    dependencies:
+      '@atproto/common': 0.7.4
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@babel/helper-string-parser@7.29.7': {}
 
@@ -4269,6 +4292,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  ws@8.21.0: {}
 
   y18n@5.0.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,9 +272,6 @@ importers:
       '@atproto/lex-schema':
         specifier: ^0.1.4
         version: 0.1.6
-      '@atproto/syntax':
-        specifier: ^0.6.4
-        version: 0.6.4
       '@atproto/ws-client':
         specifier: ^0.1.1
         version: 0.1.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,4 @@ minimumReleaseAgeExclude:
   - '@atproto/lex-password-session@0.1.8'
   - '@atproto/lex-resolver@0.2.2'
   - '@atproto/lex@0.3.0'
+  - '@atproto/ws-client@0.2.0'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "include": [],
   "references": [
     { "path": "./packages/internal-smoke-test" },
+    { "path": "./packages/jetstream" },
     { "path": "./packages/sdk" },
   ],
 }


### PR DESCRIPTION
Adds `packages/jetstream` (`@bsky.app/jetstream`), a client for [Jetstream](https://github.com/bluesky-social/jetstream) live mode (just jetstream v1).

- `Jetstream.live()` streams typed or raw events over WebSocket with server-side collection/DID filtering, cursor resume, and reconnect dedup.
- Collection filters accept plain NSIDs, wildcards, or lexicon schemas — schema filters validate records, skip invalid ones (via `onError` as `RecordValidationError`), and narrow event types so `commit.record` is fully typed per collection.
- `LexIndexer` dispatches validated records to per-collection `put`/`del` handlers (plus identity/account) with bounded concurrency and per-record ordering; `JetstreamRunner` drives any consumer with durable cursor tracking that only advances past contiguously acked events.

Rests cover decoding, dedup/resume, cursor tracking, indexer semantics, and type narrowing; an env-gated integration test (`JETSTREAM_LIVE_HOST`) exercises a real instance end to end. Later work will bring in Jetstream v2 support: snapshot, replay, and batched modes.