### PR TITLE
Bump video embed max size to 300MB

### DIFF
--- a/lexicons/app/bsky/embed/video.json
+++ b/lexicons/app/bsky/embed/video.json
@@ -9,9 +9,9 @@
       "properties": {
         "video": {
           "type": "blob",
-          "description": "The mp4 video file. May be up to 100mb, formerly limited to 50mb.",
+          "description": "The mp4 video file. May be up to 300mb, formerly limited to 100mb.",
           "accept": ["video/mp4"],
-          "maxSize": 100000000
+          "maxSize": 300000000
         },
         "captions": {
           "type": "array",


### PR DESCRIPTION
## Summary

- increase `app.bsky.embed.video` max blob size from 100 MB to 300 MB
- update the video field description to match

## Testing

- `pnpm exec prettier --check lexicons/app/bsky/embed/video.json`
- `node --test '.github/scripts/*.test.ts'`\n- lexicon DNS validation\n- `git diff --check`\n\nLinear: APP-2811