### PR TITLE
Bump @atproto/lex-schema to ^0.2.2

### DIFF
--- a/.changeset/nice-buses-relax.md
+++ b/.changeset/nice-buses-relax.md
@@ -1,0 +1,5 @@
+---
+'@bsky.app/jetstream': patch
+---
+
+Bump @atproto/lex-schema to ^0.2.2

--- a/packages/jetstream/package.json
+++ b/packages/jetstream/package.json
@@ -30,7 +30,7 @@
     "node": ">=22.12.0"
   },
   "dependencies": {
-    "@atproto/lex-schema": "^0.1.4",
+    "@atproto/lex-schema": "^0.2.2",
     "@atproto/ws-client": "^0.1.1"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,8 +267,8 @@ importers:
   packages/jetstream:
     dependencies:
       '@atproto/lex-schema':
-        specifier: ^0.1.4
-        version: 0.1.6
+        specifier: ^0.2.2
+        version: 0.2.2
       '@atproto/ws-client':
         specifier: ^0.1.1
         version: 0.1.4
@@ -329,12 +329,16 @@ packages:
     resolution: {integrity: sha512-f9U95sk0zUtxHktvK59peU+Shd0cIUYV68p//GS7sfdkAxUIeaspvX6CY+Quv9Oa4aozmsXI52SjaNn1wuU8RQ==}
     engines: {node: '>=22'}
 
+  '@atproto/lex-data@0.1.5':
+    resolution: {integrity: sha512-TEM6GHuYpNm4O90LjNgbYq1Gmcr875S+BHrDxkg4PB5w/nlsz4HlbkGQG/WP/xbIV5O8TF5nNHDpCZ5ezTRrFA==}
+    engines: {node: '>=22'}
+
   '@atproto/lex-json@0.1.3':
     resolution: {integrity: sha512-Ch2w9bCLFOwWINFFxpZo6DBW7+ZxkehciU3P8N94gSyENLe3/5WWXHdHvkiH7EXZrpI7fKY8nVWn4GIL0ttqxw==}
     engines: {node: '>=22'}
 
-  '@atproto/lex-schema@0.1.6':
-    resolution: {integrity: sha512-4AMwaB0HumrQuaXmYQDHeeZGKj8x6ACiIb8fX96Y0ZZaiM/JUmgZl0LTl/1kbQ7cGPfG+NoGsiuz1iJuFhTjxw==}
+  '@atproto/lex-schema@0.2.2':
+    resolution: {integrity: sha512-UFK0EH8pw31dvL27aoZ5K78z+UMiD3ybIgkCyd7Idm267KM1IpycerTDeABqo4CYP3/IAnzjGpQaUaVc12bELA==}
     engines: {node: '>=22'}
 
   '@atproto/lexicon@0.7.4':
@@ -343,6 +347,10 @@ packages:
 
   '@atproto/syntax@0.6.4':
     resolution: {integrity: sha512-ELgpShRGMF65cvLXcoMCZFL0HBzy67yz/Nlhox3yOtTh120B09KjjvZYXhMysVog3nUJqv2EW5rf1VRYCeM/hw==}
+    engines: {node: '>=22'}
+
+  '@atproto/syntax@0.7.2':
+    resolution: {integrity: sha512-tZ1Tr0R9pK4bI4Zs69t29cjMlCFQvRNBeNkqJC5pGeNuCt64D0eoF7s/AlqeVmYppClmQ0xJquggGgsMDP6j7w==}
     engines: {node: '>=22'}
 
   '@atproto/ws-client@0.1.4':
@@ -2103,15 +2111,21 @@ snapshots:
       uint8arrays: 5.1.1
       unicode-segmenter: 0.14.5
 
+  '@atproto/lex-data@0.1.5':
+    dependencies:
+      multiformats: 13.4.2
+      tslib: 2.8.1
+      unicode-segmenter: 0.14.5
+
   '@atproto/lex-json@0.1.3':
     dependencies:
       '@atproto/lex-data': 0.1.4
       tslib: 2.8.1
 
-  '@atproto/lex-schema@0.1.6':
+  '@atproto/lex-schema@0.2.2':
     dependencies:
-      '@atproto/lex-data': 0.1.4
-      '@atproto/syntax': 0.6.4
+      '@atproto/lex-data': 0.1.5
+      '@atproto/syntax': 0.7.2
       '@standard-schema/spec': 1.1.0
       tslib: 2.8.1
 
@@ -2123,6 +2137,11 @@ snapshots:
       zod: 3.25.76
 
   '@atproto/syntax@0.6.4':
+    dependencies:
+      iso-datestring-validator: 2.2.2
+      tslib: 2.8.1
+
+  '@atproto/syntax@0.7.2':
     dependencies:
       iso-datestring-validator: 2.2.2
       tslib: 2.8.1


### PR DESCRIPTION
Updates `@atproto/lex-schema` from `^0.1.4` to `^0.2.2` in `packages/jetstream`.