### PR TITLE
add missing fields to ageassurance, notification and graph lexicons

### DIFF
--- a/lexicons/app/bsky/ageassurance/defs.json
+++ b/lexicons/app/bsky/ageassurance/defs.json
@@ -64,6 +64,14 @@
       "description": "The Age Assurance configuration for a specific region.",
       "required": ["countryCode", "minAccessAge", "rules"],
       "properties": {
+        "platforms": {
+          "type": "array",
+          "description": "The platforms this configuration applies to. If omitted, the configuration applies to all platforms.",
+          "items": {
+            "type": "string",
+            "knownValues": ["web", "ios", "android"]
+          }
+        },
         "countryCode": {
           "type": "string",
           "description": "The ISO 3166-1 alpha-2 country code this configuration applies to."

--- a/lexicons/app/bsky/graph/getFollowers.json
+++ b/lexicons/app/bsky/graph/getFollowers.json
@@ -16,7 +16,12 @@
             "maximum": 100,
             "default": 50
           },
-          "cursor": { "type": "string" }
+          "cursor": { "type": "string" },
+          "sort": {
+            "type": "string",
+            "description": "Sort order of the returned followers.",
+            "knownValues": ["latest", "top"]
+          }
         }
       },
       "output": {

--- a/lexicons/app/bsky/graph/getFollows.json
+++ b/lexicons/app/bsky/graph/getFollows.json
@@ -16,7 +16,12 @@
             "maximum": 100,
             "default": 50
           },
-          "cursor": { "type": "string" }
+          "cursor": { "type": "string" },
+          "sort": {
+            "type": "string",
+            "description": "Sort order of the returned follows.",
+            "knownValues": ["latest", "top"]
+          }
         }
       },
       "output": {

--- a/lexicons/app/bsky/notification/listNotifications.json
+++ b/lexicons/app/bsky/notification/listNotifications.json
@@ -80,6 +80,11 @@
         },
         "reasonSubject": { "type": "string", "format": "at-uri" },
         "record": { "type": "unknown" },
+        "starterPack": {
+          "description": "The starter pack associated with this notification. Present when the notification is for a follow originating from a starter pack.",
+          "type": "ref",
+          "ref": "app.bsky.graph.defs#starterPackViewBasic"
+        },
         "isRead": { "type": "boolean" },
         "indexedAt": { "type": "string", "format": "datetime" },
         "labels": {


### PR DESCRIPTION
These fields are already emitted/accepted by the server and shipped in @atproto/api's generated types; only the source lexicons were behind. Shapes mirror the schemas in @atproto/api's dist/client/lexicons.js.

- app.bsky.ageassurance.defs#configRegion: platforms
- app.bsky.notification.listNotifications#notification: starterPack
- app.bsky.graph.getFollows / getFollowers: sort param