### PR TITLE
Sync video job status known values

### DIFF
--- a/lexicons/app/bsky/video/defs.json
+++ b/lexicons/app/bsky/video/defs.json
@@ -11,7 +11,17 @@
         "state": {
           "type": "string",
           "description": "The state of the video processing job. All values not listed as a known value indicate that the job is in process.",
-          "knownValues": ["JOB_STATE_COMPLETED", "JOB_STATE_FAILED"]
+          "knownValues": [
+            "JOB_STATE_CREATED",
+            "JOB_STATE_ENCODING",
+            "JOB_STATE_ENCODED",
+            "JOB_STATE_SCANNING",
+            "JOB_STATE_SCANNED",
+            "JOB_STATE_UPLOADING",
+            "JOB_STATE_UPLOADED",
+            "JOB_STATE_COMPLETED",
+            "JOB_STATE_FAILED"
+          ]
         },
         "progress": {
           "type": "integer",


### PR DESCRIPTION
## Summary

- add the implemented video processing lifecycle states to `app.bsky.video.defs#jobStatus.state`
- exclude the protobuf sentinel and nonexistent `JOB_STATE_IN_PROGRESS` value
- leave existing string constraints unchanged

## Testing

- `git diff --check`
- `goat lex lint lexicons/app/bsky/video/defs.json` reports the file's five pre-existing `unlimited-string` findings; no lint constraints are added in this PR

Linear: [APP-2817](https://linear.app/blueskyweb/issue/APP-2817/sync-getjobstatus-state-knownvalues)