### PR TITLE
Add video job failure codes

### DIFF
--- a/lexicons/app/bsky/video/defs.json
+++ b/lexicons/app/bsky/video/defs.json
@@ -21,6 +21,17 @@
         },
         "blob": { "type": "blob" },
         "error": { "type": "string" },
+        "failureCode": {
+          "type": "string",
+          "description": "A machine-readable code for why the video processing job failed.",
+          "knownValues": [
+            "validation_failure",
+            "encoding_failure",
+            "pds_upload_failure",
+            "pds_upload_unsupported_blob_size",
+            "generic_failure"
+          ]
+        },
         "message": { "type": "string" }
       }
     }


### PR DESCRIPTION
## Summary

- adds fixed failure codes that can be interpreted by clients to provide more detailed error messages

Mirrors https://github.com/bluesky-social/atproto/pull/5283