### PR TITLE
add missing starter pack search lexicon

### DIFF
--- a/lexicons/app/bsky/graph/searchStarterPacksV2.json
+++ b/lexicons/app/bsky/graph/searchStarterPacksV2.json
@@ -1,0 +1,52 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.graph.searchStarterPacksV2",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Find starter packs matching search criteria. Does not require auth.",
+      "parameters": {
+        "type": "params",
+        "required": ["q"],
+        "properties": {
+          "q": {
+            "type": "string",
+            "description": "Search query string. Syntax, phrase, boolean, and faceting is unspecified, but Lucene query syntax is recommended."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 25
+          },
+          "cursor": {
+            "type": "string"
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["starterPacks"],
+          "properties": {
+            "cursor": {
+              "type": "string"
+            },
+            "hitsTotal": {
+              "type": "integer",
+              "description": "Estimated total number of matching hits. May be rounded or truncated."
+            },
+            "starterPacks": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "app.bsky.graph.defs#starterPackView"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds app.bsky.graph.searchStarterPacksV2 from atproto, which was missing from this repository's lexicon inventory.

Validation:
- Prettier formatting passes
- Schema matches atproto origin/main

Note: the upstream schema reports existing unlimited-string lint warnings for q, cursor, and output cursor. Marked as override for now