### PR TITLE
fix chat export permission

### DIFF
--- a/lexicons/chat/bsky/authFullChatClient.json
+++ b/lexicons/chat/bsky/authFullChatClient.json
@@ -17,11 +17,11 @@
           "inheritAud": true,
           "lxm": [
             "chat.bsky.actor.deleteAccount",
+            "chat.bsky.actor.exportAccountData",
             "chat.bsky.actor.getStatus",
             "chat.bsky.convo.acceptConvo",
             "chat.bsky.convo.addReaction",
             "chat.bsky.convo.deleteMessageForSelf",
-            "chat.bsky.convo.exportAccountData",
             "chat.bsky.convo.getConvo",
             "chat.bsky.convo.getConvoAvailability",
             "chat.bsky.convo.getConvoForMembers",


### PR DESCRIPTION
Fixes the full-chat permission set to reference the existing chat.bsky.actor.exportAccountData endpoint instead of the nonexistent chat.bsky.convo.exportAccountData endpoint.

Validation:
- Prettier formatting passes
- goat lex lint passes
- No references to chat.bsky.convo.exportAccountData remain