### PR TITLE
import missing lexicon changes

### DIFF
--- a/lexicons/app/bsky/actor/defs.json
+++ b/lexicons/app/bsky/actor/defs.json
@@ -195,7 +195,18 @@
       "type": "object",
       "description": "Metadata about the requesting account's relationship with the subject account. Only has meaningful content for authed requests.",
       "properties": {
-        "muted": { "type": "boolean" },
+        "muted": {
+          "type": "boolean",
+          "description": "Whether the account is fully muted, directly or via a mutelist. False when the mute is scoped to specific kinds; see mutedOnlyReposts and mutedOnlyQuoteposts."
+        },
+        "mutedOnlyReposts": {
+          "type": "boolean",
+          "description": "Whether the account's reposts are muted. Scoped mutes are exclusive with muted: this can be true while muted is false. If muted is true, this will be false."
+        },
+        "mutedOnlyQuoteposts": {
+          "type": "boolean",
+          "description": "Whether the account's quote posts are muted. Scoped mutes are exclusive with muted: this can be true while muted is false. If muted is true, this will be false."
+        },
         "mutedByList": {
           "type": "ref",
           "ref": "app.bsky.graph.defs#listViewBasic"

--- a/lexicons/app/bsky/authFullApp.json
+++ b/lexicons/app/bsky/authFullApp.json
@@ -70,6 +70,7 @@
             "app.bsky.graph.muteActorList",
             "app.bsky.graph.muteThread",
             "app.bsky.graph.searchStarterPacks",
+            "app.bsky.graph.searchStarterPacksV2",
             "app.bsky.graph.unmuteActor",
             "app.bsky.graph.unmuteActorList",
             "app.bsky.graph.unmuteThread",

--- a/lexicons/app/bsky/authViewAll.json
+++ b/lexicons/app/bsky/authViewAll.json
@@ -55,6 +55,7 @@
             "app.bsky.graph.getStarterPacksWithMembership",
             "app.bsky.graph.getSuggestedFollowsByActor",
             "app.bsky.graph.searchStarterPacks",
+            "app.bsky.graph.searchStarterPacksV2",
             "app.bsky.labeler.getServices",
             "app.bsky.notification.getPreferences",
             "app.bsky.notification.getUnreadCount",

--- a/lexicons/app/bsky/draft/createDraft.json
+++ b/lexicons/app/bsky/draft/createDraft.json
@@ -26,6 +26,7 @@
           "properties": {
             "id": {
               "type": "string",
+              "format": "tid",
               "description": "The ID of the created draft."
             }
           }

--- a/lexicons/app/bsky/graph/getMutes.json
+++ b/lexicons/app/bsky/graph/getMutes.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "query",
-      "description": "Enumerates accounts that the requesting account (actor) currently has muted. Requires auth.",
+      "description": "Enumerates accounts that the requesting account (actor) currently has fully muted. Mutes scoped to specific kinds of content (only reposts, only quote posts) are not included. Responses may contain more items than the requested limit. Requires auth.",
       "parameters": {
         "type": "params",
         "properties": {

--- a/lexicons/app/bsky/graph/muteActor.json
+++ b/lexicons/app/bsky/graph/muteActor.json
@@ -4,14 +4,22 @@
   "defs": {
     "main": {
       "type": "procedure",
-      "description": "Creates a mute relationship for the specified account. Mutes are private in Bluesky. Requires auth.",
+      "description": "Creates a mute relationship for the specified account. If a mute already exists for the account, it is updated in place: the stored scope is replaced with the scope in this request. Mutes are private in Bluesky. Requires auth.",
       "input": {
         "encoding": "application/json",
         "schema": {
           "type": "object",
           "required": ["actor"],
           "properties": {
-            "actor": { "type": "string", "format": "at-identifier" }
+            "actor": { "type": "string", "format": "at-identifier" },
+            "onlyReposts": {
+              "type": "boolean",
+              "description": "Restrict the mute to the account's reposts. When any 'only' scope is set, just the scoped content is muted; when none are set, the account is fully muted. Repeat calls replace the stored scope rather than adding to it."
+            },
+            "onlyQuoteposts": {
+              "type": "boolean",
+              "description": "Restrict the mute to the account's quote posts. See onlyReposts."
+            }
           }
         }
       }

--- a/lexicons/app/bsky/unspecced/defs.json
+++ b/lexicons/app/bsky/unspecced/defs.json
@@ -46,6 +46,7 @@
       "properties": {
         "topic": { "type": "string" },
         "displayName": { "type": "string" },
+        "description": { "type": "string" },
         "link": { "type": "string" },
         "startedAt": { "type": "string", "format": "datetime" },
         "postCount": { "type": "integer" },
@@ -73,6 +74,7 @@
       "properties": {
         "topic": { "type": "string" },
         "displayName": { "type": "string" },
+        "description": { "type": "string" },
         "link": { "type": "string" },
         "startedAt": { "type": "string", "format": "datetime" },
         "postCount": { "type": "integer" },
@@ -109,7 +111,15 @@
         },
         "opThread": {
           "type": "boolean",
-          "description": "This post is part of a contiguous thread by the OP from the thread root. Many different OP threads can happen in the same thread."
+          "description": "This post is part of a contiguous thread by the OP from the thread root. Sub-threads by OP deeper in the tree are not considered an OP thread."
+        },
+        "opThreadPostIndex": {
+          "type": "integer",
+          "description": "The 1-indexed position of this post within the contiguous OP thread. Only present when this post is part of the OP thread (see `opThread`)."
+        },
+        "opThreadPostCount": {
+          "type": "integer",
+          "description": "The total number of posts in the contiguous OP thread that this post belongs to. Only present when this post is part of the OP thread (see `opThread`)."
         },
         "hiddenByThreadgate": {
           "type": "boolean",

--- a/lexicons/app/bsky/unspecced/getTrends.json
+++ b/lexicons/app/bsky/unspecced/getTrends.json
@@ -28,6 +28,10 @@
                 "type": "ref",
                 "ref": "app.bsky.unspecced.defs#trendView"
               }
+            },
+            "recIdStr": {
+              "type": "string",
+              "description": "Snowflake for this recommendation, use when submitting recommendation events."
             }
           }
         }

--- a/lexicons/app/bsky/unspecced/getTrendsSkeleton.json
+++ b/lexicons/app/bsky/unspecced/getTrendsSkeleton.json
@@ -33,6 +33,10 @@
                 "type": "ref",
                 "ref": "app.bsky.unspecced.defs#skeletonTrend"
               }
+            },
+            "recIdStr": {
+              "type": "string",
+              "description": "Snowflake for this recommendation, use when submitting recommendation events."
             }
           }
         }

--- a/lexicons/app/bsky/video/defs.json
+++ b/lexicons/app/bsky/video/defs.json
@@ -21,6 +21,17 @@
         },
         "blob": { "type": "blob" },
         "error": { "type": "string" },
+        "failureCode": {
+          "type": "string",
+          "description": "A machine-readable code for why the video processing job failed.",
+          "knownValues": [
+            "validation_failure",
+            "encoding_failure",
+            "pds_upload_failure",
+            "pds_upload_unsupported_blob_size",
+            "generic_failure"
+          ]
+        },
         "message": { "type": "string" }
       }
     }


### PR DESCRIPTION
## Summary

- import app.bsky lexicon changes that landed in atproto after this repository became the source of truth
- cover scoped mutes, OP-thread and trend metadata, video failure codes, draft IDs, and starter-pack auth scopes
- exclude internal.bsky.actor.getProfiles

## Testing

- pnpm verify