### PR TITLE
Rename npm scope from `@bsky.app` to `@bsky`

### DIFF
--- a/.github/claude-review-prompt.md
+++ b/.github/claude-review-prompt.md
@@ -1,6 +1,6 @@
 You are an experienced senior TypeScript engineer reviewing a pull
 request in the bsky monorepo — TypeScript packages published under the
-`@bsky.app` npm org, plus private service entrypoints. Read the repo's
+`@bsky` npm org, plus private service entrypoints. Read the repo's
 README and any package-level docs the diff touches before forming an
 opinion.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bsky
 
-TypeScript monorepo for Bluesky packages published under the [`@bsky.app`](https://www.npmjs.com/org/bsky.app) npm organization.
+TypeScript monorepo for Bluesky packages published under the [`@bsky`](https://www.npmjs.com/org/bsky) npm organization.
 
 ## Layout
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@bsky.app/monorepo",
+  "name": "@bsky/monorepo",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/packages/internal-smoke-test/package.json
+++ b/packages/internal-smoke-test/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@bsky.app/internal-smoke-test",
+  "name": "@bsky/internal-smoke-test",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@bsky.app/sdk",
+  "name": "@bsky/sdk",
   "version": "0.0.0",
   "license": "MIT OR Apache-2.0",
   "description": "Client library for Bluesky",


### PR DESCRIPTION
Packages in this repo now publish under the [`@bsky`](https://www.npmjs.com/org/bsky) npm organization instead of `@bsky.app`:

- `@bsky.app/sdk` → `@bsky/sdk`
- `@bsky.app/internal-smoke-test` → `@bsky/internal-smoke-test` (private)
- Root workspace package renamed to `@bsky/monorepo`

Docs (`README.md`) and the PR review prompt are updated to match. No source code imports the scoped names cross-package, so no code changes were needed.

Note: npm OIDC trusted publishing will need to be configured under the `bsky` org before the first publish.