### PR TITLE
Route Claude reviews through Agent Gateway

### DIFF
--- a/.github/workflows/claude-mention.yml
+++ b/.github/workflows/claude-mention.yml
@@ -26,6 +26,7 @@ permissions:
   pull-requests: write
   issues: write
   actions: read
+  # Required for claude-code-action's GitHub App token exchange.
   id-token: write
 
 jobs:
@@ -58,19 +59,17 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ secrets.AWS_BEDROCK_REVIEW_ROLE_ARN }}
-          aws-region: us-east-2
-
       - name: Claude
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: https://agentgateway.k1.prod.bsky.dev
         with:
-          use_bedrock: 'true'
+          # Agent Gateway service keys use Authorization: Bearer, the wire
+          # shape emitted by the action's OAuth-token input.
+          claude_code_oauth_token: ${{ secrets.AGENT_GATEWAY_CLAUDE_GH_REVIEW_KEY }}
           additional_permissions: |
             actions: read
           track_progress: true
           claude_args: |
-            --model global.anthropic.claude-opus-4-8
+            --model claude-opus-5:api
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__download_job_log,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,7 @@
 name: claude-review
 
-# Automatic Claude review on PR creation/update, via Bedrock (OIDC, no
-# long-lived tokens). Self-contained: uses upstream claude-code-action
+# Automatic Claude review on PR creation/update, via Agent Gateway.
+# Self-contained: uses upstream claude-code-action
 # defaults directly rather than the org reusable workflows, so upstream
 # fixes arrive via the floating @v1 with no central re-tag.
 #
@@ -15,13 +15,13 @@ permissions:
   contents: read
   pull-requests: write
   actions: read
+  # Required for claude-code-action's GitHub App token exchange.
   id-token: write
 
 jobs:
   review:
     # Same-repo branch PRs only: fork PRs must not trigger reviews (no
-    # Bedrock spend on unvetted code, and fork PRs can't mint the OIDC
-    # token anyway — this guard is belt-and-braces). Branch PRs can only
+    # gateway spend on unvetted code). Branch PRs can only
     # be created by people with write access, i.e. org members.
     # Bot-authored PRs (dependabot, changesets) are also skipped.
     if: >
@@ -42,21 +42,19 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: ${{ secrets.AWS_BEDROCK_REVIEW_ROLE_ARN }}
-          aws-region: us-east-2
-
       - name: Claude review
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: https://agentgateway.k1.prod.bsky.dev
         with:
-          use_bedrock: 'true'
+          # Agent Gateway service keys use Authorization: Bearer, the wire
+          # shape emitted by the action's OAuth-token input.
+          claude_code_oauth_token: ${{ secrets.AGENT_GATEWAY_CLAUDE_GH_REVIEW_KEY }}
           additional_permissions: |
             actions: read
           track_progress: true
           claude_args: |
-            --model global.anthropic.claude-opus-4-8
+            --model claude-opus-5:api
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__github_ci__get_ci_status,mcp__github_ci__download_job_log,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
Summary:

- remove AWS Bedrock credential setup from the Claude review and mention workflows
- authenticate to the external Agent Gateway with the shared org secret
- use `claude-opus-5:api` while preserving the existing trigger and authorization gates

Validation:

- `actionlint .github/workflows/claude-mention.yml .github/workflows/claude-review.yml`
- `git diff --check`
- Roast: no findings