### PR TITLE
Add Jetstream v2 live stream support

### DIFF
--- a/.changeset/short-moose-cough.md
+++ b/.changeset/short-moose-cough.md
@@ -1,0 +1,4 @@
+---
+---
+
+Jetstream v2 live stream support: `Jetstream` speaks the v2 wire by default, `JetstreamV1` covers the legacy v1 format. No published-package changes — `@bsky/jetstream` is unreleased and its pending initial-release changeset already covers this work.

--- a/packages/jetstream/README.md
+++ b/packages/jetstream/README.md
@@ -10,12 +10,12 @@ Install the Jetstream client:
 npm install @bsky/jetstream
 ```
 
-This package currently supports Jetstream's WebSocket-based live mode. Consuming events looks like:
+This package currently supports Jetstream's WebSocket-based live mode. `Jetstream` speaks the v2 wire: `live(opts)` tails `/xrpc/network.bsky.jetstream.subscribeEvents` from the cursor (or the tip), forever. Consuming events looks like:
 
 ```ts
 import { Jetstream } from '@bsky/jetstream'
 
-const js = new Jetstream('https://jetstream1.us-east.bsky.network')
+const js = new Jetstream('https://your-jetstream-host.example')
 
 for await (const evt of js.live({ collections: ['app.bsky.feed.post'] })) {
   if (evt.kind === 'commit' && evt.commit.operation === 'create') {
@@ -24,13 +24,18 @@ for await (const evt of js.live({ collections: ['app.bsky.feed.post'] })) {
 }
 ```
 
+`collections` constrains **commit** events only — identity, account, and sync
+events flow regardless — so a commits-only stream also needs
+`kinds: ['commit']`. `kinds` accepts `commit`, `identity`, `account`, and
+`sync`, and omitting it means all kinds.
+
 Using a lexicon as your collection filter will validate and type the events for you:
 
 ```ts
 import { Jetstream } from '@bsky/jetstream'
 import { app } from '@bsky/sdk/lexicons'
 
-const js = new Jetstream('https://jetstream1.us-east.bsky.network')
+const js = new Jetstream('https://your-jetstream-host.example')
 
 for await (const evt of js.live({ collections: [app.bsky.feed.post] })) {
   if (evt.kind === 'commit' && evt.commit.operation === 'create') {
@@ -39,13 +44,24 @@ for await (const evt of js.live({ collections: [app.bsky.feed.post] })) {
 }
 ```
 
+Typed records are converted lex data — `Cid`, `Uint8Array`, and `BlobRef`
+values rather than wire JSON's `{$link}` / `{$bytes}` shapes. Pass
+`live({ raw: true })` when you want the wire-faithful record instead (its
+`$link`/`$bytes` markers intact).
+
+A validating collection filter (a lexicon, or `{ collection, validateRecord:
+true }`, the default) routes a schema-invalid record away from delivery.
+Passing `validateRecord: false` only drops the _schema_ check — a record that
+isn't a `$type`'d map still fails conversion and is skipped, reported via
+`onError` (or, for `LexIndexer`, `onValidationError`) rather than delivered.
+
 For indexing workloads, `LexIndexer` dispatches schema-validated records to per-collection handlers with bounded concurrency and per-record ordering, and `JetstreamRunner` drives it with durable cursor tracking:
 
 ```ts
 import { Jetstream, LexIndexer, MemoryCursorStore } from '@bsky/jetstream'
 import { app } from '@bsky/sdk/lexicons'
 
-const js = new Jetstream('https://jetstream1.us-east.bsky.network')
+const js = new Jetstream('https://your-jetstream-host.example')
 
 const indexer = new LexIndexer()
   .commit(app.bsky.feed.like, {
@@ -66,6 +82,34 @@ const cursor = new MemoryCursorStore()
 await js.runner(indexer).live({ cursor })
 ```
 
+### Cursors
+
+`live()`'s cursor is a v2 `seq`. Values `>= 1e15` are read by the server as
+unix-microsecond timestamps instead, and the SDK treats such a value as
+wire-only: it never seeds the dedup floor, so the first delivered event
+establishes it. When the server clamps a stale timestamp it sends an
+`OutdatedCursor` advisory, reported through `onError` without ending the
+stream.
+
+Cursors are **not portable between versions**: a v1 cursor is a `time_us`
+value and a v2 cursor is a `seq`. Never replay a stored cursor against the
+other version.
+
+### Legacy v1 instances
+
+The public `jetstream*.bsky.network` hosts speak the frozen v1 wire. Use
+`JetstreamV1`, which offers `live()` only — v1 has no sealed archive, no
+`kinds` filter, and no runner/indexer path.
+
+```ts
+import { JetstreamV1 } from '@bsky/jetstream'
+
+const js = new JetstreamV1('https://jetstream1.us-east.bsky.network')
+for await (const evt of js.live({ collections: ['app.bsky.feed.post'] })) {
+  console.log(evt.seq, evt.kind)
+}
+```
+
 ## Connection behavior
 
 This package runs on Node.js and in the browser.
@@ -82,7 +126,7 @@ To observe or tune connection behavior, configure a transport with
 ```ts
 import { Jetstream, websocketTransport } from '@bsky/jetstream'
 
-const js = new Jetstream('https://jetstream2.us-east.bsky.network')
+const js = new Jetstream('https://your-jetstream-host.example')
 for await (const ev of js.live({
   collections: ['app.bsky.feed.post'],
   liveTransport: websocketTransport({

--- a/packages/jetstream/README.md
+++ b/packages/jetstream/README.md
@@ -10,12 +10,12 @@ Install the Jetstream client:
 npm install @bsky/jetstream
 ```
 
-This package currently supports Jetstream's WebSocket-based live mode. `Jetstream` speaks the v2 wire: `live(opts)` tails `/xrpc/network.bsky.jetstream.subscribeEvents` from the cursor (or the tip), forever. Consuming events looks like:
+This package currently supports Jetstream's WebSocket-based live mode, speaking Jetstream's v2 wire. Consuming events looks like:
 
 ```ts
 import { Jetstream } from '@bsky/jetstream'
 
-const js = new Jetstream('https://your-jetstream-host.example')
+const js = new Jetstream('https://jetstream.us-east.bsky.network')
 
 for await (const evt of js.live({ collections: ['app.bsky.feed.post'] })) {
   if (evt.kind === 'commit' && evt.commit.operation === 'create') {
@@ -35,7 +35,7 @@ Using a lexicon as your collection filter will validate and type the events for 
 import { Jetstream } from '@bsky/jetstream'
 import { app } from '@bsky/sdk/lexicons'
 
-const js = new Jetstream('https://your-jetstream-host.example')
+const js = new Jetstream('https://jetstream.us-east.bsky.network')
 
 for await (const evt of js.live({ collections: [app.bsky.feed.post] })) {
   if (evt.kind === 'commit' && evt.commit.operation === 'create') {
@@ -61,7 +61,7 @@ For indexing workloads, `LexIndexer` dispatches schema-validated records to per-
 import { Jetstream, LexIndexer, MemoryCursorStore } from '@bsky/jetstream'
 import { app } from '@bsky/sdk/lexicons'
 
-const js = new Jetstream('https://your-jetstream-host.example')
+const js = new Jetstream('https://jetstream.us-east.bsky.network')
 
 const indexer = new LexIndexer()
   .commit(app.bsky.feed.like, {
@@ -85,11 +85,9 @@ await js.runner(indexer).live({ cursor })
 ### Cursors
 
 `live()`'s cursor is a v2 `seq`. Values `>= 1e15` are read by the server as
-unix-microsecond timestamps instead, and the SDK treats such a value as
-wire-only: it never seeds the dedup floor, so the first delivered event
-establishes it. When the server clamps a stale timestamp it sends an
-`OutdatedCursor` advisory, reported through `onError` without ending the
-stream.
+unix-microsecond timestamps instead. When the server clamps a stale timestamp
+it sends an `OutdatedCursor` advisory, reported through `onInfo` without
+ending the stream.
 
 Cursors are **not portable between versions**: a v1 cursor is a `time_us`
 value and a v2 cursor is a `seq`. Never replay a stored cursor against the
@@ -97,9 +95,9 @@ other version.
 
 ### Legacy v1 instances
 
-The public `jetstream*.bsky.network` hosts speak the frozen v1 wire. Use
-`JetstreamV1`, which offers `live()` only — v1 has no sealed archive, no
-`kinds` filter, and no runner/indexer path.
+The public `jetstream*.bsky.network` hosts speak the legacy v1 format. Use
+`JetstreamV1`, which offers `live()` only — v1 does not support historical
+network replay, has no `kinds` filter, and no runner/indexer path.
 
 ```ts
 import { JetstreamV1 } from '@bsky/jetstream'
@@ -126,7 +124,7 @@ To observe or tune connection behavior, configure a transport with
 ```ts
 import { Jetstream, websocketTransport } from '@bsky/jetstream'
 
-const js = new Jetstream('https://your-jetstream-host.example')
+const js = new Jetstream('https://jetstream.us-east.bsky.network')
 for await (const ev of js.live({
   collections: ['app.bsky.feed.post'],
   liveTransport: websocketTransport({

--- a/packages/jetstream/README.md
+++ b/packages/jetstream/README.md
@@ -55,7 +55,7 @@ Passing `validateRecord: false` only drops the _schema_ check — a record that
 isn't a `$type`'d map still fails conversion and is skipped, reported via
 `onError` (or, for `LexIndexer`, `onValidationError`) rather than delivered.
 
-For indexing workloads, `LexIndexer` dispatches schema-validated records to per-collection handlers with bounded concurrency and per-record ordering, and `JetstreamRunner` drives it with durable cursor tracking:
+For indexing workloads, `LexIndexer` dispatches schema-validated records to per-collection handlers with bounded concurrency and per-record ordering, and `JetstreamRunner` drives it with durable cursor tracking. The runner asks the server only for the kinds a `LexIndexer` has registered handlers for — register `.identity()`/`.account()`/`.sync()` (or a collection via `.commit()`) to receive that kind at all:
 
 ```ts
 import { Jetstream, LexIndexer, MemoryCursorStore } from '@bsky/jetstream'
@@ -87,7 +87,8 @@ await js.runner(indexer).live({ cursor })
 `live()`'s cursor is a v2 `seq`. Values `>= 1e15` are read by the server as
 unix-microsecond timestamps instead. When the server clamps a stale timestamp
 it sends an `OutdatedCursor` advisory, reported through `onInfo` without
-ending the stream.
+ending the stream — an advisory is dropped silently if no `onInfo` is
+registered.
 
 Cursors are **not portable between versions**: a v1 cursor is a `time_us`
 value and a v2 cursor is a `seq`. Never replay a stored cursor against the

--- a/packages/jetstream/package.json
+++ b/packages/jetstream/package.json
@@ -30,7 +30,7 @@
     "node": ">=22.12.0"
   },
   "dependencies": {
-    "@atproto/lex-schema": "^0.2.2",
+    "@atproto/lex": "^0.3.0",
     "@atproto/ws-client": "^0.2.0"
   },
   "scripts": {

--- a/packages/jetstream/src/consumer.ts
+++ b/packages/jetstream/src/consumer.ts
@@ -31,8 +31,12 @@ export interface ConsumerContext {
  *
  * The seam element is the v2 `RawEvent`: put commits carry the record in its
  * wire representation, and the stream may include sync events.
- * typedEventFromRaw normalizes an event into TypedEvent. v1 events do not flow
- * here — JetstreamV1 is live-only.
+ * typedEventFromRaw normalizes an event into TypedEvent. By design, this
+ * seam should only ever see v2 events — but as of this commit, JetstreamRunner
+ * casts the (still v1-backed) Jetstream's raw batches into it (see
+ * runner.ts), so a real event here may in fact be a RawEventV1 wearing this
+ * type; do not assume `time`/`sync` are honestly present until that cast is
+ * removed (Task 10 flips Jetstream to v2).
  */
 export interface JetstreamConsumer {
   collections?: CollectionFilter[]

--- a/packages/jetstream/src/consumer.ts
+++ b/packages/jetstream/src/consumer.ts
@@ -31,12 +31,8 @@ export interface ConsumerContext {
  *
  * The seam element is the v2 `RawEvent`: put commits carry the record in its
  * wire representation, and the stream may include sync events.
- * typedEventFromRaw normalizes an event into TypedEvent. By design, this
- * seam should only ever see v2 events — but as of this commit, JetstreamRunner
- * casts the (still v1-backed) Jetstream's raw batches into it (see
- * runner.ts), so a real event here may in fact be a RawEventV1 wearing this
- * type; do not assume `time`/`sync` are honestly present until that cast is
- * removed (Task 10 flips Jetstream to v2).
+ * typedEventFromRaw normalizes an event into TypedEvent. This seam is v2-only
+ * — `time` and the `sync` arm are honestly present.
  */
 export interface JetstreamConsumer {
   collections?: CollectionFilter[]

--- a/packages/jetstream/src/consumer.ts
+++ b/packages/jetstream/src/consumer.ts
@@ -1,6 +1,11 @@
 import { type DidString } from '@atproto/lex'
 import { type CollectionFilter } from './engine/collections.js'
-import { type EventBatch, type RawEvent, type SeqEvent } from './event.js'
+import {
+  type EventBatch,
+  type Kind,
+  type RawEvent,
+  type SeqEvent,
+} from './event.js'
 
 /**
  * Signals that the consumer has finished processing an event. Fire-and-forget:
@@ -23,11 +28,11 @@ export interface ConsumerContext {
 }
 
 /**
- * Source-agnostic event processor. `collections`/`dids` are static declarations
- * of what the consumer handles; a Jetstream source reads them to build the
- * server-side filter. The consumer drives its own loop over the raw-batch
- * stream, decides its own concurrency/ordering, and calls ack(evt) on
- * completion. It knows nothing about cursors.
+ * Source-agnostic event processor. `collections`/`dids`/`kinds` are static
+ * declarations of what the consumer handles; a Jetstream source reads them to
+ * build the server-side filter. The consumer drives its own loop over the
+ * raw-batch stream, decides its own concurrency/ordering, and calls ack(evt)
+ * on completion. It knows nothing about cursors.
  *
  * The seam element is the v2 `RawEvent`: put commits carry the record in its
  * wire representation, and the stream may include sync events.
@@ -37,6 +42,7 @@ export interface ConsumerContext {
 export interface JetstreamConsumer {
   collections?: CollectionFilter[]
   dids?: DidString[]
+  kinds?: Kind[]
   run(
     stream: AsyncIterable<EventBatch<RawEvent>>,
     ctx: ConsumerContext,

--- a/packages/jetstream/src/consumer.ts
+++ b/packages/jetstream/src/consumer.ts
@@ -1,4 +1,4 @@
-import { type DidString } from '@atproto/lex-schema'
+import { type DidString } from '@atproto/lex'
 import { type CollectionFilter } from './engine/collections.js'
 import { type EventBatch, type RawEventV1, type SeqEvent } from './event.js'
 

--- a/packages/jetstream/src/consumer.ts
+++ b/packages/jetstream/src/consumer.ts
@@ -1,6 +1,6 @@
 import { type DidString } from '@atproto/lex'
 import { type CollectionFilter } from './engine/collections.js'
-import { type EventBatch, type RawEventV1, type SeqEvent } from './event.js'
+import { type EventBatch, type RawEvent, type SeqEvent } from './event.js'
 
 /**
  * Signals that the consumer has finished processing an event. Fire-and-forget:
@@ -29,14 +29,16 @@ export interface ConsumerContext {
  * stream, decides its own concurrency/ordering, and calls ack(evt) on
  * completion. It knows nothing about cursors.
  *
- * The seam element is the v1 raw event (parsed-JSON `record` on put commits);
- * typedEventFromRaw normalizes it into TypedEvent.
+ * The seam element is the v2 `RawEvent`: put commits carry the record in its
+ * wire representation, and the stream may include sync events.
+ * typedEventFromRaw normalizes an event into TypedEvent. v1 events do not flow
+ * here — JetstreamV1 is live-only.
  */
 export interface JetstreamConsumer {
   collections?: CollectionFilter[]
   dids?: DidString[]
   run(
-    stream: AsyncIterable<EventBatch<RawEventV1>>,
+    stream: AsyncIterable<EventBatch<RawEvent>>,
     ctx: ConsumerContext,
   ): Promise<void>
 }

--- a/packages/jetstream/src/decode-typed.ts
+++ b/packages/jetstream/src/decode-typed.ts
@@ -1,10 +1,25 @@
 import { type RecordSchema } from '@atproto/lex'
-import { type RawEventV1, type TypedCommit, type TypedEvent } from './event.js'
+import {
+  type RawEvent,
+  type RawEventV1,
+  type TypedCommit,
+  type TypedEvent,
+  type TypedEventV1,
+} from './event.js'
+import { type RawRecordJson } from './raw-record.js'
 
 export function typedEventFromRaw(
   raw: RawEventV1,
   schemasByNsid: Map<string, RecordSchema>,
-): TypedEvent {
+): TypedEventV1
+export function typedEventFromRaw(
+  raw: RawEvent<RawRecordJson>,
+  schemasByNsid: Map<string, RecordSchema>,
+): TypedEvent
+export function typedEventFromRaw(
+  raw: RawEventV1 | RawEvent<RawRecordJson>,
+  schemasByNsid: Map<string, RecordSchema>,
+): TypedEventV1 | TypedEvent {
   if (raw.kind !== 'commit') return raw
   // Delete first: DeleteCommit carries no `record`, so the put-commit handling
   // below only sees put commits.

--- a/packages/jetstream/src/decode-typed.ts
+++ b/packages/jetstream/src/decode-typed.ts
@@ -1,4 +1,4 @@
-import { type RecordSchema } from '@atproto/lex-schema'
+import { type RecordSchema } from '@atproto/lex'
 import { type RawEventV1, type TypedCommit, type TypedEvent } from './event.js'
 
 export function typedEventFromRaw(

--- a/packages/jetstream/src/decode-typed.ts
+++ b/packages/jetstream/src/decode-typed.ts
@@ -6,19 +6,22 @@ import {
   type TypedEvent,
   type TypedEventV1,
 } from './event.js'
-import { type RawRecordJson } from './raw-record.js'
+import { type RawRecordJson, parseRawRecord } from './raw-record.js'
 
 export function typedEventFromRaw(
   raw: RawEventV1,
   schemasByNsid: Map<string, RecordSchema>,
+  opts?: { strict?: boolean },
 ): TypedEventV1
 export function typedEventFromRaw(
   raw: RawEvent<RawRecordJson>,
   schemasByNsid: Map<string, RecordSchema>,
+  opts?: { strict?: boolean },
 ): TypedEvent
 export function typedEventFromRaw(
   raw: RawEventV1 | RawEvent<RawRecordJson>,
   schemasByNsid: Map<string, RecordSchema>,
+  opts?: { strict?: boolean },
 ): TypedEventV1 | TypedEvent {
   if (raw.kind !== 'commit') return raw
   // Delete first: DeleteCommit carries no `record`, so the put-commit handling
@@ -28,26 +31,32 @@ export function typedEventFromRaw(
   }
   const rawCommit = raw.commit
   const { collection, rkey, rev, operation } = rawCommit
-  // v1 put commit: the wire carried parsed JSON — there is no CBOR to decode.
-  // cid is the wire string (read for free via the delegating getter below).
-  const record: unknown = rawCommit.record
+  let record: unknown
   let validationError: Error | undefined
+  // The raw record is wire-faithful; convert it to lex data here. A failure
+  // surfaces the same way a decode failure always did.
+  try {
+    record = parseRawRecord(rawCommit.record, opts)
+  } catch (err) {
+    record = undefined
+    validationError = err instanceof Error ? err : new Error(String(err))
+  }
   const schema = schemasByNsid.get(collection)
-  if (schema) {
+  if (schema && validationError === undefined) {
     const result = schema.safeValidate(record)
-    if (!result.success) {
+    if (result.success) {
+      // Adopt the validated value: lex-schema may apply defaults or coercions,
+      // and returning the pre-coercion record would drop them.
+      record = result.value
+    } else {
       validationError = new Error(
         `record validation failed for ${collection}`,
-        {
-          cause: result.reason,
-        },
+        { cause: result.reason },
       )
     }
   }
-  // cid delegates via a getter, mirroring the source package where the v2 raw
-  // layer computes it lazily; v1's cid is a plain string, read for free
-  // through the same getter. Keeping the delegation means the future v2 port
-  // changes nothing here.
+  // cid delegates via a getter so the archive path's lazy hash is not forced
+  // for every typed event. v2 live's cid is a plain string, free either way.
   const commit = {
     operation,
     collection,

--- a/packages/jetstream/src/decode-typed.ts
+++ b/packages/jetstream/src/decode-typed.ts
@@ -38,15 +38,18 @@ export function typedEventFromRaw(
   try {
     record = parseRawRecord(rawCommit.record, opts)
   } catch (err) {
-    record = undefined
+    // `record` stays undefined — it is never assigned when parseRawRecord
+    // throws.
     validationError = err instanceof Error ? err : new Error(String(err))
   }
   const schema = schemasByNsid.get(collection)
   if (schema && validationError === undefined) {
     const result = schema.safeValidate(record)
     if (result.success) {
-      // Adopt the validated value: lex-schema may apply defaults or coercions,
-      // and returning the pre-coercion record would drop them.
+      // safeValidate (unlike safeParse) does not coerce — result.value is the
+      // input by reference, so this assignment is a no-op today. Kept so the
+      // code stays correct if this ever moves to a transforming validation
+      // method; deleting it would silently reintroduce the pre-coercion bug.
       record = result.value
     } else {
       validationError = new Error(

--- a/packages/jetstream/src/engine/collections.ts
+++ b/packages/jetstream/src/engine/collections.ts
@@ -3,7 +3,7 @@ import {
   type NsidString,
   type RecordSchema,
   getMain,
-} from '@atproto/lex-schema'
+} from '@atproto/lex'
 
 export interface SchemaCollectionFilter {
   collection: Main<RecordSchema>

--- a/packages/jetstream/src/errors.ts
+++ b/packages/jetstream/src/errors.ts
@@ -1,6 +1,12 @@
-export class MalformedError extends Error {
+import { LexError } from '@atproto/lex'
+
+// The one wire-frame malformation code this package reports; there is no
+// server taxonomy to match here, so a single fixed code is enough.
+const MALFORMED_CODE = 'Malformed'
+
+export class MalformedError extends LexError<typeof MALFORMED_CODE> {
   constructor(message: string, options?: ErrorOptions) {
-    super(message, options)
+    super(MALFORMED_CODE, message, options)
     this.name = 'MalformedError'
   }
 }
@@ -11,11 +17,9 @@ export class MalformedError extends Error {
  * sending one. This is a legitimate server signal (e.g. ConsumerTooSlow), not
  * malformed data — v2 only, since the v1 wire has no error frames.
  */
-export class XrpcSubscriptionError extends Error {
-  readonly error: string
+export class XrpcSubscriptionError extends LexError {
   constructor(error: string, message: string) {
-    super(message)
+    super(error, message)
     this.name = 'XrpcSubscriptionError'
-    this.error = error
   }
 }

--- a/packages/jetstream/src/errors.ts
+++ b/packages/jetstream/src/errors.ts
@@ -4,3 +4,18 @@ export class MalformedError extends Error {
     this.name = 'MalformedError'
   }
 }
+
+/**
+ * A terminal error frame on the v2 subscription
+ * (`{"$type":"error","error":…,"message":…}`). The server closes right after
+ * sending one. This is a legitimate server signal (e.g. ConsumerTooSlow), not
+ * malformed data — v2 only, since the v1 wire has no error frames.
+ */
+export class XrpcSubscriptionError extends Error {
+  readonly error: string
+  constructor(error: string, message: string) {
+    super(message)
+    this.name = 'XrpcSubscriptionError'
+    this.error = error
+  }
+}

--- a/packages/jetstream/src/event.ts
+++ b/packages/jetstream/src/event.ts
@@ -7,20 +7,39 @@ import {
   type RecordKeyString,
   type TidString,
 } from '@atproto/lex'
+import { type RawRecord, type RawRecordJson } from './raw-record.js'
 
 export type Operation = 'create' | 'update' | 'delete'
-export type Kind = 'commit' | 'identity' | 'account'
+
+/** Event kinds on the v2 wire. */
+export type Kind = 'commit' | 'identity' | 'account' | 'sync'
+/** Event kinds on the frozen v1 wire — it never emits sync. */
+export type KindV1 = 'commit' | 'identity' | 'account'
 
 /**
- * The minimal envelope contract every event the SDK yields satisfies (v1: seq =
- * time_us). It is the only thing the cursor/dedup/batching/tracking machinery
- * needs.
+ * The minimal envelope the cursor/dedup/batching/tracking machinery needs. Both
+ * wires' events satisfy it, which is why that machinery is version-agnostic.
  */
 export interface SeqEvent {
   seq: number
 }
 
+/**
+ * The v2 envelope. `seq` is the cursor; `time` is the wire datetime passed
+ * through untouched — nothing re-encodes it.
+ */
 export interface EventBase {
+  did: DidString
+  seq: number
+  time: DatetimeString
+}
+
+/**
+ * The v1 envelope. v1's cursor IS its `time_us` field, so seq and timeUs are
+ * always the same value. Deliberately separate from EventBase: the wires
+ * disagree here and unifying them would mean converting one into the other.
+ */
+export interface EventBaseV1 {
   did: DidString
   seq: number
   timeUs: number
@@ -67,29 +86,59 @@ export interface Account {
   time?: DatetimeString
 }
 
+// The relay's #sync event, reduced to what a consumer can act on. The wire
+// carries `blocks` (the signed commit) too; we discard it. v2 only.
+export interface Sync {
+  did: DidString
+  rev: TidString
+  time?: DatetimeString
+}
+
 export type TypedEvent<R = unknown> =
   | (EventBase & { kind: 'commit'; commit: TypedCommit<R> })
   | (EventBase & { kind: 'identity'; identity: Identity })
   | (EventBase & { kind: 'account'; account: Account })
+  | (EventBase & { kind: 'sync'; sync: Sync })
+
+export type TypedEventV1<R = unknown> =
+  | (EventBaseV1 & { kind: 'commit'; commit: TypedCommit<R> })
+  | (EventBaseV1 & { kind: 'identity'; identity: Identity })
+  | (EventBaseV1 & { kind: 'account'; account: Account })
 
 export interface EventBatch<E> {
   events: E[]
   lastCursor: number
 }
 
-export interface RawPutCommitV1 {
+/**
+ * A put commit's record in its wire representation. Identical on both wires
+ * today. The generic has one arm now; snapshot support widens RawRecord to
+ * include DAG-CBOR bytes, and this parameter is how each mode narrows to the
+ * arm it yields.
+ */
+export interface RawPutCommit<T extends RawRecord = RawRecord> {
   operation: 'create' | 'update'
   collection: NsidString
   rkey: RecordKeyString
   rev: TidString
   cid: CidString
-  record: unknown // v1 wire carries parsed JSON; no canonical CBOR exists
+  record: T
 }
-export type RawCommitV1 = RawPutCommitV1 | DeleteCommit
-export type RawEventV1 =
-  | (EventBase & { kind: 'commit'; commit: RawCommitV1 })
+export type RawCommit<T extends RawRecord = RawRecord> =
+  RawPutCommit<T> | DeleteCommit
+
+/** A v2 live or archive event. */
+export type RawEvent<T extends RawRecord = RawRecord> =
+  | (EventBase & { kind: 'commit'; commit: RawCommit<T> })
   | (EventBase & { kind: 'identity'; identity: Identity })
   | (EventBase & { kind: 'account'; account: Account })
+  | (EventBase & { kind: 'sync'; sync: Sync })
+
+/** A v1 live event. Not assignable to RawEvent — the envelopes differ. */
+export type RawEventV1 =
+  | (EventBaseV1 & { kind: 'commit'; commit: RawCommit<RawRecordJson> })
+  | (EventBaseV1 & { kind: 'identity'; identity: Identity })
+  | (EventBaseV1 & { kind: 'account'; account: Account })
 
 /**
  * Default per-key serialization key for concurrent indexers: the record path

--- a/packages/jetstream/src/event.ts
+++ b/packages/jetstream/src/event.ts
@@ -6,7 +6,7 @@ import {
   type NsidString,
   type RecordKeyString,
   type TidString,
-} from '@atproto/lex-schema'
+} from '@atproto/lex'
 
 export type Operation = 'create' | 'update' | 'delete'
 export type Kind = 'commit' | 'identity' | 'account'

--- a/packages/jetstream/src/event.ts
+++ b/packages/jetstream/src/event.ts
@@ -6,6 +6,7 @@ import {
   type NsidString,
   type RecordKeyString,
   type TidString,
+  type TypedLexMap,
 } from '@atproto/lex'
 import { type RawRecord, type RawRecordJson } from './raw-record.js'
 
@@ -45,17 +46,10 @@ export interface EventBaseV1 {
   timeUs: number
 }
 
-/**
- * The record shape earned by collection filtering alone (no schema
- * validation): the server routed the event by collection, and a record's
- * $type is its collection NSID — we trust that rather than re-checking at
- * runtime. TType carries the collection literal when the filter provides one.
- */
-export type UnvalidatedRecord<TType extends string = string> = {
-  $type: TType
-} & Record<string, unknown>
-
-export interface TypedPutCommit<R = unknown, C extends string = NsidString> {
+export interface TypedPutCommit<
+  R = TypedLexMap,
+  C extends string = NsidString,
+> {
   operation: 'create' | 'update'
   collection: C
   rkey: RecordKeyString
@@ -72,7 +66,7 @@ export interface DeleteCommit<C extends string = NsidString> {
   rev: TidString
 }
 
-export type TypedCommit<R = unknown> = TypedPutCommit<R> | DeleteCommit
+export type TypedCommit<R = TypedLexMap> = TypedPutCommit<R> | DeleteCommit
 
 export interface Identity {
   did: DidString
@@ -94,13 +88,13 @@ export interface Sync {
   time?: DatetimeString
 }
 
-export type TypedEvent<R = unknown> =
+export type TypedEvent<R = TypedLexMap> =
   | (EventBase & { kind: 'commit'; commit: TypedCommit<R> })
   | (EventBase & { kind: 'identity'; identity: Identity })
   | (EventBase & { kind: 'account'; account: Account })
   | (EventBase & { kind: 'sync'; sync: Sync })
 
-export type TypedEventV1<R = unknown> =
+export type TypedEventV1<R = TypedLexMap> =
   | (EventBaseV1 & { kind: 'commit'; commit: TypedCommit<R> })
   | (EventBaseV1 & { kind: 'identity'; identity: Identity })
   | (EventBaseV1 & { kind: 'account'; account: Account })

--- a/packages/jetstream/src/filter-types.ts
+++ b/packages/jetstream/src/filter-types.ts
@@ -4,8 +4,11 @@ import {
   type Account,
   type DeleteCommit,
   type EventBase,
+  type EventBaseV1,
   type Identity,
+  type Sync,
   type TypedEvent,
+  type TypedEventV1,
   type TypedPutCommit,
   type UnvalidatedRecord,
 } from './event.js'
@@ -47,7 +50,7 @@ export type TypedCommitFor<F extends CollectionFilter> = F extends string
         ? ValidatedCommit<S['$type'], InferOutput<S>>
         : never
 
-// The typed event union for a filter tuple. No filters (readonly []) means
+// The typed event union for a v2 filter tuple. No filters (readonly []) means
 // no narrowing was earned: plain TypedEvent. Non-commit kinds are identical
 // across all filters.
 export type TypedEventFor<F extends readonly CollectionFilter[]> =
@@ -56,3 +59,30 @@ export type TypedEventFor<F extends readonly CollectionFilter[]> =
     : | (EventBase & { kind: 'commit'; commit: TypedCommitFor<F[number]> })
       | (EventBase & { kind: 'identity'; identity: Identity })
       | (EventBase & { kind: 'account'; account: Account })
+      | (EventBase & { kind: 'sync'; sync: Sync })
+
+// The v1 equivalent: its own envelope, and no sync arm. Declared rather than
+// derived from TypedEventFor — the envelopes diverge, so an Exclude would not
+// express it.
+export type TypedEventForV1<F extends readonly CollectionFilter[]> =
+  F extends readonly []
+    ? TypedEventV1
+    : | (EventBaseV1 & { kind: 'commit'; commit: TypedCommitFor<F[number]> })
+      | (EventBaseV1 & { kind: 'identity'; identity: Identity })
+      | (EventBaseV1 & { kind: 'account'; account: Account })
+
+// Widest commit accepted by a live() implementation signature: collection is
+// `string` (not NsidString) so TypedCommitFor<F> is assignable for any filter
+// tuple, and record is unknown to cover validated and unvalidated alike.
+type WideCommit = TypedPutCommit<unknown, string> | DeleteCommit<string>
+
+export type WideTypedEvent =
+  | (EventBase & { kind: 'commit'; commit: WideCommit })
+  | (EventBase & { kind: 'identity'; identity: Identity })
+  | (EventBase & { kind: 'account'; account: Account })
+  | (EventBase & { kind: 'sync'; sync: Sync })
+
+export type WideTypedEventV1 =
+  | (EventBaseV1 & { kind: 'commit'; commit: WideCommit })
+  | (EventBaseV1 & { kind: 'identity'; identity: Identity })
+  | (EventBaseV1 & { kind: 'account'; account: Account })

--- a/packages/jetstream/src/filter-types.ts
+++ b/packages/jetstream/src/filter-types.ts
@@ -1,4 +1,4 @@
-import { type InferOutput, type RecordSchema } from '@atproto/lex-schema'
+import { type InferOutput, type RecordSchema } from '@atproto/lex'
 import { type CollectionFilter } from './engine/collections.js'
 import {
   type Account,

--- a/packages/jetstream/src/filter-types.ts
+++ b/packages/jetstream/src/filter-types.ts
@@ -1,4 +1,8 @@
-import { type InferOutput, type RecordSchema } from '@atproto/lex'
+import {
+  type InferOutput,
+  type RecordSchema,
+  type TypedLexMap,
+} from '@atproto/lex'
 import { type CollectionFilter } from './engine/collections.js'
 import {
   type Account,
@@ -10,7 +14,6 @@ import {
   type TypedEvent,
   type TypedEventV1,
   type TypedPutCommit,
-  type UnvalidatedRecord,
 } from './event.js'
 
 // Unwrap Main<S> = S | { main: S } to the schema itself.
@@ -28,10 +31,10 @@ type ValidatedCommit<C extends string, R> =
 // 'app.test.*' → `app.test.${string}`; literal NSIDs keep their literal;
 // non-literal string degrades to string.
 type StringFilterCommit<F extends string> = F extends `${infer P}.*`
-  ? UnvalidatedCommit<`${P}.${string}`, UnvalidatedRecord<`${P}.${string}`>>
+  ? UnvalidatedCommit<`${P}.${string}`, TypedLexMap<`${P}.${string}`>>
   : string extends F
-    ? UnvalidatedCommit<string, UnvalidatedRecord>
-    : UnvalidatedCommit<F, UnvalidatedRecord<F>>
+    ? UnvalidatedCommit<string, TypedLexMap>
+    : UnvalidatedCommit<F, TypedLexMap<F>>
 
 // The commit shape(s) contributed by ONE filter. Distributes over a union of
 // filters (F[number]) to build the correlated union: checking
@@ -40,7 +43,7 @@ export type TypedCommitFor<F extends CollectionFilter> = F extends string
   ? StringFilterCommit<F>
   : F extends { collection: infer M; validateRecord: false }
     ? MainOf<M> extends infer S extends RecordSchema
-      ? UnvalidatedCommit<S['$type'], UnvalidatedRecord<S['$type']>>
+      ? UnvalidatedCommit<S['$type'], TypedLexMap<S['$type']>>
       : never
     : F extends { collection: infer M }
       ? MainOf<M> extends infer S extends RecordSchema

--- a/packages/jetstream/src/filter-types.ts
+++ b/packages/jetstream/src/filter-types.ts
@@ -76,6 +76,12 @@ export type TypedEventV1For<F extends readonly CollectionFilter[]> =
 
 // The widest event a live() implementation signature accepts: CollectionFilter[]
 // (not a specific tuple) makes TypedCommitFor<F[number]> assignable for any
-// filter tuple a caller might pass.
-export type WideTypedEvent = TypedEventFor<CollectionFilter[]>
-export type WideTypedEventV1 = TypedEventV1For<CollectionFilter[]>
+// concrete filter tuple a caller might pass. The empty-tuple case (no filter
+// at all) is unioned in separately: TypedEventFor<readonly []> is plain
+// TypedEvent, whose default (untied to any collection) record type is
+// TypedLexMap<string> — narrower-branded than the CollectionFilter[] arms'
+// TypedLexMap<NsidString>-and-friends, so it is not covered by
+// TypedEventFor<CollectionFilter[]> alone.
+export type WideTypedEvent = TypedEventFor<CollectionFilter[]> | TypedEvent
+export type WideTypedEventV1 =
+  TypedEventV1For<CollectionFilter[]> | TypedEventV1

--- a/packages/jetstream/src/filter-types.ts
+++ b/packages/jetstream/src/filter-types.ts
@@ -67,25 +67,15 @@ export type TypedEventFor<F extends readonly CollectionFilter[]> =
 // The v1 equivalent: its own envelope, and no sync arm. Declared rather than
 // derived from TypedEventFor — the envelopes diverge, so an Exclude would not
 // express it.
-export type TypedEventForV1<F extends readonly CollectionFilter[]> =
+export type TypedEventV1For<F extends readonly CollectionFilter[]> =
   F extends readonly []
     ? TypedEventV1
     : | (EventBaseV1 & { kind: 'commit'; commit: TypedCommitFor<F[number]> })
       | (EventBaseV1 & { kind: 'identity'; identity: Identity })
       | (EventBaseV1 & { kind: 'account'; account: Account })
 
-// Widest commit accepted by a live() implementation signature: collection is
-// `string` (not NsidString) so TypedCommitFor<F> is assignable for any filter
-// tuple, and record is unknown to cover validated and unvalidated alike.
-type WideCommit = TypedPutCommit<unknown, string> | DeleteCommit<string>
-
-export type WideTypedEvent =
-  | (EventBase & { kind: 'commit'; commit: WideCommit })
-  | (EventBase & { kind: 'identity'; identity: Identity })
-  | (EventBase & { kind: 'account'; account: Account })
-  | (EventBase & { kind: 'sync'; sync: Sync })
-
-export type WideTypedEventV1 =
-  | (EventBaseV1 & { kind: 'commit'; commit: WideCommit })
-  | (EventBaseV1 & { kind: 'identity'; identity: Identity })
-  | (EventBaseV1 & { kind: 'account'; account: Account })
+// The widest event a live() implementation signature accepts: CollectionFilter[]
+// (not a specific tuple) makes TypedCommitFor<F[number]> assignable for any
+// filter tuple a caller might pass.
+export type WideTypedEvent = TypedEventFor<CollectionFilter[]>
+export type WideTypedEventV1 = TypedEventV1For<CollectionFilter[]>

--- a/packages/jetstream/src/index.ts
+++ b/packages/jetstream/src/index.ts
@@ -1,5 +1,7 @@
 export { Jetstream } from './jetstream.js'
 export type { JetstreamOpts, LiveOpts } from './jetstream.js'
+export { JetstreamV1 } from './jetstream-v1.js'
+export type { LiveV1Opts } from './jetstream-v1.js'
 export { typedEventFromRaw } from './decode-typed.js'
 export { parseRawRecord } from './raw-record.js'
 export type { RawRecord, RawRecordJson } from './raw-record.js'

--- a/packages/jetstream/src/index.ts
+++ b/packages/jetstream/src/index.ts
@@ -15,17 +15,28 @@ export type {
 export type {
   Account,
   DeleteCommit,
+  EventBase,
+  EventBaseV1,
   EventBatch,
   Identity,
-  RawCommitV1,
+  Kind,
+  KindV1,
+  RawCommit,
+  RawEvent,
   RawEventV1,
-  RawPutCommitV1,
+  RawPutCommit,
   SeqEvent,
+  Sync,
   TypedCommit,
   TypedEvent,
+  TypedEventV1,
   UnvalidatedRecord,
 } from './event.js'
-export type { TypedCommitFor, TypedEventFor } from './filter-types.js'
+export type {
+  TypedCommitFor,
+  TypedEventFor,
+  TypedEventForV1,
+} from './filter-types.js'
 export { CommitTracker } from './execute/commit-tracker.js'
 export { type CursorStore, MemoryCursorStore } from './execute/cursor-store.js'
 export { LexIndexer } from './lex-indexer.js'

--- a/packages/jetstream/src/index.ts
+++ b/packages/jetstream/src/index.ts
@@ -1,6 +1,8 @@
 export { Jetstream } from './jetstream.js'
 export type { JetstreamOpts, LiveOpts } from './jetstream.js'
 export { typedEventFromRaw } from './decode-typed.js'
+export { parseRawRecord } from './raw-record.js'
+export type { RawRecord, RawRecordJson } from './raw-record.js'
 export { websocketTransport } from './live/transport.js'
 export type {
   LiveTransport,

--- a/packages/jetstream/src/index.ts
+++ b/packages/jetstream/src/index.ts
@@ -52,5 +52,5 @@ export type {
 export type { Ack, ConsumerContext, JetstreamConsumer } from './consumer.js'
 export { JetstreamRunner } from './runner.js'
 export type { RunnerLiveOpts } from './runner.js'
-export { MalformedError } from './errors.js'
+export { MalformedError, XrpcSubscriptionError } from './errors.js'
 export { RecordValidationError } from './shape.js'

--- a/packages/jetstream/src/index.ts
+++ b/packages/jetstream/src/index.ts
@@ -30,7 +30,6 @@ export type {
   TypedCommit,
   TypedEvent,
   TypedEventV1,
-  UnvalidatedRecord,
 } from './event.js'
 export type {
   TypedCommitFor,

--- a/packages/jetstream/src/index.ts
+++ b/packages/jetstream/src/index.ts
@@ -36,7 +36,7 @@ export type {
 export type {
   TypedCommitFor,
   TypedEventFor,
-  TypedEventForV1,
+  TypedEventV1For,
 } from './filter-types.js'
 export { CommitTracker } from './execute/commit-tracker.js'
 export { type CursorStore, MemoryCursorStore } from './execute/cursor-store.js'

--- a/packages/jetstream/src/index.ts
+++ b/packages/jetstream/src/index.ts
@@ -47,6 +47,7 @@ export type {
   IdentityEvent,
   LexIndexerOpts,
   PutEvent,
+  SyncEvent,
   ValidationErrorEvent,
 } from './lex-indexer.js'
 export type { Ack, ConsumerContext, JetstreamConsumer } from './consumer.js'

--- a/packages/jetstream/src/jetstream-v1.ts
+++ b/packages/jetstream/src/jetstream-v1.ts
@@ -49,7 +49,7 @@ export class JetstreamV1 {
   live(opts: LiveV1Opts & { raw: true }): AsyncGenerator<RawEventV1>
   live(opts: LiveV1Opts = {}): AsyncGenerator<RawEventV1 | WideTypedEventV1> {
     const { schemasByNsid } = parseCollectionFilters(opts.collections ?? [])
-    // The cast here is unrelated to rawBatchStream's overload (its call above
+    // The cast here is unrelated to rawBatchStream's overload (its call below
     // is already the honest v1-only type): shape() is version-generic, so its
     // declared return covers both wires' possible outputs and needs narrowing
     // to this class's v1-only union.

--- a/packages/jetstream/src/jetstream-v1.ts
+++ b/packages/jetstream/src/jetstream-v1.ts
@@ -5,7 +5,7 @@ import {
 } from './engine/collections.js'
 import { type RawEventV1 } from './event.js'
 import { type CursorStore } from './execute/cursor-store.js'
-import { type TypedEventForV1, type WideTypedEventV1 } from './filter-types.js'
+import { type TypedEventV1For, type WideTypedEventV1 } from './filter-types.js'
 import { type JetstreamOpts } from './jetstream.js'
 import { rawBatchStream } from './live/pipeline.js'
 import { type LiveTransport } from './live/transport.js'
@@ -45,10 +45,14 @@ export class JetstreamV1 {
 
   live<const F extends readonly CollectionFilter[] = readonly []>(
     opts?: LiveV1Opts<F> & { raw?: false },
-  ): AsyncGenerator<TypedEventForV1<F>>
+  ): AsyncGenerator<TypedEventV1For<F>>
   live(opts: LiveV1Opts & { raw: true }): AsyncGenerator<RawEventV1>
   live(opts: LiveV1Opts = {}): AsyncGenerator<RawEventV1 | WideTypedEventV1> {
     const { schemasByNsid } = parseCollectionFilters(opts.collections ?? [])
+    // The cast here is unrelated to rawBatchStream's overload (its call above
+    // is already the honest v1-only type): shape() is version-generic, so its
+    // declared return covers both wires' possible outputs and needs narrowing
+    // to this class's v1-only union.
     return shape(
       rawBatchStream(this.service, opts, 1, this.opts.validateWire),
       { ...opts, validateWire: this.opts.validateWire },

--- a/packages/jetstream/src/jetstream-v1.ts
+++ b/packages/jetstream/src/jetstream-v1.ts
@@ -1,0 +1,59 @@
+import { type DidString } from '@atproto/lex'
+import {
+  type CollectionFilter,
+  parseCollectionFilters,
+} from './engine/collections.js'
+import { type RawEventV1 } from './event.js'
+import { type CursorStore } from './execute/cursor-store.js'
+import { type TypedEventForV1, type WideTypedEventV1 } from './filter-types.js'
+import { type JetstreamOpts } from './jetstream.js'
+import { rawBatchStream } from './live/pipeline.js'
+import { type LiveTransport } from './live/transport.js'
+import { shape } from './shape.js'
+
+/**
+ * Live options for a v1 instance. No `kinds`: the frozen v1 /subscribe wire has
+ * no kind filter, so the option cannot be honoured.
+ */
+export interface LiveV1Opts<
+  F extends readonly CollectionFilter[] = readonly CollectionFilter[],
+> {
+  collections?: F
+  dids?: DidString[]
+  cursor?: CursorStore
+  signal?: AbortSignal
+  onError?: (err: Error) => void
+  liveTransport?: LiveTransport
+  raw?: boolean
+}
+
+/**
+ * A Jetstream instance speaking the frozen v1 wire — what the public
+ * jetstream*.bsky.network hosts serve today. Live streaming only: v1 has no
+ * sealed archive, and its cursors are `time_us` values that are not portable
+ * to or from a v2 host.
+ */
+export class JetstreamV1 {
+  readonly service: string
+  readonly opts: JetstreamOpts
+
+  constructor(service: string | JetstreamOpts) {
+    const opts = typeof service === 'string' ? { service } : service
+    this.service = opts.service
+    this.opts = opts
+  }
+
+  live<const F extends readonly CollectionFilter[] = readonly []>(
+    opts?: LiveV1Opts<F> & { raw?: false },
+  ): AsyncGenerator<TypedEventForV1<F>>
+  live(opts: LiveV1Opts & { raw: true }): AsyncGenerator<RawEventV1>
+  live(opts: LiveV1Opts = {}): AsyncGenerator<RawEventV1 | WideTypedEventV1> {
+    const { schemasByNsid } = parseCollectionFilters(opts.collections ?? [])
+    return shape(
+      rawBatchStream(this.service, opts, 1, this.opts.validateWire),
+      { ...opts, validateWire: this.opts.validateWire },
+      schemasByNsid,
+      opts.onError,
+    ) as AsyncGenerator<RawEventV1 | WideTypedEventV1>
+  }
+}

--- a/packages/jetstream/src/jetstream.ts
+++ b/packages/jetstream/src/jetstream.ts
@@ -4,11 +4,12 @@ import {
   type CollectionFilter,
   parseCollectionFilters,
 } from './engine/collections.js'
-import { type EventBatch, type RawEventV1 } from './event.js'
+import { type EventBatch, type Kind, type RawEvent } from './event.js'
 import { type CursorStore } from './execute/cursor-store.js'
-import { type TypedEventForV1, type WideTypedEventV1 } from './filter-types.js'
+import { type TypedEventFor, type WideTypedEvent } from './filter-types.js'
 import { rawBatchStream } from './live/pipeline.js'
 import { type LiveTransport } from './live/transport.js'
+import { type RawRecordJson } from './raw-record.js'
 import { JetstreamRunner } from './runner.js'
 import { shape } from './shape.js'
 
@@ -29,6 +30,11 @@ export interface LiveOpts<
 > {
   collections?: F
   dids?: DidString[]
+  /**
+   * Event kinds to receive. Omitted means all kinds. The collections filter
+   * constrains only commits, so a commits-only stream needs kinds: ['commit'].
+   */
+  kinds?: Kind[]
   cursor?: CursorStore
   signal?: AbortSignal
   onError?: (err: Error) => void
@@ -48,20 +54,22 @@ export class Jetstream {
 
   live<const F extends readonly CollectionFilter[] = readonly []>(
     opts?: LiveOpts<F> & { raw?: false },
-  ): AsyncGenerator<TypedEventForV1<F>>
-  live(opts: LiveOpts & { raw: true }): AsyncGenerator<RawEventV1>
-  live(opts: LiveOpts = {}): AsyncGenerator<RawEventV1 | WideTypedEventV1> {
+  ): AsyncGenerator<TypedEventFor<F>>
+  live(opts: LiveOpts & { raw: true }): AsyncGenerator<RawEvent<RawRecordJson>>
+  live(
+    opts: LiveOpts = {},
+  ): AsyncGenerator<RawEvent<RawRecordJson> | WideTypedEvent> {
     const { schemasByNsid } = parseCollectionFilters(opts.collections ?? [])
     // shape() is version-generic (one implementation serves both wires); this
-    // Jetstream is v1-backed, so its output is honestly RawEventV1 |
-    // WideTypedEventV1 at runtime even though shape()'s declared return type
+    // Jetstream is v2-backed, so its output is honestly RawEvent<RawRecordJson>
+    // | WideTypedEvent at runtime even though shape()'s declared return type
     // covers both wires' possibilities.
     return shape(
       this.liveRawBatches(opts),
       { ...opts, validateWire: this.opts.validateWire },
       schemasByNsid,
       opts.onError,
-    ) as AsyncGenerator<RawEventV1 | WideTypedEventV1>
+    ) as AsyncGenerator<RawEvent<RawRecordJson> | WideTypedEvent>
   }
 
   runner(consumer: JetstreamConsumer): JetstreamRunner {
@@ -73,12 +81,14 @@ export class Jetstream {
   // buffering — live delivery stays realtime. EventBatch is used only as the
   // standard internal interface, looking ahead to v2 modes (snapshot/replay)
   // where batches carry real grouping.
-  liveRawBatches(opts: LiveOpts): AsyncGenerator<EventBatch<RawEventV1>> {
+  liveRawBatches(
+    opts: LiveOpts,
+  ): AsyncGenerator<EventBatch<RawEvent<RawRecordJson>>> {
     return rawBatchStream(
       this.service,
       opts,
-      1, // TEMPORARY: flipped to 2 in the next task
+      2,
       this.opts.validateWire,
-    ) as AsyncGenerator<EventBatch<RawEventV1>>
+    ) as AsyncGenerator<EventBatch<RawEvent<RawRecordJson>>>
   }
 }

--- a/packages/jetstream/src/jetstream.ts
+++ b/packages/jetstream/src/jetstream.ts
@@ -89,6 +89,7 @@ export class Jetstream {
       signal: opts.signal,
       onError: opts.onError,
       validateWire: this.opts.validateWire,
+      version: 1, // TEMPORARY: removed in the task that flips Jetstream to v2
     })) {
       yield { events: [ev], lastCursor: ev.seq }
     }

--- a/packages/jetstream/src/jetstream.ts
+++ b/packages/jetstream/src/jetstream.ts
@@ -7,7 +7,7 @@ import {
 import { type EventBatch, type RawEventV1 } from './event.js'
 import { type CursorStore } from './execute/cursor-store.js'
 import { type TypedEventForV1, type WideTypedEventV1 } from './filter-types.js'
-import { liveEvents } from './live/source.js'
+import { rawBatchStream } from './live/pipeline.js'
 import { type LiveTransport } from './live/transport.js'
 import { JetstreamRunner } from './runner.js'
 import { shape } from './shape.js'
@@ -73,25 +73,12 @@ export class Jetstream {
   // buffering — live delivery stays realtime. EventBatch is used only as the
   // standard internal interface, looking ahead to v2 modes (snapshot/replay)
   // where batches carry real grouping.
-  async *liveRawBatches(
-    opts: LiveOpts,
-  ): AsyncGenerator<EventBatch<RawEventV1>> {
-    const host = this.service
-    const { nsids } = parseCollectionFilters(opts.collections ?? [])
-    const start = await opts.cursor?.load()
-    for await (const ev of liveEvents({
-      host,
-      collections: nsids,
-      dids: opts.dids,
-      cursor: start,
-      dedupFloor: start, // a resume cursor is also the dedup floor
-      transport: opts.liveTransport,
-      signal: opts.signal,
-      onError: opts.onError,
-      validateWire: this.opts.validateWire,
-      version: 1, // TEMPORARY: removed in the task that flips Jetstream to v2
-    })) {
-      yield { events: [ev], lastCursor: ev.seq }
-    }
+  liveRawBatches(opts: LiveOpts): AsyncGenerator<EventBatch<RawEventV1>> {
+    return rawBatchStream(
+      this.service,
+      opts,
+      1, // TEMPORARY: flipped to 2 in the next task
+      this.opts.validateWire,
+    ) as AsyncGenerator<EventBatch<RawEventV1>>
   }
 }

--- a/packages/jetstream/src/jetstream.ts
+++ b/packages/jetstream/src/jetstream.ts
@@ -18,9 +18,19 @@ export interface JetstreamOpts {
   /**
    * Strict wire validation. By default the branded string types on events are
    * optimistic — "the server said so." With validateWire: true, every decode
-   * boundary checks its wire schema (lex-schema format validators); any
-   * violation — including otherwise-skipped malformed frames — throws
-   * MalformedError, fatal in every mode.
+   * boundary checks its wire schema (lex-schema format validators).
+   *
+   * The two boundaries this touches fail differently. A wire-FRAME violation
+   * (a malformed envelope, otherwise silently skipped) throws MalformedError,
+   * fatal in every mode. A RECORD-conversion violation — a put commit's
+   * record failing to convert to lex data or failing schema validation — is
+   * never fatal: it is reported per record (via the per-call `onError`, or
+   * `LexIndexer`'s `onValidationError`) and that one event is skipped.
+   *
+   * Note: `runner()`'s stream (`LexIndexer` over `liveRawBatches()`) gets
+   * strict wire decode from this flag, but never strict record conversion —
+   * `LexIndexer.run` calls `typedEventFromRaw` with no `opts`, so record
+   * conversion there is always non-strict regardless of `validateWire`.
    */
   validateWire?: boolean
 }
@@ -42,6 +52,12 @@ export interface LiveOpts<
   raw?: boolean
 }
 
+/**
+ * A Jetstream instance speaking the v2 wire
+ * (`/xrpc/network.bsky.jetstream.subscribeEvents`). Live streaming via
+ * `live()`, plus `runner()` for indexer-driven consumption. Cursors are `seq`
+ * values — not portable to or from a v1 host (see `JetstreamV1`).
+ */
 export class Jetstream {
   readonly service: string
   readonly opts: JetstreamOpts

--- a/packages/jetstream/src/jetstream.ts
+++ b/packages/jetstream/src/jetstream.ts
@@ -1,4 +1,4 @@
-import { type DidString } from '@atproto/lex-schema'
+import { type DidString } from '@atproto/lex'
 import { type JetstreamConsumer } from './consumer.js'
 import {
   type CollectionFilter,

--- a/packages/jetstream/src/jetstream.ts
+++ b/packages/jetstream/src/jetstream.ts
@@ -4,17 +4,9 @@ import {
   type CollectionFilter,
   parseCollectionFilters,
 } from './engine/collections.js'
-import {
-  type Account,
-  type DeleteCommit,
-  type EventBase,
-  type EventBatch,
-  type Identity,
-  type RawEventV1,
-  type TypedPutCommit,
-} from './event.js'
+import { type EventBatch, type RawEventV1 } from './event.js'
 import { type CursorStore } from './execute/cursor-store.js'
-import { type TypedEventFor } from './filter-types.js'
+import { type TypedEventForV1, type WideTypedEventV1 } from './filter-types.js'
 import { liveEvents } from './live/source.js'
 import { type LiveTransport } from './live/transport.js'
 import { JetstreamRunner } from './runner.js'
@@ -44,17 +36,6 @@ export interface LiveOpts<
   raw?: boolean
 }
 
-// Widest typed event accepted by the impl signature: collection is `string`
-// (not narrowed to NsidString) so TypedEventFor<F> is assignable here for any
-// CollectionFilter tuple F. record: unknown covers validated and unvalidated.
-type WideTypedEvent =
-  | (EventBase & {
-      kind: 'commit'
-      commit: TypedPutCommit<unknown, string> | DeleteCommit<string>
-    })
-  | (EventBase & { kind: 'identity'; identity: Identity })
-  | (EventBase & { kind: 'account'; account: Account })
-
 export class Jetstream {
   readonly service: string
   readonly opts: JetstreamOpts
@@ -67,11 +48,20 @@ export class Jetstream {
 
   live<const F extends readonly CollectionFilter[] = readonly []>(
     opts?: LiveOpts<F> & { raw?: false },
-  ): AsyncGenerator<TypedEventFor<F>>
+  ): AsyncGenerator<TypedEventForV1<F>>
   live(opts: LiveOpts & { raw: true }): AsyncGenerator<RawEventV1>
-  live(opts: LiveOpts = {}): AsyncGenerator<RawEventV1 | WideTypedEvent> {
+  live(opts: LiveOpts = {}): AsyncGenerator<RawEventV1 | WideTypedEventV1> {
     const { schemasByNsid } = parseCollectionFilters(opts.collections ?? [])
-    return shape(this.liveRawBatches(opts), opts, schemasByNsid, opts.onError)
+    // shape() is version-generic (one implementation serves both wires); this
+    // Jetstream is v1-backed, so its output is honestly RawEventV1 |
+    // WideTypedEventV1 at runtime even though shape()'s declared return type
+    // covers both wires' possibilities.
+    return shape(
+      this.liveRawBatches(opts),
+      opts,
+      schemasByNsid,
+      opts.onError,
+    ) as AsyncGenerator<RawEventV1 | WideTypedEventV1>
   }
 
   runner(consumer: JetstreamConsumer): JetstreamRunner {

--- a/packages/jetstream/src/jetstream.ts
+++ b/packages/jetstream/src/jetstream.ts
@@ -48,6 +48,12 @@ export interface LiveOpts<
   cursor?: CursorStore
   signal?: AbortSignal
   onError?: (err: Error) => void
+  /**
+   * Seq-less server advisories (`#info` frames, e.g. `OutdatedCursor`). Not
+   * an error: when omitted, an advisory is dropped silently rather than
+   * routed to onError.
+   */
+  onInfo?: (info: { name: string; message?: string }) => void
   liveTransport?: LiveTransport
   raw?: boolean
 }
@@ -100,11 +106,6 @@ export class Jetstream {
   liveRawBatches(
     opts: LiveOpts,
   ): AsyncGenerator<EventBatch<RawEvent<RawRecordJson>>> {
-    return rawBatchStream(
-      this.service,
-      opts,
-      2,
-      this.opts.validateWire,
-    ) as AsyncGenerator<EventBatch<RawEvent<RawRecordJson>>>
+    return rawBatchStream(this.service, opts, 2, this.opts.validateWire)
   }
 }

--- a/packages/jetstream/src/jetstream.ts
+++ b/packages/jetstream/src/jetstream.ts
@@ -58,7 +58,7 @@ export class Jetstream {
     // covers both wires' possibilities.
     return shape(
       this.liveRawBatches(opts),
-      opts,
+      { ...opts, validateWire: this.opts.validateWire },
       schemasByNsid,
       opts.onError,
     ) as AsyncGenerator<RawEventV1 | WideTypedEventV1>

--- a/packages/jetstream/src/lex-indexer.ts
+++ b/packages/jetstream/src/lex-indexer.ts
@@ -18,7 +18,7 @@ import { typedEventFromRaw } from './decode-typed.js'
 import { type CollectionFilter } from './engine/collections.js'
 import {
   type EventBatch,
-  type RawEventV1,
+  type RawEvent,
   type UnvalidatedRecord,
 } from './event.js'
 import { eventUri } from './event.js'
@@ -88,7 +88,7 @@ export interface CommitHandlers<R> {
 
 export interface LexIndexerOpts {
   concurrency?: number
-  keyOf?: (evt: RawEventV1) => string
+  keyOf?: (evt: RawEvent) => string
 }
 
 const isThenable = (v: unknown): v is PromiseLike<unknown> =>
@@ -132,7 +132,7 @@ interface AnyCommitHandlers {
 
 export class LexIndexer implements JetstreamConsumer {
   readonly concurrency: number
-  readonly #keyOf: ((evt: RawEventV1) => string) | undefined
+  readonly #keyOf: ((evt: RawEvent) => string) | undefined
   readonly #collections = new Map<NsidString, AnyCommitHandlers>()
   #identityHandler:
     | ((e: IdentityEvent, ctx: HandlerContext) => unknown | Promise<unknown>)
@@ -243,11 +243,11 @@ export class LexIndexer implements JetstreamConsumer {
   }
 
   async run(
-    stream: AsyncIterable<EventBatch<RawEventV1>>,
+    stream: AsyncIterable<EventBatch<RawEvent>>,
     ctx: ConsumerContext,
   ): Promise<void> {
     const concurrency = Math.max(1, this.concurrency)
-    const keyOf = this.#keyOf ?? ((evt: RawEventV1) => eventUri(evt))
+    const keyOf = this.#keyOf ?? ((evt: RawEvent) => eventUri(evt))
     // schemasByNsid drives typedEventFromRaw's validation; a collection
     // registered with validateRecord: false is deliberately OMITTED so its
     // records skip schema.safeValidate (routing is unaffected — handlers are
@@ -297,7 +297,7 @@ export class LexIndexer implements JetstreamConsumer {
     // PERF: plain function (not async) — a sync user handler completes without
     // any promise allocation; the CALLER inspects the return for a thenable.
     // Each branch returns the handler's result directly (may be a thenable).
-    const handle = (evt: RawEventV1): unknown => {
+    const handle = (evt: RawEvent): unknown => {
       if (evt.kind === 'identity') {
         if (this.#identityHandler) {
           return this.#identityHandler(
@@ -419,7 +419,7 @@ export class LexIndexer implements JetstreamConsumer {
     // stopped-skip passes skipAck=true so the slot is released WITHOUT acking
     // (acking a skipped event would advance the watermark past unprocessed
     // events). Always releases the slot exactly once.
-    const settle = (evt: RawEventV1, err: unknown, skipAck = false): void => {
+    const settle = (evt: RawEvent, err: unknown, skipAck = false): void => {
       if (err === undefined) {
         if (!skipAck) ctx.ack(evt)
       } else {
@@ -437,7 +437,7 @@ export class LexIndexer implements JetstreamConsumer {
     // when a tail exists, acquire/release pairing (settle runs once per
     // dispatched event), fail-fast without acking the failed event. The async
     // fallback below is the original chain semantics.
-    const dispatch = (evt: RawEventV1): void => {
+    const dispatch = (evt: RawEvent): void => {
       // NOTE: keyOf is deliberately NOT guarded — a key-computation failure is
       // an implementer bug (broken custom keyOf) and should throw hard out of
       // run() rather than be settled like a handler error. The default

--- a/packages/jetstream/src/lex-indexer.ts
+++ b/packages/jetstream/src/lex-indexer.ts
@@ -52,7 +52,8 @@ export type DelEvent = {
 }
 // Same flat shape as PutEvent but carries the decode/validation `error` instead
 // of a decoded `record`. Routed here (not to `put`) when a create/update record
-// fails to schema-validate, so `put`'s `record` is always a valid decoded R.
+// fails to convert (e.g. missing $type) or fails to schema-validate, so
+// `put`'s `record` is always a valid decoded R.
 export type ValidationErrorEvent = {
   did: DidString
   seq: number
@@ -355,8 +356,9 @@ export class LexIndexer implements JetstreamConsumer {
       if (typed.kind !== 'commit' || typed.commit.operation === 'delete')
         return undefined
       if (typed.commit.validationError !== undefined) {
-        // Invalid record: fails schema-validation. Never reaches put; route to
-        // the optional handler, otherwise ack-and-skip.
+        // Invalid record: failed conversion (e.g. missing $type) or
+        // schema-validation. Never reaches put; route to the optional
+        // handler, otherwise ack-and-skip.
         if (this.#validationErrorHandler) {
           const did = typed.did
           const tc = typed.commit

--- a/packages/jetstream/src/lex-indexer.ts
+++ b/packages/jetstream/src/lex-indexer.ts
@@ -10,17 +10,14 @@ import {
   type RecordKeyString,
   type RecordSchema,
   type TidString,
+  type TypedLexMap,
   atUri,
   getMain,
 } from '@atproto/lex'
 import { type ConsumerContext, type JetstreamConsumer } from './consumer.js'
 import { typedEventFromRaw } from './decode-typed.js'
 import { type CollectionFilter } from './engine/collections.js'
-import {
-  type EventBatch,
-  type RawEvent,
-  type UnvalidatedRecord,
-} from './event.js'
+import { type EventBatch, type RawEvent } from './event.js'
 import { eventUri } from './event.js'
 
 // Shared per-run context handed to every handler as the second arg. Allocated
@@ -170,11 +167,11 @@ export class LexIndexer implements JetstreamConsumer {
     validateRecord?: true
   }): this
   // Options form, non-validating. The literal `false` selects the
-  // UnvalidatedRecord handler typing: no runtime record checks — the $type
-  // floor is trusted from the server's collection routing, not verified.
+  // TypedLexMap handler typing: no schema checks — only the $type floor
+  // (already enforced by record conversion) is guaranteed.
   commit<S extends RecordSchema>(opts: {
     collection: Main<S>
-    handlers: CommitHandlers<UnvalidatedRecord<S['$type']>>
+    handlers: CommitHandlers<TypedLexMap<S['$type']>>
     validateRecord: false
   }): this
   commit<S extends RecordSchema>(

--- a/packages/jetstream/src/lex-indexer.ts
+++ b/packages/jetstream/src/lex-indexer.ts
@@ -17,7 +17,7 @@ import {
 import { type ConsumerContext, type JetstreamConsumer } from './consumer.js'
 import { typedEventFromRaw } from './decode-typed.js'
 import { type CollectionFilter } from './engine/collections.js'
-import { type EventBatch, type RawEvent } from './event.js'
+import { type EventBatch, type Kind, type RawEvent } from './event.js'
 import { eventUri } from './event.js'
 
 // Shared per-run context handed to every handler as the second arg. Allocated
@@ -161,6 +161,20 @@ export class LexIndexer implements JetstreamConsumer {
 
   get collections(): CollectionFilter[] {
     return [...this.#collections.keys()]
+  }
+
+  // Derived from registrations, like `collections`. onValidationError is
+  // commit-related but implies nothing on its own — it only ever fires for a
+  // collection already registered via commit(). Nothing registered must
+  // return undefined, not []: an empty array is still a concrete kinds list
+  // to a caller reading the type, and undefined is the honest "no filter."
+  get kinds(): Kind[] | undefined {
+    const kinds: Kind[] = []
+    if (this.#collections.size > 0) kinds.push('commit')
+    if (this.#identityHandler) kinds.push('identity')
+    if (this.#accountHandler) kinds.push('account')
+    if (this.#syncHandler) kinds.push('sync')
+    return kinds.length > 0 ? kinds : undefined
   }
 
   // Simple form: register a collection with schema-validated records

--- a/packages/jetstream/src/lex-indexer.ts
+++ b/packages/jetstream/src/lex-indexer.ts
@@ -12,7 +12,7 @@ import {
   type TidString,
   atUri,
   getMain,
-} from '@atproto/lex-schema'
+} from '@atproto/lex'
 import { type ConsumerContext, type JetstreamConsumer } from './consumer.js'
 import { typedEventFromRaw } from './decode-typed.js'
 import { type CollectionFilter } from './engine/collections.js'

--- a/packages/jetstream/src/lex-indexer.ts
+++ b/packages/jetstream/src/lex-indexer.ts
@@ -78,6 +78,12 @@ export type AccountEvent = {
   time?: DatetimeString
   seq: number
 }
+export type SyncEvent = {
+  did: DidString
+  rev: TidString
+  time?: DatetimeString
+  seq: number
+}
 
 export interface CommitHandlers<R> {
   put?: (e: PutEvent<R>, ctx: HandlerContext) => unknown | Promise<unknown>
@@ -137,6 +143,9 @@ export class LexIndexer implements JetstreamConsumer {
     | undefined
   #accountHandler:
     | ((e: AccountEvent, ctx: HandlerContext) => unknown | Promise<unknown>)
+    | undefined
+  #syncHandler:
+    | ((e: SyncEvent, ctx: HandlerContext) => unknown | Promise<unknown>)
     | undefined
   #validationErrorHandler:
     | ((
@@ -230,6 +239,13 @@ export class LexIndexer implements JetstreamConsumer {
     return this
   }
 
+  sync(
+    fn: (e: SyncEvent, ctx: HandlerContext) => unknown | Promise<unknown>,
+  ): this {
+    this.#syncHandler = fn
+    return this
+  }
+
   onValidationError(
     fn: (
       e: ValidationErrorEvent,
@@ -318,6 +334,20 @@ export class LexIndexer implements JetstreamConsumer {
               active: evt.account.active,
               status: evt.account.status,
               time: evt.account.time,
+              seq: evt.seq,
+            },
+            hctx,
+          )
+        }
+        return undefined
+      }
+      if (evt.kind === 'sync') {
+        if (this.#syncHandler) {
+          return this.#syncHandler(
+            {
+              did: evt.sync.did,
+              rev: evt.sync.rev,
+              time: evt.sync.time,
               seq: evt.seq,
             },
             hctx,

--- a/packages/jetstream/src/live/decode-v1.ts
+++ b/packages/jetstream/src/live/decode-v1.ts
@@ -54,7 +54,10 @@ const wireV1AccountFrame = l.object({
   kind: l.literal('account'),
   account: l.object({
     did: l.string({ format: 'did' }),
-    active: l.optional(l.boolean()),
+    // Required: "active" vs "inactive" is the takedown/deactivation signal,
+    // so a missing value must throw rather than default to false (which
+    // downstream would read as "deactivated").
+    active: l.boolean(),
     status: l.optional(l.string()),
     time: l.optional(l.string({ format: 'datetime' })),
   }),
@@ -178,9 +181,19 @@ export function decodeLiveFrameV1(
         throw new MalformedError(
           `v1 account frame missing payload (seq=${seq})`,
         )
+      // The cast above is optimistic (non-strict mode skips validation), so
+      // `active` can still be absent or non-boolean here even though the
+      // schema marks it required. It is the takedown/deactivation signal, so
+      // defaulting a missing value to `false` would fabricate "deactivated"
+      // — throw instead, in every mode.
+      if (typeof f.account.active !== 'boolean') {
+        throw new MalformedError(
+          `v1 account event missing required field active (did=${did})`,
+        )
+      }
       const account: Account = {
         did: f.account.did || did,
-        active: f.account.active ?? false,
+        active: f.account.active,
         status: f.account.status,
         time: f.account.time,
       }

--- a/packages/jetstream/src/live/decode-v1.ts
+++ b/packages/jetstream/src/live/decode-v1.ts
@@ -1,6 +1,7 @@
 import { type InferOutput, l } from '@atproto/lex'
 import { MalformedError } from '../errors.js'
 import { type Account, type Identity, type RawEventV1 } from '../event.js'
+import { type RawRecordJson } from '../raw-record.js'
 import { SKIP_FRAME } from './decode.js'
 
 // v1 wire frame — the authoritative jetstream-legacy shape
@@ -156,7 +157,7 @@ export function decodeLiveFrameV1(
           rkey: c.rkey,
           rev: c.rev,
           cid: c.cid,
-          record: c.record,
+          record: c.record as RawRecordJson,
         },
       }
     }

--- a/packages/jetstream/src/live/decode-v1.ts
+++ b/packages/jetstream/src/live/decode-v1.ts
@@ -1,4 +1,4 @@
-import { type InferOutput, l } from '@atproto/lex-schema'
+import { type InferOutput, l } from '@atproto/lex'
 import { MalformedError } from '../errors.js'
 import { type Account, type Identity, type RawEventV1 } from '../event.js'
 import { SKIP_FRAME } from './decode.js'

--- a/packages/jetstream/src/live/decode.ts
+++ b/packages/jetstream/src/live/decode.ts
@@ -77,7 +77,10 @@ const wireAccountPayload = l.object({
   account: l.object({
     seq: l.optional(l.integer()),
     did: l.string({ format: 'did' }),
-    active: l.optional(l.boolean()),
+    // Required on subscribeRepos#account: "active" vs "inactive" is the
+    // takedown/deactivation signal, so a missing value must throw rather than
+    // default to false (which downstream would read as "deactivated").
+    active: l.boolean(),
     status: l.optional(l.string()),
     time: l.optional(l.string({ format: 'datetime' })),
   }),
@@ -125,6 +128,13 @@ export function decodeLiveFrame(
     parsed = JSON.parse(typeof data === 'string' ? data : td.decode(data))
   } catch (err) {
     throw new MalformedError('decode live frame', { cause: err })
+  }
+  // `null` is valid JSON but not a frame: without this guard, `peek.$type`
+  // below throws TypeError instead of MalformedError. Other non-object JSON
+  // (numbers, strings, arrays) reads `$type` as undefined and correctly falls
+  // out as SKIP_FRAME further down, so only null needs the explicit guard.
+  if (parsed === null) {
+    throw new MalformedError('live frame is null')
   }
 
   const peek = parsed as PeekFrame
@@ -195,9 +205,19 @@ export function decodeLiveFrame(
       return { ...base, kind: 'identity', identity }
     }
     case ACCOUNT: {
+      // The cast above is optimistic (non-strict mode skips validation), so
+      // `active` can still be absent or non-boolean here even though the
+      // schema marks it required. It is the takedown/deactivation signal, so
+      // defaulting a missing value to `false` would fabricate "deactivated"
+      // — throw instead, in every mode.
+      if (typeof p.account.active !== 'boolean') {
+        throw new MalformedError(
+          `live account event missing required field active (did=${did})`,
+        )
+      }
       const account: Account = {
         did: p.account.did || did,
-        active: Boolean(p.account.active),
+        active: p.account.active,
         status: p.account.status,
         time: p.account.time,
       }

--- a/packages/jetstream/src/live/decode.ts
+++ b/packages/jetstream/src/live/decode.ts
@@ -1,3 +1,258 @@
-// Shared decoder sentinel. The v2 live-frame decoder that accompanies it in
-// jetstream-sdk is not part of the v1-live subset; it lands here with v2.
+import { type InferOutput, l } from '@atproto/lex'
+import { MalformedError, XrpcSubscriptionError } from '../errors.js'
+import {
+  type Account,
+  type Identity,
+  type RawCommit,
+  type RawEvent,
+  type RawPutCommit,
+  type Sync,
+} from '../event.js'
+import { type RawRecordJson } from '../raw-record.js'
+
 export const SKIP_FRAME = Symbol('jetstream.skipFrame')
+
+const NSID = 'network.bsky.jetstream.subscribeEvents'
+const COMMIT = `${NSID}#commit`
+const IDENTITY = `${NSID}#identity`
+const ACCOUNT = `${NSID}#account`
+const SYNC = `${NSID}#sync`
+const INFO = `${NSID}#info`
+
+/**
+ * A seq-less advisory (today only `OutdatedCursor`, sent when a
+ * timestamp-domain cursor was clamped). Kept distinct from SKIP_FRAME so
+ * liveEvents can report it instead of discarding it silently.
+ */
+export interface LiveInfoFrame {
+  info: { name: string; message?: string }
+}
+
+// The v2 wire contract, declared once: payload types are inferred from these
+// schemas, the `as WirePayload` cast below is the single optimistic boundary,
+// and validateWire safeValidates the SAME schemas. These describe the
+// parsed-JSON shape, so `record` and `blocks` stay unknown() — conversion to
+// lex values belongs to the typed layer.
+const wireEnvelopeFields = {
+  seq: l.integer(),
+  did: l.string({ format: 'did' }),
+  time: l.string({ format: 'datetime' }),
+}
+
+// One object with optionals rather than a put/delete union: the lexicon models
+// operation as knownValues and marks record/cid absent for deletes. No
+// recordCbor — it is not on the v2 wire; lex objects are open, so an older
+// server's stray field is ignored rather than copied onto our commit.
+const wireCommitPayload = l.object({
+  ...wireEnvelopeFields,
+  $type: l.literal(COMMIT),
+  rev: l.string({ format: 'tid' }),
+  operation: l.union([
+    l.literal('create'),
+    l.literal('update'),
+    l.literal('delete'),
+  ]),
+  collection: l.string({ format: 'nsid' }),
+  rkey: l.string({ format: 'record-key' }),
+  cid: l.optional(l.string({ format: 'cid' })),
+  record: l.optional(l.unknown()),
+})
+
+// identity/account/sync wrap the relay's subscribeRepos event verbatim. The
+// wrapped seq/time are the relay's, so only the envelope's become our cursor.
+const wireIdentityPayload = l.object({
+  ...wireEnvelopeFields,
+  $type: l.literal(IDENTITY),
+  identity: l.object({
+    seq: l.optional(l.integer()),
+    did: l.string({ format: 'did' }),
+    handle: l.optional(l.string({ format: 'handle' })),
+    time: l.optional(l.string({ format: 'datetime' })),
+  }),
+})
+
+const wireAccountPayload = l.object({
+  ...wireEnvelopeFields,
+  $type: l.literal(ACCOUNT),
+  account: l.object({
+    seq: l.optional(l.integer()),
+    did: l.string({ format: 'did' }),
+    active: l.optional(l.boolean()),
+    status: l.optional(l.string()),
+    time: l.optional(l.string({ format: 'datetime' })),
+  }),
+})
+
+const wireSyncPayload = l.object({
+  ...wireEnvelopeFields,
+  $type: l.literal(SYNC),
+  sync: l.object({
+    seq: l.optional(l.integer()),
+    did: l.string({ format: 'did' }),
+    rev: l.string({ format: 'tid' }),
+    time: l.optional(l.string({ format: 'datetime' })),
+    blocks: l.optional(l.unknown()), // accepted and discarded
+  }),
+})
+
+const wirePayload = l.union([
+  wireCommitPayload,
+  wireIdentityPayload,
+  wireAccountPayload,
+  wireSyncPayload,
+])
+type WirePayload = InferOutput<typeof wirePayload>
+type WireCommitPayload = InferOutput<typeof wireCommitPayload>
+
+// Pre-discrimination peek: error frames, #info advisories, and unknown types
+// are handled before the WirePayload cast (l.union rejects unknown
+// discriminants by design).
+interface PeekFrame {
+  $type?: unknown
+  error?: unknown
+  message?: unknown
+  payload?: { $type?: unknown; name?: unknown; message?: unknown }
+}
+
+const td = new TextDecoder()
+
+export function decodeLiveFrame(
+  data: Uint8Array | string,
+  validateWire?: boolean,
+): RawEvent<RawRecordJson> | LiveInfoFrame | typeof SKIP_FRAME {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(typeof data === 'string' ? data : td.decode(data))
+  } catch (err) {
+    throw new MalformedError('decode live frame', { cause: err })
+  }
+
+  const peek = parsed as PeekFrame
+  if (peek.$type === 'error') {
+    const code = String(peek.error ?? 'unknown')
+    const message = peek.message == null ? '' : String(peek.message)
+    throw new XrpcSubscriptionError(code, message)
+  }
+  if (peek.$type !== 'message') return SKIP_FRAME
+
+  const payloadType = peek.payload?.$type
+  if (payloadType === INFO) {
+    // Legitimate wire, not malformed — accepted even in strict mode.
+    const name = peek.payload?.name
+    const message = peek.payload?.message
+    return {
+      info: {
+        name: name == null ? 'unknown' : String(name),
+        message: message == null ? undefined : String(message),
+      },
+    }
+  }
+  if (
+    payloadType !== COMMIT &&
+    payloadType !== IDENTITY &&
+    payloadType !== ACCOUNT &&
+    payloadType !== SYNC
+  ) {
+    return SKIP_FRAME // unknown payload type: skip for forward compatibility
+  }
+
+  // PERF: strict mode only — one predictable branch on the hot path.
+  if (validateWire) {
+    const result = wirePayload.safeValidate(peek.payload)
+    if (!result.success) {
+      throw new MalformedError('wire validation failed', {
+        cause: result.reason,
+      })
+    }
+  }
+  const p = (parsed as { payload: WirePayload }).payload // optimistic boundary
+
+  // seq IS the cursor (dedup, resume, watermark), so it is checked in every
+  // mode. v2 seqs are 1-based: seq <= 0 means a missing or invalid required
+  // field that the dedup floor would otherwise swallow silently.
+  const seq = p.seq
+  if (!Number.isSafeInteger(seq) || seq <= 0) {
+    throw new MalformedError(
+      `live seq is not a positive safe integer (got ${String(seq)})`,
+    )
+  }
+  const did = p.did
+  // `time` passes through as a branded string, like did/collection/rkey: the
+  // v2 envelope carries it verbatim and nothing re-encodes it. validateWire
+  // format-checks it via the wire schema.
+  const time = p.time
+  const base = { did, seq, time }
+
+  switch (p.$type) {
+    case COMMIT:
+      return { ...base, kind: 'commit', commit: liveCommit(p) }
+    case IDENTITY: {
+      const identity: Identity = {
+        did: p.identity.did || did,
+        handle: p.identity.handle,
+        time: p.identity.time,
+      }
+      return { ...base, kind: 'identity', identity }
+    }
+    case ACCOUNT: {
+      const account: Account = {
+        did: p.account.did || did,
+        active: Boolean(p.account.active),
+        status: p.account.status,
+        time: p.account.time,
+      }
+      return { ...base, kind: 'account', account }
+    }
+    case SYNC: {
+      const sync: Sync = {
+        did: p.sync.did || did,
+        rev: p.sync.rev,
+        time: p.sync.time,
+      }
+      return { ...base, kind: 'sync', sync }
+    }
+  }
+}
+
+function liveCommit(p: WireCommitPayload): RawCommit<RawRecordJson> {
+  // Widen to string: the cast above is optimistic, so garbage flows here in
+  // default mode.
+  const op: string = p.operation
+  // Deliberately stricter than the lexicon's knownValues: RawCommit has no
+  // field to hold an unrecognized operation's data, so throwing beats
+  // misclassifying it as one of the three we know.
+  if (op !== 'create' && op !== 'update' && op !== 'delete') {
+    throw new MalformedError(
+      `unknown live commit operation ${JSON.stringify(op)}`,
+    )
+  }
+  if (op === 'delete') {
+    return {
+      operation: 'delete',
+      collection: p.collection,
+      rkey: p.rkey,
+      rev: p.rev,
+    }
+  }
+  // Both are required on a put by the lexicon, so absence is a contract
+  // violation rather than something to default.
+  if (p.record === undefined) {
+    throw new MalformedError(
+      `live ${op} commit missing record (collection=${p.collection} rkey=${p.rkey})`,
+    )
+  }
+  if (p.cid === undefined) {
+    throw new MalformedError(
+      `live ${op} commit missing cid (collection=${p.collection} rkey=${p.rkey})`,
+    )
+  }
+  const commit: RawPutCommit<RawRecordJson> = {
+    operation: op,
+    collection: p.collection,
+    rkey: p.rkey,
+    rev: p.rev,
+    cid: p.cid,
+    record: p.record as RawRecordJson,
+  }
+  return commit
+}

--- a/packages/jetstream/src/live/pipeline.ts
+++ b/packages/jetstream/src/live/pipeline.ts
@@ -1,0 +1,63 @@
+import { type DidString } from '@atproto/lex'
+import {
+  type CollectionFilter,
+  parseCollectionFilters,
+} from '../engine/collections.js'
+import {
+  type EventBatch,
+  type Kind,
+  type RawEvent,
+  type RawEventV1,
+} from '../event.js'
+import { type CursorStore } from '../execute/cursor-store.js'
+import { type RawRecordJson } from '../raw-record.js'
+import { liveEvents } from './source.js'
+import { type LiveTransport } from './transport.js'
+
+export interface LiveStreamOpts {
+  collections?: readonly CollectionFilter[]
+  dids?: DidString[]
+  kinds?: Kind[]
+  cursor?: CursorStore
+  signal?: AbortSignal
+  onError?: (err: Error) => void
+  liveTransport?: LiveTransport
+}
+
+/**
+ * The raw batch stream both classes build on. Each event becomes a trivial
+ * single-event batch with no buffering, so live delivery stays realtime;
+ * EventBatch is the internal seam unit that snapshot and replay will fill with
+ * real grouping.
+ */
+export async function* rawBatchStream(
+  host: string,
+  opts: LiveStreamOpts,
+  version: 1 | 2,
+  validateWire?: boolean,
+): AsyncGenerator<EventBatch<RawEventV1 | RawEvent<RawRecordJson>>> {
+  const { nsids } = parseCollectionFilters(opts.collections ?? [])
+  const start = await opts.cursor?.load()
+  const common = {
+    host,
+    collections: nsids,
+    dids: opts.dids,
+    kinds: opts.kinds,
+    cursor: start,
+    dedupFloor: start, // a resume cursor is also the dedup floor
+    transport: opts.liveTransport,
+    signal: opts.signal,
+    onError: opts.onError,
+    validateWire,
+  }
+  // Branch on a literal version so each call selects the right liveEvents
+  // overload — the envelopes differ, so a non-literal `version` would type the
+  // v1 stream as v2.
+  const events =
+    version === 1
+      ? liveEvents({ ...common, version: 1 })
+      : liveEvents({ ...common, version: 2 })
+  for await (const ev of events) {
+    yield { events: [ev], lastCursor: ev.seq }
+  }
+}

--- a/packages/jetstream/src/live/pipeline.ts
+++ b/packages/jetstream/src/live/pipeline.ts
@@ -21,6 +21,7 @@ export interface LiveStreamOpts {
   cursor?: CursorStore
   signal?: AbortSignal
   onError?: (err: Error) => void
+  onInfo?: (info: { name: string; message?: string }) => void
   liveTransport?: LiveTransport
 }
 
@@ -30,6 +31,18 @@ export interface LiveStreamOpts {
  * EventBatch is the internal seam unit that snapshot and replay will fill with
  * real grouping.
  */
+export function rawBatchStream(
+  host: string,
+  opts: LiveStreamOpts,
+  version: 1,
+  validateWire?: boolean,
+): AsyncGenerator<EventBatch<RawEventV1>>
+export function rawBatchStream(
+  host: string,
+  opts: LiveStreamOpts,
+  version: 2,
+  validateWire?: boolean,
+): AsyncGenerator<EventBatch<RawEvent<RawRecordJson>>>
 export async function* rawBatchStream(
   host: string,
   opts: LiveStreamOpts,
@@ -48,6 +61,7 @@ export async function* rawBatchStream(
     transport: opts.liveTransport,
     signal: opts.signal,
     onError: opts.onError,
+    onInfo: opts.onInfo,
     validateWire,
   }
   // Branch on a literal version so each call selects the right liveEvents

--- a/packages/jetstream/src/live/source.ts
+++ b/packages/jetstream/src/live/source.ts
@@ -1,20 +1,42 @@
 import { type DidString } from '@atproto/lex'
-import { type RawEventV1 } from '../event.js'
+import { type Kind, type RawEvent, type RawEventV1 } from '../event.js'
+import { type RawRecordJson } from '../raw-record.js'
 import { decodeLiveFrameV1 } from './decode-v1.js'
-import { SKIP_FRAME } from './decode.js'
+import { type LiveInfoFrame, SKIP_FRAME, decodeLiveFrame } from './decode.js'
 import { type LiveTransport, websocketTransport } from './transport.js'
 
 export { type LiveTransport } from './transport.js'
+
+const V2_NSID = 'network.bsky.jetstream.subscribeEvents'
+
+// v2's ?cursor= has two domains split at this threshold (server
+// internal/subscribe/cursor.go): below it a cursor is a seq, at or above it the
+// server reads a unix-µs timestamp and translates it. A timestamp value must
+// never seed the dedup floor — it is not a seq, so every real seq would compare
+// as a duplicate. v1 has no split: there, seq IS time_us.
+const V2_CURSOR_SEQ_MAX_THRESHOLD = 1e15
+
+// Server-side caps on the v2 filter params. Exceeding one is a pre-upgrade 400
+// whose body `ws` discards, so check locally and say why.
+const V2_MAX_DIDS = 10_000
+const V2_MAX_COLLECTIONS = 100
 
 export interface LiveEventsOpts {
   host: string
   collections?: string[]
   dids?: DidString[]
+  /**
+   * Event kinds to receive (v2 only). Omitted means all kinds. The collections
+   * filter constrains only commits, so a commits-only stream needs
+   * kinds: ['commit'].
+   */
+  kinds?: Kind[]
   cursor?: number // undefined = live from tip; 0 = replay from start
   dedupFloor?: number // undefined = nothing delivered (seq 0 passes); else drop seq <= floor
   transport?: LiveTransport
   signal?: AbortSignal
   onError?: (err: Error) => void
+  version?: 1 | 2 // default 2; 1 uses the frozen /subscribe wire + v1 decoder
   validateWire?: boolean // strict wire validation: throws MalformedError (fatal), never routed to onError
 }
 
@@ -25,32 +47,88 @@ function wsScheme(host: string): string {
   return u.origin
 }
 
+// The two wires yield different envelopes, so the overloads pick per version
+// and the implementation is honest about producing either.
+export function liveEvents(
+  opts: LiveEventsOpts & { version: 1 },
+): AsyncGenerator<RawEventV1>
+export function liveEvents(
+  opts: LiveEventsOpts,
+): AsyncGenerator<RawEvent<RawRecordJson>>
 export async function* liveEvents(
   opts: LiveEventsOpts,
-): AsyncGenerator<RawEventV1> {
+): AsyncGenerator<RawEventV1 | RawEvent<RawRecordJson>> {
+  const version = opts.version ?? 2
+  // v1 has no kinds equivalent. Ignoring the filter would deliver kinds the
+  // caller asked to exclude, which is worse than failing.
+  if (version === 1 && opts.kinds?.length) {
+    throw new Error(
+      'jetstream v1 does not support the kinds filter (v1 /subscribe has no equivalent parameter)',
+    )
+  }
+  if (version === 2) {
+    if ((opts.dids?.length ?? 0) > V2_MAX_DIDS) {
+      throw new RangeError(
+        `dids filter exceeds the server limit of ${V2_MAX_DIDS}`,
+      )
+    }
+    if ((opts.collections?.length ?? 0) > V2_MAX_COLLECTIONS) {
+      throw new RangeError(
+        `collections filter exceeds the server limit of ${V2_MAX_COLLECTIONS}`,
+      )
+    }
+  }
+  // The decoder-select union is the truth: the v1 decoder yields RawEventV1 (a
+  // subtype), the v2 decoder yields RawEvent plus LiveInfoFrame, and both can
+  // yield SKIP_FRAME.
+  const decode: (
+    chunk: Uint8Array | string,
+    validateWire?: boolean,
+  ) =>
+    RawEventV1 | RawEvent<RawRecordJson> | LiveInfoFrame | typeof SKIP_FRAME =
+    version === 1 ? decodeLiveFrameV1 : decodeLiveFrame
+
   const origin = wsScheme(opts.host)
   const transport = opts.transport ?? websocketTransport()
   const signal = opts.signal ?? new AbortController().signal
   // lastSeq is the highest DELIVERED seq = reconnect cursor + dedup floor.
-  // undefined means nothing delivered yet (seq 0 passes).
-  let lastSeq: number | undefined = opts.dedupFloor
+  // undefined means nothing delivered yet (seq 0 passes). A v2 timestamp
+  // cursor stays wire-only: leave lastSeq unset so the first delivered event
+  // establishes a real floor, while getUrl keeps sending the timestamp.
+  const isTimestampDomainFloor =
+    version === 2 &&
+    opts.dedupFloor !== undefined &&
+    opts.dedupFloor >= V2_CURSOR_SEQ_MAX_THRESHOLD
+  let lastSeq: number | undefined = isTimestampDomainFloor
+    ? undefined
+    : opts.dedupFloor
 
   const getUrl = (): string => {
-    const u = new URL('/subscribe', origin)
+    const u = new URL(version === 1 ? '/subscribe' : `/xrpc/${V2_NSID}`, origin)
     // Resume from highest-delivered once anything has been delivered; otherwise
     // fall back to the initial wire cursor (which may be 0 = replay from start).
     const wire = lastSeq ?? opts.cursor
     if (wire !== undefined) u.searchParams.set('cursor', String(wire))
-    for (const c of opts.collections ?? [])
-      u.searchParams.append('wantedCollections', c)
-    for (const d of opts.dids ?? []) u.searchParams.append('wantedDids', d)
+    // The param names are version-gated and must not cross: v2 answers the v1
+    // names with a 400 rather than ignoring them.
+    if (version === 1) {
+      for (const c of opts.collections ?? [])
+        u.searchParams.append('wantedCollections', c)
+      for (const d of opts.dids ?? []) u.searchParams.append('wantedDids', d)
+    } else {
+      for (const c of opts.collections ?? [])
+        u.searchParams.append('collections', c)
+      for (const d of opts.dids ?? []) u.searchParams.append('dids', d)
+      for (const k of opts.kinds ?? []) u.searchParams.append('kinds', k)
+    }
     return u.toString()
   }
 
   for await (const chunk of transport.stream(getUrl, signal)) {
-    let ev: RawEventV1 | typeof SKIP_FRAME
+    let ev:
+      RawEventV1 | RawEvent<RawRecordJson> | LiveInfoFrame | typeof SKIP_FRAME
     try {
-      ev = decodeLiveFrameV1(chunk, opts.validateWire)
+      ev = decode(chunk, opts.validateWire)
     } catch (err) {
       // Strict-mode violations are fatal by contract (the flag asserts the
       // data source) — rethrow past the malformed-frame skip.
@@ -59,9 +137,17 @@ export async function* liveEvents(
       continue // skip malformed / error frames; never fatal in default mode
     }
     if (ev === SKIP_FRAME) continue
+    if ('info' in ev) {
+      // Seq-less advisory: reported, never fatal, and it does not move the
+      // cursor.
+      opts.onError?.(
+        new Error(`jetstream info: ${ev.info.name}: ${ev.info.message ?? ''}`),
+      )
+      continue
+    }
     // v1 note: seq is time_us from v1's monotonic clock (strictly increasing,
-    // unique — verified in the v1 source), so the inclusive dedup is exact.
-    if (lastSeq !== undefined && ev.seq <= lastSeq) continue // dedup inclusive overlap
+    // unique), so the inclusive dedup is exact for both versions.
+    if (lastSeq !== undefined && ev.seq <= lastSeq) continue
     lastSeq = ev.seq
     yield ev
   }

--- a/packages/jetstream/src/live/source.ts
+++ b/packages/jetstream/src/live/source.ts
@@ -36,6 +36,12 @@ export interface LiveEventsOpts {
   transport?: LiveTransport
   signal?: AbortSignal
   onError?: (err: Error) => void
+  /**
+   * Seq-less server advisories (`#info` frames, e.g. `OutdatedCursor`). v2
+   * only — the v1 wire has no `#info` frame. Not an error: when omitted, an
+   * advisory is dropped silently rather than routed to onError.
+   */
+  onInfo?: (info: { name: string; message?: string }) => void
   version?: 1 | 2 // default 2; 1 uses the frozen /subscribe wire + v1 decoder
   validateWire?: boolean // strict wire validation: throws MalformedError (fatal), never routed to onError
 }
@@ -138,11 +144,9 @@ export async function* liveEvents(
     }
     if (ev === SKIP_FRAME) continue
     if ('info' in ev) {
-      // Seq-less advisory: reported, never fatal, and it does not move the
-      // cursor.
-      opts.onError?.(
-        new Error(`jetstream info: ${ev.info.name}: ${ev.info.message ?? ''}`),
-      )
+      // Seq-less advisory: never fatal, and it does not move the cursor. Not
+      // an error, so drop it silently when no onInfo is registered.
+      opts.onInfo?.(ev.info)
       continue
     }
     // v1 note: seq is time_us from v1's monotonic clock (strictly increasing,

--- a/packages/jetstream/src/live/source.ts
+++ b/packages/jetstream/src/live/source.ts
@@ -1,4 +1,4 @@
-import { type DidString } from '@atproto/lex-schema'
+import { type DidString } from '@atproto/lex'
 import { type RawEventV1 } from '../event.js'
 import { decodeLiveFrameV1 } from './decode-v1.js'
 import { SKIP_FRAME } from './decode.js'

--- a/packages/jetstream/src/live/transport.ts
+++ b/packages/jetstream/src/live/transport.ts
@@ -37,11 +37,36 @@ export type WebsocketTransportOptions = Omit<
   idleTimeoutMs?: number | false
 }
 
+// ws raises `Unexpected server response: <status>` when an upgrade is refused
+// and discards the response body, so the XRPC error envelope naming
+// CursorTooOld is unreachable from here — only the status is available.
+// Matching on someone else's message text is a stopgap until ws-client
+// surfaces the handshake response; the unit tests fail loudly if it changes.
+const HANDSHAKE_REJECTION_RE = /Unexpected server response: (\d{3})/
+
+export function handshakeRejectionStatus(error: unknown): number | undefined {
+  // ws-client nests the ws error under SocketError, so walk the cause chain.
+  for (let e: unknown = error, depth = 0; depth < 5; depth++) {
+    if (!(e instanceof Error)) break
+    const match = HANDSHAKE_REJECTION_RE.exec(e.message)
+    if (match) return Number(match[1])
+    e = e.cause
+  }
+  return undefined
+}
+
 // A jetstream server closing 1000 (restart, load-shed) should not end the
 // consumer's stream — the resume cursor makes the redial seamless. Everything
 // else keeps ws-client's classification: protocol closes
 // (1002/1003/1007/1009), DataModeError, and local resource errors stay fatal.
 export function jetstreamShouldReconnect(error: unknown): boolean {
+  // A 4xx refusal is permanent for this request; 5xx is transient and keeps
+  // the default treatment.
+  const status = handshakeRejectionStatus(error)
+  if (status !== undefined) {
+    if (status >= 400 && status < 500) return false
+    if (status >= 500) return true
+  }
   return (
     (error instanceof CloseError && error.code === CloseCode.Normal) ||
     defaultShouldReconnect(error)
@@ -59,7 +84,7 @@ export function resolveWebsocketOptions(
     shouldReconnect = jetstreamShouldReconnect,
     ...rest
   } = options
-  if (idleTimeoutMs !== false && idleTimeoutMs <= 0) {
+  if (idleTimeoutMs !== false && !(idleTimeoutMs > 0)) {
     throw new RangeError(
       'idleTimeoutMs must be > 0; use false to disable idle detection',
     )

--- a/packages/jetstream/src/live/transport.ts
+++ b/packages/jetstream/src/live/transport.ts
@@ -1,6 +1,7 @@
 import {
   CloseCode,
   CloseError,
+  SocketError,
   type WebSocketOptions,
   defaultShouldReconnect,
   websocket,
@@ -45,14 +46,12 @@ export type WebsocketTransportOptions = Omit<
 const HANDSHAKE_REJECTION_RE = /Unexpected server response: (\d{3})/
 
 export function handshakeRejectionStatus(error: unknown): number | undefined {
-  // ws-client nests the ws error under SocketError, so walk the cause chain.
-  for (let e: unknown = error, depth = 0; depth < 5; depth++) {
-    if (!(e instanceof Error)) break
-    const match = HANDSHAKE_REJECTION_RE.exec(e.message)
-    if (match) return Number(match[1])
-    e = e.cause
-  }
-  return undefined
+  // ws-client wraps the raw ws error in a SocketError, one level deep.
+  if (!(error instanceof SocketError)) return undefined
+  const cause = error.cause
+  if (!(cause instanceof Error)) return undefined
+  const match = HANDSHAKE_REJECTION_RE.exec(cause.message)
+  return match ? Number(match[1]) : undefined
 }
 
 // A jetstream server closing 1000 (restart, load-shed) should not end the
@@ -84,7 +83,12 @@ export function resolveWebsocketOptions(
     shouldReconnect = jetstreamShouldReconnect,
     ...rest
   } = options
-  if (idleTimeoutMs !== false && !(idleTimeoutMs > 0)) {
+  if (Number.isNaN(idleTimeoutMs)) {
+    throw new RangeError(
+      'idleTimeoutMs must be > 0; use false to disable idle detection',
+    )
+  }
+  if (idleTimeoutMs !== false && idleTimeoutMs <= 0) {
     throw new RangeError(
       'idleTimeoutMs must be > 0; use false to disable idle detection',
     )

--- a/packages/jetstream/src/raw-record.ts
+++ b/packages/jetstream/src/raw-record.ts
@@ -1,4 +1,4 @@
-import { type JsonValue, jsonToLex, type TypedLexMap } from '@atproto/lex'
+import { type JsonValue, type TypedLexMap, jsonToLex } from '@atproto/lex'
 import { MalformedError } from './errors.js'
 
 /** Parsed wire JSON, NOT converted to lex values ({$link}/{$bytes} intact). */

--- a/packages/jetstream/src/raw-record.ts
+++ b/packages/jetstream/src/raw-record.ts
@@ -1,0 +1,49 @@
+import { type JsonValue, jsonToLex, type TypedLexMap } from '@atproto/lex'
+import { MalformedError } from './errors.js'
+
+/** Parsed wire JSON, NOT converted to lex values ({$link}/{$bytes} intact). */
+export type RawRecordJson = JsonValue
+
+/**
+ * A record in its wire representation. One arm today; snapshot support adds a
+ * byte-exact DAG-CBOR arm, which is why the raw event types are generic over
+ * this.
+ */
+export type RawRecord = RawRecordJson
+
+// O(1) gate for a value that is already a lex value. @atproto/lex's
+// isTypedLexMap deep-walks the record to learn these two facts; a prototype
+// check answers both. Arrays, Uint8Array, and Cid instances all fail it.
+function isTypedLexMapShallow(v: unknown): v is TypedLexMap {
+  if (typeof v !== 'object' || v === null) return false
+  const proto: unknown = Object.getPrototypeOf(v)
+  if (proto !== Object.prototype && proto !== null) return false
+  const t = (v as { $type?: unknown }).$type
+  return typeof t === 'string' && t.length > 0
+}
+
+/**
+ * Converts a wire record to the lex data model: {$link} becomes a Cid,
+ * {$bytes} a Uint8Array, blob refs a BlobRef. Strict mode additionally rejects
+ * non-integer numbers and malformed special objects, matching what
+ * validateWire asserts elsewhere. Records are $type'd maps by contract, so
+ * anything else throws rather than flowing on as garbage.
+ */
+export function parseRawRecord(
+  record: RawRecord,
+  opts?: { strict?: boolean },
+): TypedLexMap {
+  let lex: unknown
+  try {
+    lex = jsonToLex(record, { strict: opts?.strict === true })
+  } catch (err) {
+    // jsonToLex throws on a literal __proto__ key in either mode.
+    throw new MalformedError('parse raw record', { cause: err })
+  }
+  if (!isTypedLexMapShallow(lex)) {
+    const got =
+      lex === null ? 'null' : Array.isArray(lex) ? 'array' : typeof lex
+    throw new MalformedError(`record is not a $type'd object (got ${got})`)
+  }
+  return lex
+}

--- a/packages/jetstream/src/runner.ts
+++ b/packages/jetstream/src/runner.ts
@@ -9,6 +9,7 @@ export interface RunnerLiveOpts {
   cursor?: CursorStore
   signal?: AbortSignal
   onError?: (err: Error) => void
+  onInfo?: (info: { name: string; message?: string }) => void
   liveTransport?: LiveTransport
 }
 

--- a/packages/jetstream/src/runner.ts
+++ b/packages/jetstream/src/runner.ts
@@ -15,7 +15,7 @@ export interface RunnerLiveOpts {
 /**
  * Drives a JetstreamConsumer from a Jetstream source with cursor tracking:
  * builds the live raw batch stream (filtered by the consumer's static
- * collections/dids), registers each event's seq with a CommitTracker before
+ * collections/dids/kinds), registers each event's seq with a CommitTracker before
  * the consumer sees it, and persists the contiguous acked watermark via the
  * CursorStore. flush() runs even when the consumer throws.
  */
@@ -33,6 +33,7 @@ export class JetstreamRunner {
       ...opts,
       collections: this.#consumer.collections,
       dids: this.#consumer.dids,
+      kinds: this.#consumer.kinds,
     })
     await this.#drive(src, opts)
   }

--- a/packages/jetstream/src/runner.ts
+++ b/packages/jetstream/src/runner.ts
@@ -40,11 +40,12 @@ export class JetstreamRunner {
     // assignable. Task 10 flips Jetstream to speak v2, at which point this
     // cast is removed and the assignment becomes honestly type-safe. Nothing
     // downstream of this cast reads the v2-only `time` field today (only
-    // `seq`), so this is not a runtime hazard in the interim.
-    await this.#drive(
-      src as unknown as AsyncGenerator<EventBatch<RawEvent>>,
-      opts,
-    )
+    // `seq`), so this is not a runtime hazard in the interim. Deliberately a
+    // single `as` (not `as unknown as`): AsyncGenerator's type argument stays
+    // comparable even though RawEventV1/RawEvent are not assignable, so a
+    // future divergence (e.g. RawRecord gaining a CBOR arm, or an envelope
+    // rename) still re-errors here instead of silently passing.
+    await this.#drive(src as AsyncGenerator<EventBatch<RawEvent>>, opts)
   }
 
   async #drive(

--- a/packages/jetstream/src/runner.ts
+++ b/packages/jetstream/src/runner.ts
@@ -34,18 +34,7 @@ export class JetstreamRunner {
       collections: this.#consumer.collections,
       dids: this.#consumer.dids,
     })
-    // TEMPORARY: Jetstream is still v1-backed (liveRawBatches yields
-    // EventBatch<RawEventV1>), but the runner/consumer seam is v2-only
-    // (EventBatch<RawEvent>) — see event.ts for why the two are not
-    // assignable. Task 10 flips Jetstream to speak v2, at which point this
-    // cast is removed and the assignment becomes honestly type-safe. Nothing
-    // downstream of this cast reads the v2-only `time` field today (only
-    // `seq`), so this is not a runtime hazard in the interim. Deliberately a
-    // single `as` (not `as unknown as`): AsyncGenerator's type argument stays
-    // comparable even though RawEventV1/RawEvent are not assignable, so a
-    // future divergence (e.g. RawRecord gaining a CBOR arm, or an envelope
-    // rename) still re-errors here instead of silently passing.
-    await this.#drive(src as AsyncGenerator<EventBatch<RawEvent>>, opts)
+    await this.#drive(src, opts)
   }
 
   async #drive(

--- a/packages/jetstream/src/runner.ts
+++ b/packages/jetstream/src/runner.ts
@@ -1,5 +1,5 @@
 import { type JetstreamConsumer } from './consumer.js'
-import { type EventBatch, type RawEventV1 } from './event.js'
+import { type EventBatch, type RawEvent } from './event.js'
 import { type CursorStore } from './execute/cursor-store.js'
 import { type Jetstream } from './jetstream.js'
 import { type LiveTransport } from './live/transport.js'
@@ -34,11 +34,21 @@ export class JetstreamRunner {
       collections: this.#consumer.collections,
       dids: this.#consumer.dids,
     })
-    await this.#drive(src, opts)
+    // TEMPORARY: Jetstream is still v1-backed (liveRawBatches yields
+    // EventBatch<RawEventV1>), but the runner/consumer seam is v2-only
+    // (EventBatch<RawEvent>) — see event.ts for why the two are not
+    // assignable. Task 10 flips Jetstream to speak v2, at which point this
+    // cast is removed and the assignment becomes honestly type-safe. Nothing
+    // downstream of this cast reads the v2-only `time` field today (only
+    // `seq`), so this is not a runtime hazard in the interim.
+    await this.#drive(
+      src as unknown as AsyncGenerator<EventBatch<RawEvent>>,
+      opts,
+    )
   }
 
   async #drive(
-    src: AsyncGenerator<EventBatch<RawEventV1>>,
+    src: AsyncGenerator<EventBatch<RawEvent>>,
     opts: { cursor?: CursorStore; signal?: AbortSignal },
   ): Promise<void> {
     const ts = trackedStream(src, opts.cursor)

--- a/packages/jetstream/src/shape.ts
+++ b/packages/jetstream/src/shape.ts
@@ -57,11 +57,11 @@ export async function* shape(
     } else {
       for (const e of batch.events) {
         // The overloads exist for callers; this internal fan-out runs one body
-        // for both wires.
-        const t = typedEventFromRaw(
-          e as RawEvent<RawRecordJson>,
-          schemasByNsid,
-        ) as TypedEventV1 | TypedEvent
+        // for both wires. Only the input-side cast is needed — the v2
+        // overload's result (TypedEvent) already sits inside the declared
+        // union (TypedEventV1 | TypedEvent), so a result-side cast would be a
+        // no-op that could silently swallow a future mismatch.
+        const t = typedEventFromRaw(e as RawEvent<RawRecordJson>, schemasByNsid)
         if (skipInvalid(t, schemasByNsid, onError)) continue
         yield t
       }

--- a/packages/jetstream/src/shape.ts
+++ b/packages/jetstream/src/shape.ts
@@ -40,6 +40,7 @@ export class RecordValidationError extends Error {
 
 export interface ShapeFlags {
   raw?: boolean
+  validateWire?: boolean
 }
 
 type AnyRaw = RawEventV1 | RawEvent<RawRecordJson>
@@ -61,7 +62,13 @@ export async function* shape(
         // overload's result (TypedEvent) already sits inside the declared
         // union (TypedEventV1 | TypedEvent), so a result-side cast would be a
         // no-op that could silently swallow a future mismatch.
-        const t = typedEventFromRaw(e as RawEvent<RawRecordJson>, schemasByNsid)
+        const t = typedEventFromRaw(
+          e as RawEvent<RawRecordJson>,
+          schemasByNsid,
+          {
+            strict: flags.validateWire === true,
+          },
+        )
         if (skipInvalid(t, schemasByNsid, onError)) continue
         yield t
       }

--- a/packages/jetstream/src/shape.ts
+++ b/packages/jetstream/src/shape.ts
@@ -1,4 +1,4 @@
-import { type RecordSchema } from '@atproto/lex-schema'
+import { type RecordSchema } from '@atproto/lex'
 import { typedEventFromRaw } from './decode-typed.js'
 import { type EventBatch, type RawEventV1, type TypedEvent } from './event.js'
 

--- a/packages/jetstream/src/shape.ts
+++ b/packages/jetstream/src/shape.ts
@@ -1,6 +1,13 @@
 import { type RecordSchema } from '@atproto/lex'
 import { typedEventFromRaw } from './decode-typed.js'
-import { type EventBatch, type RawEventV1, type TypedEvent } from './event.js'
+import {
+  type EventBatch,
+  type RawEvent,
+  type RawEventV1,
+  type TypedEvent,
+  type TypedEventV1,
+} from './event.js'
+import { type RawRecordJson } from './raw-record.js'
 
 /**
  * Reported through the per-call onError when a put commit's record fails
@@ -35,19 +42,26 @@ export interface ShapeFlags {
   raw?: boolean
 }
 
+type AnyRaw = RawEventV1 | RawEvent<RawRecordJson>
+
 export async function* shape(
-  src: AsyncIterable<EventBatch<RawEventV1>>,
+  src: AsyncIterable<EventBatch<AnyRaw>>,
   flags: ShapeFlags,
   schemasByNsid: Map<string, RecordSchema>,
   onError?: (err: Error) => void,
-): AsyncGenerator<RawEventV1 | TypedEvent> {
+): AsyncGenerator<AnyRaw | TypedEventV1 | TypedEvent> {
   const raw = flags.raw === true
   for await (const batch of src) {
     if (raw) {
       for (const e of batch.events) yield e
     } else {
       for (const e of batch.events) {
-        const t = typedEventFromRaw(e, schemasByNsid)
+        // The overloads exist for callers; this internal fan-out runs one body
+        // for both wires.
+        const t = typedEventFromRaw(
+          e as RawEvent<RawRecordJson>,
+          schemasByNsid,
+        ) as TypedEventV1 | TypedEvent
         if (skipInvalid(t, schemasByNsid, onError)) continue
         yield t
       }
@@ -60,7 +74,7 @@ export async function* shape(
 // (string filters, validateRecord: false) flow through — exactly the pre-skip
 // behavior.
 function skipInvalid(
-  t: TypedEvent,
+  t: TypedEventV1 | TypedEvent,
   schemasByNsid: Map<string, RecordSchema>,
   onError?: (err: Error) => void,
 ): boolean {

--- a/packages/jetstream/src/shape.ts
+++ b/packages/jetstream/src/shape.ts
@@ -11,8 +11,9 @@ import { type RawRecordJson } from './raw-record.js'
 
 /**
  * Reported through the per-call onError when a put commit's record fails
- * schema validation for a validating schema filter and the event is skipped.
- * Distinguishable from transport errors via instanceof.
+ * conversion (regardless of collection) or fails schema validation for a
+ * validating schema filter, and the event is skipped. Distinguishable from
+ * transport errors via instanceof.
  */
 export class RecordValidationError extends Error {
   readonly did: string
@@ -76,10 +77,16 @@ export async function* shape(
   }
 }
 
-// True (skip) only for put commits whose collection has a VALIDATING schema
-// and whose record failed validation. Collections without a registered schema
-// (string filters, validateRecord: false) flow through — exactly the pre-skip
-// behavior.
+// Skip (and report) a put commit whose record is unusable. Two distinct
+// failure shapes reach here, both carrying `validationError`:
+//   - conversion failed: `record` is undefined, REGARDLESS of collection —
+//     the static type (TypedLexMap, non-optional) promises a record is
+//     present, so delivering undefined would be data corruption. Always
+//     skip and report.
+//   - schema validation failed: `record` is defined (the converted value)
+//     but didn't validate. Skipped only for collections with a VALIDATING
+//     schema; collections without one (string filters, validateRecord:
+//     false) flow through — exactly the pre-skip behavior.
 function skipInvalid(
   t: TypedEventV1 | TypedEvent,
   schemasByNsid: Map<string, RecordSchema>,
@@ -87,7 +94,7 @@ function skipInvalid(
 ): boolean {
   if (t.kind !== 'commit' || t.commit.operation === 'delete') return false
   if (t.commit.validationError === undefined) return false
-  if (!schemasByNsid.has(t.commit.collection)) return false
+  if (t.commit.record && !schemasByNsid.has(t.commit.collection)) return false
   onError?.(
     new RecordValidationError({
       did: t.did,

--- a/packages/jetstream/tests/engine/collections-filter.test.ts
+++ b/packages/jetstream/tests/engine/collections-filter.test.ts
@@ -1,4 +1,4 @@
-import { l, record } from '@atproto/lex-schema'
+import { l, record } from '@atproto/lex'
 import { describe, expect, it } from 'vitest'
 import { parseCollectionFilters } from '../../src/engine/collections.js'
 import { RecordValidationError } from '../../src/shape.js'

--- a/packages/jetstream/tests/event-brands.test.ts
+++ b/packages/jetstream/tests/event-brands.test.ts
@@ -4,7 +4,7 @@ import type {
   DidString,
   HandleString,
   NsidString,
-} from '@atproto/lex-schema'
+} from '@atproto/lex'
 import { expectTypeOf, test } from 'vitest'
 import type { CollectionFilter } from '../src/engine/collections.js'
 import type {

--- a/packages/jetstream/tests/event-brands.test.ts
+++ b/packages/jetstream/tests/event-brands.test.ts
@@ -10,7 +10,7 @@ import type { CollectionFilter } from '../src/engine/collections.js'
 import type {
   Identity,
   RawEventV1,
-  RawPutCommitV1,
+  RawPutCommit,
   TypedEvent,
 } from '../src/event.js'
 import type { LiveOpts } from '../src/jetstream.js'
@@ -18,7 +18,7 @@ import type { IdentityEvent, PutEvent } from '../src/lex-indexer.js'
 
 test('event envelope fields carry lex string format brands', () => {
   expectTypeOf<RawEventV1['did']>().toEqualTypeOf<DidString>()
-  expectTypeOf<RawPutCommitV1['collection']>().toEqualTypeOf<NsidString>()
+  expectTypeOf<RawPutCommit['collection']>().toEqualTypeOf<NsidString>()
   expectTypeOf<Identity['handle']>().toEqualTypeOf<HandleString | undefined>()
   expectTypeOf<Identity['time']>().toEqualTypeOf<DatetimeString | undefined>()
 })
@@ -32,8 +32,8 @@ test('a plain string does not satisfy the branded fields', () => {
   expectTypeOf<string>().not.toMatchTypeOf<DidString>()
   expectTypeOf<string>().not.toMatchTypeOf<NsidString>()
   // free aliases intentionally accept plain string
-  expectTypeOf<string>().toMatchTypeOf<RawPutCommitV1['cid']>()
-  expectTypeOf<string>().toMatchTypeOf<RawPutCommitV1['rkey']>()
+  expectTypeOf<string>().toMatchTypeOf<RawPutCommit['cid']>()
+  expectTypeOf<string>().toMatchTypeOf<RawPutCommit['rkey']>()
 })
 
 test('indexer handler events carry brands', () => {

--- a/packages/jetstream/tests/filter-types.test.ts
+++ b/packages/jetstream/tests/filter-types.test.ts
@@ -1,10 +1,12 @@
-import { type InferOutput, type NsidString, l, record } from '@atproto/lex'
-import { expectTypeOf, test } from 'vitest'
 import {
-  type DeleteCommit,
-  type TypedEvent,
-  type UnvalidatedRecord,
-} from '../src/event.js'
+  type InferOutput,
+  type NsidString,
+  type TypedLexMap,
+  l,
+  record,
+} from '@atproto/lex'
+import { expectTypeOf, test } from 'vitest'
+import { type DeleteCommit, type TypedEvent } from '../src/event.js'
 import { type TypedCommitFor, type TypedEventFor } from '../src/filter-types.js'
 
 // likeSchema is consumed only via `typeof likeSchema`; the runtime value is
@@ -37,7 +39,7 @@ test('validateRecord: false keeps the collection literal, floor-types the record
   }>
   expectTypeOf<Commit['collection']>().toEqualTypeOf<'app.test.like'>()
   expectTypeOf<PutOf<Commit>['record']>().toEqualTypeOf<
-    UnvalidatedRecord<'app.test.like'>
+    TypedLexMap<'app.test.like'>
   >()
   // unvalidated commits keep validationError (decode failures flow through)
   expectTypeOf<PutOf<Commit>>().toHaveProperty('validationError')
@@ -47,7 +49,7 @@ test('string literal filter floor-types the record with its literal', () => {
   type Commit = TypedCommitFor<'app.test.post'>
   expectTypeOf<Commit['collection']>().toEqualTypeOf<'app.test.post'>()
   expectTypeOf<PutOf<Commit>['record']>().toEqualTypeOf<
-    UnvalidatedRecord<'app.test.post'>
+    TypedLexMap<'app.test.post'>
   >()
   // string filters are unvalidated: validationError stays available
   expectTypeOf<PutOf<Commit>>().toHaveProperty('validationError')
@@ -57,7 +59,7 @@ test('wildcard filter maps to a template-literal collection', () => {
   type Commit = TypedCommitFor<'app.test.*'>
   expectTypeOf<Commit['collection']>().toEqualTypeOf<`app.test.${string}`>()
   expectTypeOf<PutOf<Commit>['record']>().toEqualTypeOf<
-    UnvalidatedRecord<`app.test.${string}`>
+    TypedLexMap<`app.test.${string}`>
   >()
 })
 
@@ -65,7 +67,7 @@ test('a bare NsidString filter (no literal) floor-types with the brand', () => {
   type Commit = TypedCommitFor<NsidString>
   expectTypeOf<Commit['collection']>().toEqualTypeOf<NsidString>()
   expectTypeOf<PutOf<Commit>['record']>().toEqualTypeOf<
-    UnvalidatedRecord<NsidString>
+    TypedLexMap<NsidString>
   >()
 })
 
@@ -82,7 +84,7 @@ test('mixed filters form a correlated union narrowed by collection', () => {
     }
     if (ev.commit.collection === 'app.test.post') {
       expectTypeOf(ev.commit.record).toEqualTypeOf<
-        UnvalidatedRecord<'app.test.post'>
+        TypedLexMap<'app.test.post'>
       >()
     }
   }

--- a/packages/jetstream/tests/filter-types.test.ts
+++ b/packages/jetstream/tests/filter-types.test.ts
@@ -6,8 +6,18 @@ import {
   record,
 } from '@atproto/lex'
 import { expectTypeOf, test } from 'vitest'
-import { type DeleteCommit, type TypedEvent } from '../src/event.js'
-import { type TypedCommitFor, type TypedEventFor } from '../src/filter-types.js'
+import {
+  type DeleteCommit,
+  type TypedEvent,
+  type TypedEventV1,
+} from '../src/event.js'
+import {
+  type TypedCommitFor,
+  type TypedEventFor,
+  type TypedEventV1For,
+  type WideTypedEvent,
+  type WideTypedEventV1,
+} from '../src/filter-types.js'
 
 // likeSchema is consumed only via `typeof likeSchema`; the runtime value is
 // required for that type query, so eslint's no-unused-vars is a false positive.
@@ -101,6 +111,25 @@ test('opts form with validateRecord omitted behaves like the bare schema', () =>
   expectTypeOf<Commit['collection']>().toEqualTypeOf<'app.test.like'>()
   expectTypeOf<PutOf<Commit>['record']>().toEqualTypeOf<Like>()
   expectTypeOf<PutOf<Commit>>().not.toHaveProperty('validationError')
+})
+
+test('WideTypedEvent covers both the empty-tuple and concrete-tuple shapes', () => {
+  // The empty-tuple case (TypedEventFor<readonly []> is plain TypedEvent) is
+  // the one a hand-derived `TypedEventFor<CollectionFilter[]>` alone misses:
+  // its default record type is TypedLexMap<string>, narrower-branded arms
+  // like TypedLexMap<NsidString> don't cover it.
+  expectTypeOf<TypedEventFor<readonly []>>().toExtend<WideTypedEvent>()
+  expectTypeOf<TypedEventV1For<readonly []>>().toExtend<WideTypedEventV1>()
+  // Concrete tuples were never the problem, but pin them too.
+  expectTypeOf<
+    TypedEventFor<readonly [typeof likeSchema]>
+  >().toExtend<WideTypedEvent>()
+  expectTypeOf<
+    TypedEventV1For<readonly [typeof likeSchema]>
+  >().toExtend<WideTypedEventV1>()
+  // Sanity: the bare envelope types extend the wide types too.
+  expectTypeOf<TypedEvent>().toExtend<WideTypedEvent>()
+  expectTypeOf<TypedEventV1>().toExtend<WideTypedEventV1>()
 })
 
 test('non-commit event kinds are unaffected by the filter generic', () => {

--- a/packages/jetstream/tests/filter-types.test.ts
+++ b/packages/jetstream/tests/filter-types.test.ts
@@ -1,9 +1,4 @@
-import {
-  type InferOutput,
-  type NsidString,
-  l,
-  record,
-} from '@atproto/lex-schema'
+import { type InferOutput, type NsidString, l, record } from '@atproto/lex'
 import { expectTypeOf, test } from 'vitest'
 import {
   type DeleteCommit,

--- a/packages/jetstream/tests/indexer/indexer-type.test.ts
+++ b/packages/jetstream/tests/indexer/indexer-type.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { type Ack, type JetstreamConsumer } from '../../src/consumer.js'
-import { type EventBatch, type RawEventV1 } from '../../src/event.js'
+import { type EventBatch, type RawEvent } from '../../src/event.js'
 
-function rawDelete(seq: number): RawEventV1 {
+function rawDelete(seq: number): RawEvent {
   return {
     did: 'did:plc:a',
     seq,
-    timeUs: 0,
+    time: '2024-09-09T19:46:02.329308Z',
     kind: 'commit',
     commit: {
       operation: 'delete',
@@ -17,7 +17,7 @@ function rawDelete(seq: number): RawEventV1 {
   }
 }
 
-async function* batches(...bs: EventBatch<RawEventV1>[]) {
+async function* batches(...bs: EventBatch<RawEvent>[]) {
   for (const b of bs) yield b
 }
 

--- a/packages/jetstream/tests/indexer/lex-indexer-register.test.ts
+++ b/packages/jetstream/tests/indexer/lex-indexer-register.test.ts
@@ -1,4 +1,4 @@
-import { l, record } from '@atproto/lex-schema'
+import { l, record } from '@atproto/lex'
 import { describe, expect, it } from 'vitest'
 import { LexIndexer } from '../../src/lex-indexer.js'
 

--- a/packages/jetstream/tests/indexer/lex-indexer-register.test.ts
+++ b/packages/jetstream/tests/indexer/lex-indexer-register.test.ts
@@ -36,3 +36,34 @@ describe('LexIndexer registration', () => {
     expect(new LexIndexer({ concurrency: 4 }).concurrency).toBe(4)
   })
 })
+
+describe('LexIndexer.kinds', () => {
+  it('is undefined when nothing is registered', () => {
+    expect(new LexIndexer().kinds).toBeUndefined()
+  })
+
+  it('derives "commit" from a registered collection', () => {
+    const ix = new LexIndexer().commit(likeSchema, { put: () => {} })
+    expect(ix.kinds).toEqual(['commit'])
+  })
+
+  it('derives one entry per registered handler, in registration order', () => {
+    const ix = new LexIndexer()
+      .commit(likeSchema, { put: () => {} })
+      .identity(() => {})
+      .account(() => {})
+      .sync(() => {})
+    expect(ix.kinds).toEqual(['commit', 'identity', 'account', 'sync'])
+  })
+
+  it('onValidationError alone implies nothing (no collection registered)', () => {
+    const ix = new LexIndexer().onValidationError(() => {})
+    expect(ix.kinds).toBeUndefined()
+  })
+
+  it('identity/account/sync handlers derive their own kind without a collection', () => {
+    expect(new LexIndexer().identity(() => {}).kinds).toEqual(['identity'])
+    expect(new LexIndexer().account(() => {}).kinds).toEqual(['account'])
+    expect(new LexIndexer().sync(() => {}).kinds).toEqual(['sync'])
+  })
+})

--- a/packages/jetstream/tests/indexer/lex-indexer-run.test.ts
+++ b/packages/jetstream/tests/indexer/lex-indexer-run.test.ts
@@ -1,5 +1,5 @@
 import { setTimeout as delay } from 'node:timers/promises'
-import { l, record } from '@atproto/lex-schema'
+import { l, record } from '@atproto/lex'
 import { describe, expect, it } from 'vitest'
 import { type EventBatch, type RawEventV1 } from '../../src/event.js'
 import { LexIndexer } from '../../src/lex-indexer.js'

--- a/packages/jetstream/tests/indexer/lex-indexer-run.test.ts
+++ b/packages/jetstream/tests/indexer/lex-indexer-run.test.ts
@@ -1,7 +1,7 @@
 import { setTimeout as delay } from 'node:timers/promises'
 import { l, record } from '@atproto/lex'
 import { describe, expect, it } from 'vitest'
-import { type EventBatch, type RawEventV1 } from '../../src/event.js'
+import { type EventBatch, type RawEvent } from '../../src/event.js'
 import { LexIndexer } from '../../src/lex-indexer.js'
 
 const likeSchema = record(
@@ -10,11 +10,13 @@ const likeSchema = record(
   l.object({ subject: l.string() }),
 )
 
-function rawPut(seq: number, subject: string): RawEventV1 {
+const TIME = '2024-09-09T19:46:02.329308Z'
+
+function rawPut(seq: number, subject: string): RawEvent {
   return {
     did: 'did:plc:a',
     seq,
-    timeUs: 0,
+    time: TIME,
     kind: 'commit',
     commit: {
       operation: 'create',
@@ -28,11 +30,11 @@ function rawPut(seq: number, subject: string): RawEventV1 {
 }
 // A create commit whose record is missing the required `subject` (typed as a
 // number), so likeSchema.safeValidate fails => typed.commit.validationError set.
-function rawInvalidPut(seq: number): RawEventV1 {
+function rawInvalidPut(seq: number): RawEvent {
   return {
     did: 'did:plc:a',
     seq,
-    timeUs: 0,
+    time: TIME,
     kind: 'commit',
     commit: {
       operation: 'create',
@@ -44,11 +46,11 @@ function rawInvalidPut(seq: number): RawEventV1 {
     },
   }
 }
-function rawDel(seq: number): RawEventV1 {
+function rawDel(seq: number): RawEvent {
   return {
     did: 'did:plc:a',
     seq,
-    timeUs: 0,
+    time: TIME,
     kind: 'commit',
     commit: {
       operation: 'delete',
@@ -58,11 +60,11 @@ function rawDel(seq: number): RawEventV1 {
     },
   }
 }
-function rawUnregistered(seq: number): RawEventV1 {
+function rawUnregistered(seq: number): RawEvent {
   return {
     did: 'did:plc:a',
     seq,
-    timeUs: 0,
+    time: TIME,
     kind: 'commit',
     commit: {
       operation: 'delete',
@@ -73,7 +75,7 @@ function rawUnregistered(seq: number): RawEventV1 {
   }
 }
 
-async function* batches(...bs: EventBatch<RawEventV1>[]) {
+async function* batches(...bs: EventBatch<RawEvent>[]) {
   for (const b of bs) yield b
 }
 
@@ -178,17 +180,17 @@ describe('LexIndexer.run', () => {
     const ix = new LexIndexer()
       .identity((e) => ids.push(e.did))
       .account((e) => accts.push({ did: e.did, active: e.active }))
-    const idEvt: RawEventV1 = {
+    const idEvt: RawEvent = {
       did: 'did:plc:b',
       seq: 1,
-      timeUs: 0,
+      time: TIME,
       kind: 'identity',
       identity: { did: 'did:plc:b', handle: 'h.test' },
     }
-    const acctEvt: RawEventV1 = {
+    const acctEvt: RawEvent = {
       did: 'did:plc:c',
       seq: 2,
-      timeUs: 0,
+      time: TIME,
       kind: 'account',
       account: { did: 'did:plc:c', active: true },
     }
@@ -414,10 +416,10 @@ describe('LexIndexer.run', () => {
         },
       })
       // Same uri (same did/collection/rkey) for both events => same key.
-      const sameKey = (seq: number): RawEventV1 => ({
+      const sameKey = (seq: number): RawEvent => ({
         did: 'did:plc:a',
         seq,
-        timeUs: 0,
+        time: TIME,
         kind: 'commit',
         commit: {
           operation: 'create',

--- a/packages/jetstream/tests/indexer/lex-indexer-sync.test.ts
+++ b/packages/jetstream/tests/indexer/lex-indexer-sync.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { type EventBatch, type RawEvent } from '../../src/event.js'
+import { LexIndexer, type SyncEvent } from '../../src/index.js'
+
+const syncEvent = (seq: number): RawEvent => ({
+  did: 'did:plc:a' as never,
+  seq,
+  time: '2024-09-09T19:46:02.329308Z' as never,
+  kind: 'sync',
+  sync: {
+    did: 'did:plc:a' as never,
+    rev: '3kabc' as never,
+    time: '2024-09-09T19:46:02.329308Z' as never,
+  },
+})
+
+async function* batches(
+  evts: RawEvent[],
+): AsyncGenerator<EventBatch<RawEvent>> {
+  for (const e of evts) yield { events: [e], lastCursor: e.seq }
+}
+
+describe('LexIndexer.sync', () => {
+  it('dispatches sync events and acks them', async () => {
+    const seen: SyncEvent[] = []
+    const acked: number[] = []
+    const ix = new LexIndexer().sync((e) => {
+      seen.push(e)
+    })
+    await ix.run(batches([syncEvent(1), syncEvent(2)]), {
+      ack: (e) => acked.push(e.seq),
+    })
+    expect(seen.map((e) => e.seq)).toEqual([1, 2])
+    expect(seen[0]).toMatchObject({ did: 'did:plc:a', rev: '3kabc' })
+    expect(acked).toEqual([1, 2])
+  })
+
+  it('acks sync events as no-ops when no handler is registered', async () => {
+    const acked: number[] = []
+    const ix = new LexIndexer()
+    await ix.run(batches([syncEvent(1)]), { ack: (e) => acked.push(e.seq) })
+    expect(acked).toEqual([1])
+  })
+
+  it('surfaces a handler failure and holds the watermark', async () => {
+    const acked: number[] = []
+    const ix = new LexIndexer().sync(() => {
+      throw new Error('handler boom')
+    })
+    await expect(
+      ix.run(batches([syncEvent(1)]), { ack: (e) => acked.push(e.seq) }),
+    ).rejects.toThrow('handler boom')
+    expect(acked).toEqual([])
+  })
+
+  it('passes the handler context signal', async () => {
+    let aborted: boolean | undefined
+    const ix = new LexIndexer().sync((_e, ctx) => {
+      aborted = ctx.signal.aborted
+    })
+    await ix.run(batches([syncEvent(1)]), { ack: () => {} })
+    expect(aborted).toBe(false)
+  })
+})

--- a/packages/jetstream/tests/indexer/lex-indexer-validate.test.ts
+++ b/packages/jetstream/tests/indexer/lex-indexer-validate.test.ts
@@ -1,7 +1,7 @@
-import { l, record } from '@atproto/lex'
+import { type TypedLexMap, l, record } from '@atproto/lex'
 import { describe, expect, expectTypeOf, it } from 'vitest'
 import { type EventBatch, type RawEvent } from '../../src/event.js'
-import { LexIndexer, type UnvalidatedRecord } from '../../src/index.js'
+import { LexIndexer } from '../../src/index.js'
 import { type RawRecordJson } from '../../src/raw-record.js'
 
 const likeSchema = record(
@@ -55,7 +55,7 @@ describe('commit validateRecord', () => {
     expect(invalid).toEqual([2])
   })
 
-  it('validateRecord: false: no runtime checks — schema-invalid and $type-less records both reach put', async () => {
+  it('validateRecord: false: no schema checks — schema-invalid records still reach put', async () => {
     const puts: number[] = []
     const invalid: number[] = []
     const idx = new LexIndexer()
@@ -64,9 +64,7 @@ describe('commit validateRecord', () => {
         validateRecord: false,
         handlers: {
           put: (e) => {
-            expectTypeOf(e.record).toEqualTypeOf<
-              UnvalidatedRecord<'app.test.like'>
-            >()
+            expectTypeOf(e.record).toEqualTypeOf<TypedLexMap<'app.test.like'>>()
             puts.push(e.seq)
           },
         },
@@ -75,7 +73,7 @@ describe('commit validateRecord', () => {
     await idx.run(
       oneBatch([
         putWithRecord(1, { $type: 'app.test.like', subject: 123 }), // schema-invalid: OK
-        putWithRecord(2, { hello: 'no $type' }), // no floor check: also reaches put
+        putWithRecord(2, { $type: 'app.test.like', extra: 'no schema check' }), // schema-invalid: OK
       ]),
       { ack: () => {} },
     )
@@ -107,11 +105,11 @@ describe('commit validateRecord', () => {
     const idx = new LexIndexer().commit(likeSchema, {
       put: (e) => {
         // The simple form keeps the schema-inferred record type (which carries
-        // a branded $type plus the typed fields), NOT the loose
-        // UnvalidatedRecord. Assert the load-bearing distinction: the typed
-        // `subject: string` is present and the record is not UnvalidatedRecord.
+        // a branded $type plus the typed fields), NOT the loose unvalidated
+        // TypedLexMap. Assert the load-bearing distinction: the typed
+        // `subject: string` is present and the record is not a bare TypedLexMap.
         expectTypeOf(e.record.subject).toEqualTypeOf<string>()
-        expectTypeOf(e.record).not.toEqualTypeOf<UnvalidatedRecord>()
+        expectTypeOf(e.record).not.toEqualTypeOf<TypedLexMap>()
         puts.push(e.seq)
       },
     })

--- a/packages/jetstream/tests/indexer/lex-indexer-validate.test.ts
+++ b/packages/jetstream/tests/indexer/lex-indexer-validate.test.ts
@@ -74,11 +74,16 @@ describe('commit validateRecord', () => {
       oneBatch([
         putWithRecord(1, { $type: 'app.test.like', subject: 123 }), // schema-invalid: OK
         putWithRecord(2, { $type: 'app.test.like', extra: 'no schema check' }), // schema-invalid: OK
+        putWithRecord(3, { hello: 'no $type' }), // conversion floor still applies
       ]),
       { ack: () => {} },
     )
+    // validateRecord: false skips SCHEMA checks, but the $type floor (record
+    // conversion, established independent of any collection's schema) still
+    // applies: a $type-less record fails conversion and routes to
+    // onValidationError, never put.
     expect(puts).toEqual([1, 2])
-    expect(invalid).toEqual([])
+    expect(invalid).toEqual([3])
   })
 
   it('validateRecord: false still routes ONLY the registered collection', async () => {

--- a/packages/jetstream/tests/indexer/lex-indexer-validate.test.ts
+++ b/packages/jetstream/tests/indexer/lex-indexer-validate.test.ts
@@ -1,4 +1,4 @@
-import { l, record } from '@atproto/lex-schema'
+import { l, record } from '@atproto/lex'
 import { describe, expect, expectTypeOf, it } from 'vitest'
 import { type EventBatch, type RawEventV1 } from '../../src/event.js'
 import { LexIndexer, type UnvalidatedRecord } from '../../src/index.js'

--- a/packages/jetstream/tests/indexer/lex-indexer-validate.test.ts
+++ b/packages/jetstream/tests/indexer/lex-indexer-validate.test.ts
@@ -1,7 +1,8 @@
 import { l, record } from '@atproto/lex'
 import { describe, expect, expectTypeOf, it } from 'vitest'
-import { type EventBatch, type RawEventV1 } from '../../src/event.js'
+import { type EventBatch, type RawEvent } from '../../src/event.js'
 import { LexIndexer, type UnvalidatedRecord } from '../../src/index.js'
+import { type RawRecordJson } from '../../src/raw-record.js'
 
 const likeSchema = record(
   'tid',
@@ -9,11 +10,11 @@ const likeSchema = record(
   l.object({ subject: l.string() }),
 )
 
-function putWithRecord(seq: number, rec: unknown): RawEventV1 {
+function putWithRecord(seq: number, rec: RawRecordJson): RawEvent {
   return {
     did: 'did:plc:a',
     seq,
-    timeUs: 0,
+    time: '2024-09-09T19:46:02.329308Z',
     kind: 'commit',
     commit: {
       operation: 'create',
@@ -26,7 +27,7 @@ function putWithRecord(seq: number, rec: unknown): RawEventV1 {
   }
 }
 
-function oneBatch(events: RawEventV1[]): AsyncIterable<EventBatch<RawEventV1>> {
+function oneBatch(events: RawEvent[]): AsyncIterable<EventBatch<RawEvent>> {
   return (async function* () {
     yield { events, lastCursor: events[events.length - 1]?.seq ?? 0 }
   })()
@@ -84,7 +85,7 @@ describe('commit validateRecord', () => {
 
   it('validateRecord: false still routes ONLY the registered collection', async () => {
     const puts: number[] = []
-    const other: RawEventV1 = {
+    const other: RawEvent = {
       ...putWithRecord(3, { $type: 'app.test.other' }),
     }
     ;(other as { commit: { collection: string } }).commit.collection =

--- a/packages/jetstream/tests/integration/lex-indexer-run.test.ts
+++ b/packages/jetstream/tests/integration/lex-indexer-run.test.ts
@@ -4,6 +4,11 @@ import { Jetstream, LexIndexer, MemoryCursorStore } from '../../src/index.js'
 import { type LiveTransport } from '../../src/live/transport.js'
 
 const NSID = 'network.bsky.jetstream.subscribeEvents'
+const CID = 'bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a'
+// A well-formed TID (13-char base32-sortable) — wire-valid even though no
+// test here enables validateWire, so a strict-mode test added later doesn't
+// fail on this fixture for an unrelated reason.
+const TID = '3jzfcijpj2z2a'
 
 const likeSchema = record(
   'tid',
@@ -22,8 +27,8 @@ function likeFrame(seq: number, subject: string): string {
       operation: 'create',
       collection: 'app.test.like',
       rkey: 'r' + seq,
-      rev: 'v',
-      cid: 'cid' + seq,
+      rev: TID,
+      cid: CID,
       record: { $type: 'app.test.like', subject },
     },
   })

--- a/packages/jetstream/tests/integration/lex-indexer-run.test.ts
+++ b/packages/jetstream/tests/integration/lex-indexer-run.test.ts
@@ -3,32 +3,33 @@ import { describe, expect, it } from 'vitest'
 import { Jetstream, LexIndexer, MemoryCursorStore } from '../../src/index.js'
 import { type LiveTransport } from '../../src/live/transport.js'
 
+const NSID = 'network.bsky.jetstream.subscribeEvents'
+
 const likeSchema = record(
   'tid',
   'app.test.like',
   l.object({ subject: l.string() }),
 )
 
-function likeFrame(seq: number, subject: string): Uint8Array {
-  // v1 live frame carries the record as parsed JSON
-  return new TextEncoder().encode(
-    JSON.stringify({
+function likeFrame(seq: number, subject: string): string {
+  return JSON.stringify({
+    $type: 'message',
+    payload: {
+      $type: `${NSID}#commit`,
+      seq,
       did: 'did:plc:a',
-      kind: 'commit',
-      time_us: seq,
-      commit: {
-        operation: 'create',
-        collection: 'app.test.like',
-        rkey: 'r' + seq,
-        rev: 'v',
-        cid: 'cid' + seq,
-        record: { $type: 'app.test.like', subject },
-      },
-    }),
-  )
+      time: '2024-09-09T19:46:02.329308Z',
+      operation: 'create',
+      collection: 'app.test.like',
+      rkey: 'r' + seq,
+      rev: 'v',
+      cid: 'cid' + seq,
+      record: { $type: 'app.test.like', subject },
+    },
+  })
 }
 
-function fakeTransport(frames: Uint8Array[]): LiveTransport {
+function fakeTransport(frames: string[]): LiveTransport {
   return {
     async *stream() {
       for (const f of frames) yield f

--- a/packages/jetstream/tests/integration/lex-indexer-run.test.ts
+++ b/packages/jetstream/tests/integration/lex-indexer-run.test.ts
@@ -1,4 +1,4 @@
-import { l, record } from '@atproto/lex-schema'
+import { l, record } from '@atproto/lex'
 import { describe, expect, it } from 'vitest'
 import { Jetstream, LexIndexer, MemoryCursorStore } from '../../src/index.js'
 import { type LiveTransport } from '../../src/live/transport.js'

--- a/packages/jetstream/tests/integration/live-real.test.ts
+++ b/packages/jetstream/tests/integration/live-real.test.ts
@@ -1,19 +1,33 @@
 import { expect, test } from 'vitest'
+import { JetstreamV1 } from '../../src/jetstream-v1.js'
 import { Jetstream } from '../../src/jetstream.js'
 
 const HOST = process.env.JETSTREAM_LIVE_HOST // e.g. https://jetstream1.us-east.bsky.network
+// The public jetstream*.bsky.network hosts speak v1 today. Set
+// JETSTREAM_LIVE_VERSION=2 to point this at a v2 deployment.
+const VERSION = process.env.JETSTREAM_LIVE_VERSION === '2' ? 2 : 1
 const maybe = HOST ? test : test.skip
 
 maybe(
   'live() decodes real frames from a running jetstream',
   async () => {
-    const js = new Jetstream({ service: HOST! })
     const signal = AbortSignal.timeout(15000)
+    // Calling live() on a Jetstream | JetstreamV1 union does not
+    // overload-resolve (the two classes' live() overload sets don't
+    // reconcile across the union), so each branch calls its own live() and
+    // only the resulting generators are unioned.
+    const stream =
+      VERSION === 2
+        ? new Jetstream(HOST!).live({
+            collections: ['app.bsky.feed.post'],
+            signal,
+          })
+        : new JetstreamV1(HOST!).live({
+            collections: ['app.bsky.feed.post'],
+            signal,
+          })
     const seen: string[] = []
-    for await (const e of js.live({
-      collections: ['app.bsky.feed.post'],
-      signal,
-    })) {
+    for await (const e of stream) {
       if (e.kind === 'commit' && e.commit.operation !== 'delete') {
         expect(e.commit.cid).toMatch(/^bafy/)
         seen.push(e.commit.collection)

--- a/packages/jetstream/tests/jetstream/filter-narrowing.test.ts
+++ b/packages/jetstream/tests/jetstream/filter-narrowing.test.ts
@@ -6,7 +6,11 @@ import {
   record,
 } from '@atproto/lex'
 import { describe, expect, expectTypeOf, it } from 'vitest'
-import { Jetstream, type UnvalidatedRecord } from '../../src/index.js'
+import {
+  Jetstream,
+  type RawRecordJson,
+  type UnvalidatedRecord,
+} from '../../src/index.js'
 import type { LiveTransport } from '../../src/live/transport.js'
 
 const likeSchema = record(
@@ -100,7 +104,7 @@ describe('live() filter narrowing (public API)', () => {
     })) {
       seqs.push(ev.seq)
       if (ev.kind === 'commit' && ev.commit.operation !== 'delete') {
-        expectTypeOf(ev.commit.record).toEqualTypeOf<unknown>()
+        expectTypeOf(ev.commit.record).toEqualTypeOf<RawRecordJson>()
       }
     }
     expect(seqs).toEqual([1]) // invalid record NOT skipped in raw mode

--- a/packages/jetstream/tests/jetstream/filter-narrowing.test.ts
+++ b/packages/jetstream/tests/jetstream/filter-narrowing.test.ts
@@ -2,15 +2,12 @@ import {
   type DidString,
   type InferOutput,
   type NsidString,
+  type TypedLexMap,
   l,
   record,
 } from '@atproto/lex'
 import { describe, expect, expectTypeOf, it } from 'vitest'
-import {
-  Jetstream,
-  type RawRecordJson,
-  type UnvalidatedRecord,
-} from '../../src/index.js'
+import { Jetstream, type RawRecordJson } from '../../src/index.js'
 import type { LiveTransport } from '../../src/live/transport.js'
 
 const likeSchema = record(
@@ -68,7 +65,7 @@ describe('live() filter narrowing (public API)', () => {
         }
         if (ev.commit.collection === 'app.test.post') {
           expectTypeOf(ev.commit.record).toEqualTypeOf<
-            UnvalidatedRecord<'app.test.post'>
+            TypedLexMap<'app.test.post'>
           >()
           posts.push(ev.seq)
         }
@@ -86,7 +83,7 @@ describe('live() filter narrowing (public API)', () => {
       ]),
     })) {
       if (ev.kind === 'commit' && ev.commit.operation !== 'delete') {
-        expectTypeOf(ev.commit.record).toEqualTypeOf<unknown>()
+        expectTypeOf(ev.commit.record).toEqualTypeOf<TypedLexMap>()
         expectTypeOf(ev.commit.collection).toEqualTypeOf<NsidString>()
       }
     }

--- a/packages/jetstream/tests/jetstream/filter-narrowing.test.ts
+++ b/packages/jetstream/tests/jetstream/filter-narrowing.test.ts
@@ -7,7 +7,7 @@ import {
   record,
 } from '@atproto/lex'
 import { describe, expect, expectTypeOf, it } from 'vitest'
-import { Jetstream, type RawRecordJson } from '../../src/index.js'
+import { JetstreamV1, type RawRecordJson } from '../../src/index.js'
 import type { LiveTransport } from '../../src/live/transport.js'
 
 const likeSchema = record(
@@ -45,7 +45,7 @@ function fakeTransport(frames: string[]): LiveTransport {
 
 describe('live() filter narrowing (public API)', () => {
   it('mixed filters: correlated narrowing + validation skip, end to end', async () => {
-    const jetstream = new Jetstream({ service: 'https://js.example' })
+    const jetstream = new JetstreamV1({ service: 'https://js.example' })
     const likes: Like[] = []
     const posts: number[] = []
     for await (const ev of jetstream.live({
@@ -76,7 +76,7 @@ describe('live() filter narrowing (public API)', () => {
   })
 
   it('no collections filter still yields plain TypedEvent', async () => {
-    const jetstream = new Jetstream({ service: 'https://js.example' })
+    const jetstream = new JetstreamV1({ service: 'https://js.example' })
     for await (const ev of jetstream.live({
       liveTransport: fakeTransport([
         frame(1, 'app.test.like', { $type: 'app.test.like', subject: 'ok' }),
@@ -90,7 +90,7 @@ describe('live() filter narrowing (public API)', () => {
   })
 
   it('raw mode is untouched by schema filters (no skip, RawEventV1 shape)', async () => {
-    const jetstream = new Jetstream({ service: 'https://js.example' })
+    const jetstream = new JetstreamV1({ service: 'https://js.example' })
     const seqs: number[] = []
     for await (const ev of jetstream.live({
       raw: true,

--- a/packages/jetstream/tests/jetstream/filter-narrowing.test.ts
+++ b/packages/jetstream/tests/jetstream/filter-narrowing.test.ts
@@ -4,7 +4,7 @@ import {
   type NsidString,
   l,
   record,
-} from '@atproto/lex-schema'
+} from '@atproto/lex'
 import { describe, expect, expectTypeOf, it } from 'vitest'
 import { Jetstream, type UnvalidatedRecord } from '../../src/index.js'
 import type { LiveTransport } from '../../src/live/transport.js'

--- a/packages/jetstream/tests/jetstream/live-v1.test.ts
+++ b/packages/jetstream/tests/jetstream/live-v1.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { MemoryCursorStore } from '../../src/execute/cursor-store.js'
-import { Jetstream } from '../../src/jetstream.js'
+import { JetstreamV1 } from '../../src/jetstream-v1.js'
 import { type LiveTransport } from '../../src/live/transport.js'
 
 const te = new TextEncoder()
@@ -28,9 +28,9 @@ function fakeTransport(seqs: number[]): LiveTransport {
   }
 }
 
-describe('Jetstream.live', () => {
+describe('JetstreamV1.live', () => {
   it('typed yields one TypedEvent per frame', async () => {
-    const js = new Jetstream({ service: 'https://js.example' })
+    const js = new JetstreamV1({ service: 'https://js.example' })
     const out: number[] = []
     for await (const evt of js.live({
       liveTransport: fakeTransport([1, 2, 3]),
@@ -43,7 +43,7 @@ describe('Jetstream.live', () => {
   it('reads resume cursor from the store as the dedup floor', async () => {
     const store = new MemoryCursorStore()
     await store.save(2)
-    const js = new Jetstream({ service: 'https://js.example' })
+    const js = new JetstreamV1({ service: 'https://js.example' })
     const out: number[] = []
     for await (const evt of js.live({
       cursor: store,

--- a/packages/jetstream/tests/jetstream/live-validate-v1.test.ts
+++ b/packages/jetstream/tests/jetstream/live-validate-v1.test.ts
@@ -1,6 +1,6 @@
 import { l, record } from '@atproto/lex'
 import { describe, expect, it } from 'vitest'
-import { Jetstream, RecordValidationError } from '../../src/index.js'
+import { JetstreamV1, RecordValidationError } from '../../src/index.js'
 import type { LiveTransport } from '../../src/live/transport.js'
 
 const likeSchema = record(
@@ -35,9 +35,9 @@ function fakeTransport(frames: string[]): LiveTransport {
   }
 }
 
-describe('live() with a validating schema filter', () => {
+describe('JetstreamV1.live() with a validating schema filter', () => {
   it('yields only valid records; invalid ones go to onError as RecordValidationError', async () => {
-    const jetstream = new Jetstream({ service: 'https://js.example' })
+    const jetstream = new JetstreamV1({ service: 'https://js.example' })
     const errors: Error[] = []
     const seqs: number[] = []
     for await (const ev of jetstream.live({

--- a/packages/jetstream/tests/jetstream/live-validate.test.ts
+++ b/packages/jetstream/tests/jetstream/live-validate.test.ts
@@ -1,4 +1,4 @@
-import { l, record } from '@atproto/lex-schema'
+import { l, record } from '@atproto/lex'
 import { describe, expect, it } from 'vitest'
 import { Jetstream, RecordValidationError } from '../../src/index.js'
 import type { LiveTransport } from '../../src/live/transport.js'

--- a/packages/jetstream/tests/jetstream/live.test.ts
+++ b/packages/jetstream/tests/jetstream/live.test.ts
@@ -1,7 +1,8 @@
 import { l, record } from '@atproto/lex'
 import { describe, expect, it } from 'vitest'
+import { type TypedEvent } from '../../src/event.js'
 import { MemoryCursorStore } from '../../src/execute/cursor-store.js'
-import { Jetstream } from '../../src/index.js'
+import { Jetstream, RecordValidationError } from '../../src/index.js'
 import { type LiveTransport } from '../../src/live/transport.js'
 
 const NSID = 'network.bsky.jetstream.subscribeEvents'
@@ -175,6 +176,49 @@ describe('Jetstream.live (v2)', () => {
     expect(seqs).toEqual([1])
     expect(errors).toHaveLength(1)
     expect(errors[0].name).toBe('RecordValidationError')
+  })
+
+  it('typed mode: strict tightens record conversion; default mode does not', async () => {
+    // 1.5 is a non-integer number: strict conversion (matching validateWire)
+    // rejects it, loose conversion accepts it as-is.
+    const float = { $type: 'app.test.rec', n: 1.5 }
+
+    const strictErrors: Error[] = []
+    const strictJs = new Jetstream({
+      service: 'https://js.example',
+      validateWire: true,
+    })
+    const strictOut: unknown[] = []
+    for await (const ev of strictJs.live({
+      liveTransport: fakeTransport([putFrame(1, float)]),
+      onError: (err) => strictErrors.push(err),
+    })) {
+      strictOut.push(ev)
+    }
+    // The conversion failure is skipped and reported, never delivered.
+    expect(strictOut).toHaveLength(0)
+    expect(strictErrors).toHaveLength(1)
+    expect(strictErrors[0]).toBeInstanceOf(RecordValidationError)
+
+    const defaultJs = new Jetstream('https://js.example')
+    const defaultOut: TypedEvent[] = []
+    for await (const ev of defaultJs.live({
+      liveTransport: fakeTransport([putFrame(1, float)]),
+      onError: () => {
+        throw new Error('default mode must not report a conversion error')
+      },
+    })) {
+      defaultOut.push(ev)
+    }
+    expect(defaultOut).toHaveLength(1)
+    const defaultEv = defaultOut[0]
+    if (
+      defaultEv.kind !== 'commit' ||
+      defaultEv.commit.operation === 'delete'
+    ) {
+      throw new Error('expected a put commit')
+    }
+    expect(defaultEv.commit.validationError).toBeUndefined()
   })
 
   it('makes a malformed frame fatal under validateWire', async () => {

--- a/packages/jetstream/tests/jetstream/live.test.ts
+++ b/packages/jetstream/tests/jetstream/live.test.ts
@@ -7,6 +7,9 @@ import { type LiveTransport } from '../../src/live/transport.js'
 const NSID = 'network.bsky.jetstream.subscribeEvents'
 const CID = 'bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a'
 const TIME = '2024-09-09T19:46:02.329308Z'
+// A well-formed TID (13-char base32-sortable) — required so the strict-mode
+// test below (which is about `did`, not `rev`) doesn't spuriously fail on it.
+const TID = '3jzfcijpj2z2a'
 
 const deleteFrame = (seq: number): string =>
   JSON.stringify({
@@ -16,7 +19,7 @@ const deleteFrame = (seq: number): string =>
       seq,
       did: 'did:plc:a',
       time: TIME,
-      rev: 'rev',
+      rev: TID,
       operation: 'delete',
       collection: 'app.test.rec',
       rkey: `r${seq}`,
@@ -31,7 +34,7 @@ const putFrame = (seq: number, rec: unknown): string =>
       seq,
       did: 'did:plc:a',
       time: TIME,
-      rev: 'rev',
+      rev: TID,
       operation: 'create',
       collection: 'app.test.rec',
       rkey: `r${seq}`,
@@ -48,7 +51,7 @@ const syncFrame = (seq: number): string =>
       seq,
       did: 'did:plc:a',
       time: TIME,
-      sync: { did: 'did:plc:a', rev: 'rev' },
+      sync: { did: 'did:plc:a', rev: TID },
     },
   })
 
@@ -186,7 +189,7 @@ describe('Jetstream.live (v2)', () => {
         seq: 1,
         did: 'not-a-did',
         time: TIME,
-        rev: 'rev',
+        rev: TID,
         operation: 'delete',
         collection: 'app.test.rec',
         rkey: 'r1',

--- a/packages/jetstream/tests/jetstream/live.test.ts
+++ b/packages/jetstream/tests/jetstream/live.test.ts
@@ -1,0 +1,201 @@
+import { l, record } from '@atproto/lex'
+import { describe, expect, it } from 'vitest'
+import { MemoryCursorStore } from '../../src/execute/cursor-store.js'
+import { Jetstream } from '../../src/index.js'
+import { type LiveTransport } from '../../src/live/transport.js'
+
+const NSID = 'network.bsky.jetstream.subscribeEvents'
+const CID = 'bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a'
+const TIME = '2024-09-09T19:46:02.329308Z'
+
+const deleteFrame = (seq: number): string =>
+  JSON.stringify({
+    $type: 'message',
+    payload: {
+      $type: `${NSID}#commit`,
+      seq,
+      did: 'did:plc:a',
+      time: TIME,
+      rev: 'rev',
+      operation: 'delete',
+      collection: 'app.test.rec',
+      rkey: `r${seq}`,
+    },
+  })
+
+const putFrame = (seq: number, rec: unknown): string =>
+  JSON.stringify({
+    $type: 'message',
+    payload: {
+      $type: `${NSID}#commit`,
+      seq,
+      did: 'did:plc:a',
+      time: TIME,
+      rev: 'rev',
+      operation: 'create',
+      collection: 'app.test.rec',
+      rkey: `r${seq}`,
+      cid: CID,
+      record: rec,
+    },
+  })
+
+const syncFrame = (seq: number): string =>
+  JSON.stringify({
+    $type: 'message',
+    payload: {
+      $type: `${NSID}#sync`,
+      seq,
+      did: 'did:plc:a',
+      time: TIME,
+      sync: { did: 'did:plc:a', rev: 'rev' },
+    },
+  })
+
+function fakeTransport(frames: string[]): LiveTransport & { urls: string[] } {
+  const urls: string[] = []
+  return {
+    urls,
+    async *stream(getUrl) {
+      urls.push(getUrl())
+      for (const f of frames) yield f
+    },
+  }
+}
+
+describe('Jetstream.live (v2)', () => {
+  it('dials the v2 endpoint by default', async () => {
+    const t = fakeTransport([deleteFrame(1)])
+    const js = new Jetstream({ service: 'https://js.example' })
+    for await (const _ of js.live({ liveTransport: t })) void _
+    expect(t.urls[0]).toContain(`/xrpc/${NSID}`)
+  })
+
+  it('yields one typed event per frame', async () => {
+    const js = new Jetstream('https://js.example')
+    const out: number[] = []
+    for await (const evt of js.live({
+      liveTransport: fakeTransport([
+        deleteFrame(1),
+        deleteFrame(2),
+        deleteFrame(3),
+      ]),
+    })) {
+      out.push(evt.seq)
+    }
+    expect(out).toEqual([1, 2, 3])
+  })
+
+  it('delivers sync events', async () => {
+    const js = new Jetstream('https://js.example')
+    const kinds: string[] = []
+    for await (const evt of js.live({
+      liveTransport: fakeTransport([syncFrame(1), deleteFrame(2)]),
+    })) {
+      kinds.push(evt.kind)
+    }
+    expect(kinds).toEqual(['sync', 'commit'])
+  })
+
+  it('sends the kinds filter', async () => {
+    const t = fakeTransport([deleteFrame(1)])
+    const js = new Jetstream('https://js.example')
+    for await (const _ of js.live({ liveTransport: t, kinds: ['commit'] }))
+      void _
+    expect(t.urls[0]).toContain('kinds=commit')
+  })
+
+  it('converts typed records to lex data', async () => {
+    const schema = record('tid', 'app.test.rec', l.object({ text: l.string() }))
+    const js = new Jetstream('https://js.example')
+    const texts: string[] = []
+    for await (const evt of js.live({
+      collections: [schema],
+      liveTransport: fakeTransport([
+        putFrame(1, { $type: 'app.test.rec', text: 'hi' }),
+      ]),
+    })) {
+      if (evt.kind === 'commit' && evt.commit.operation !== 'delete') {
+        texts.push(evt.commit.record.text)
+      }
+    }
+    expect(texts).toEqual(['hi'])
+  })
+
+  it('uses a stored cursor as both wire cursor and dedup floor', async () => {
+    const cursor = new MemoryCursorStore()
+    await cursor.save(2)
+    const t = fakeTransport([deleteFrame(2), deleteFrame(3)])
+    const js = new Jetstream('https://js.example')
+    const out: number[] = []
+    for await (const evt of js.live({ cursor, liveTransport: t })) {
+      out.push(evt.seq)
+    }
+    expect(t.urls[0]).toContain('cursor=2')
+    expect(out).toEqual([3]) // the replayed seq 2 is deduped
+  })
+
+  it('yields raw events with raw: true', async () => {
+    const js = new Jetstream('https://js.example')
+    const out: unknown[] = []
+    for await (const evt of js.live({
+      raw: true,
+      liveTransport: fakeTransport([
+        putFrame(1, { $type: 'app.test.rec', text: 'x' }),
+      ]),
+    })) {
+      out.push(evt)
+    }
+    expect(out).toHaveLength(1)
+    // Raw records stay wire-faithful — no conversion on this path.
+    expect(out[0]).toMatchObject({
+      kind: 'commit',
+      commit: { record: { $type: 'app.test.rec', text: 'x' } },
+    })
+  })
+
+  it('skips schema-invalid records and reports RecordValidationError', async () => {
+    const schema = record('tid', 'app.test.rec', l.object({ text: l.string() }))
+    const js = new Jetstream('https://js.example')
+    const errors: Error[] = []
+    const seqs: number[] = []
+    for await (const evt of js.live({
+      collections: [schema],
+      onError: (e) => errors.push(e),
+      liveTransport: fakeTransport([
+        putFrame(1, { $type: 'app.test.rec', text: 'ok' }),
+        putFrame(2, { $type: 'app.test.rec', text: 123 }), // invalid
+      ]),
+    })) {
+      seqs.push(evt.seq)
+    }
+    expect(seqs).toEqual([1])
+    expect(errors).toHaveLength(1)
+    expect(errors[0].name).toBe('RecordValidationError')
+  })
+
+  it('makes a malformed frame fatal under validateWire', async () => {
+    const js = new Jetstream({
+      service: 'https://js.example',
+      validateWire: true,
+    })
+    const bad = JSON.stringify({
+      $type: 'message',
+      payload: {
+        $type: `${NSID}#commit`,
+        seq: 1,
+        did: 'not-a-did',
+        time: TIME,
+        rev: 'rev',
+        operation: 'delete',
+        collection: 'app.test.rec',
+        rkey: 'r1',
+      },
+    })
+    await expect(async () => {
+      for await (const _ of js.live({ liveTransport: fakeTransport([bad]) })) {
+        void _
+      }
+    }).rejects.toThrow(/wire validation failed/)
+  })
+})

--- a/packages/jetstream/tests/jetstream/runner.test.ts
+++ b/packages/jetstream/tests/jetstream/runner.test.ts
@@ -1,7 +1,8 @@
+import { l, record } from '@atproto/lex'
 import { describe, expect, it } from 'vitest'
 import { type JetstreamConsumer } from '../../src/consumer.js'
 import { MemoryCursorStore } from '../../src/execute/cursor-store.js'
-import { Jetstream, JetstreamRunner } from '../../src/index.js'
+import { Jetstream, JetstreamRunner, LexIndexer } from '../../src/index.js'
 import { type LiveTransport } from '../../src/live/transport.js'
 
 const NSID = 'network.bsky.jetstream.subscribeEvents'
@@ -32,6 +33,27 @@ function fakeTransport(seqs: number[]): LiveTransport {
     },
   }
 }
+
+// Records the request URL(s) and ends the stream immediately (no frames) —
+// enough to observe what the runner asked the wire for.
+function urlRecordingTransport(): { transport: LiveTransport; urls: string[] } {
+  const urls: string[] = []
+  return {
+    transport: {
+      // eslint-disable-next-line require-yield
+      async *stream(getUrl) {
+        urls.push(getUrl())
+      },
+    },
+    urls,
+  }
+}
+
+const likeSchema = record(
+  'tid',
+  'app.test.like',
+  l.object({ subject: l.string() }),
+)
 
 describe('JetstreamRunner', () => {
   it('drives a live indexer end to end and persists the contiguous watermark', async () => {
@@ -127,5 +149,22 @@ describe('JetstreamRunner', () => {
     })
     expect(seen).toEqual([1, 2, 3])
     expect(await store.load()).toBe(3)
+  })
+
+  it("derives the wire request from the consumer's registrations (collections + kinds)", async () => {
+    // A commit collection plus a sync handler, and nothing else registered:
+    // kinds should list exactly commit and sync, never identity/account.
+    const ix = new LexIndexer()
+      .commit(likeSchema, { put: () => {} })
+      .sync(() => {})
+    const { transport, urls } = urlRecordingTransport()
+    const js = new Jetstream({ service: 'https://js.example' })
+    await js.runner(ix).live({ liveTransport: transport })
+    expect(urls).toHaveLength(1)
+    expect(urls[0]).toContain('collections=app.test.like')
+    expect(urls[0]).toContain('kinds=commit')
+    expect(urls[0]).toContain('kinds=sync')
+    expect(urls[0]).not.toContain('kinds=identity')
+    expect(urls[0]).not.toContain('kinds=account')
   })
 })

--- a/packages/jetstream/tests/jetstream/runner.test.ts
+++ b/packages/jetstream/tests/jetstream/runner.test.ts
@@ -4,25 +4,26 @@ import { MemoryCursorStore } from '../../src/execute/cursor-store.js'
 import { Jetstream, JetstreamRunner } from '../../src/index.js'
 import { type LiveTransport } from '../../src/live/transport.js'
 
-// fake transport emitting v1 JSON delete-commit frames then ending
+const NSID = 'network.bsky.jetstream.subscribeEvents'
+
+// fake transport emitting v2 delete-commit frames then ending
 function fakeTransport(seqs: number[]): LiveTransport {
-  const enc = new TextEncoder()
   return {
     async *stream() {
       for (const seq of seqs) {
-        yield enc.encode(
-          JSON.stringify({
+        yield JSON.stringify({
+          $type: 'message',
+          payload: {
+            $type: `${NSID}#commit`,
+            seq,
             did: 'did:plc:a',
-            kind: 'commit',
-            time_us: seq,
-            commit: {
-              operation: 'delete',
-              collection: 'app.test.rec',
-              rkey: 'r' + seq,
-              rev: 'v',
-            },
-          }),
-        )
+            time: '2024-09-09T19:46:02.329308Z',
+            rev: 'v',
+            operation: 'delete',
+            collection: 'app.test.rec',
+            rkey: 'r' + seq,
+          },
+        })
       }
     },
   }

--- a/packages/jetstream/tests/jetstream/runner.test.ts
+++ b/packages/jetstream/tests/jetstream/runner.test.ts
@@ -5,6 +5,10 @@ import { Jetstream, JetstreamRunner } from '../../src/index.js'
 import { type LiveTransport } from '../../src/live/transport.js'
 
 const NSID = 'network.bsky.jetstream.subscribeEvents'
+// A well-formed TID (13-char base32-sortable) — wire-valid even though no
+// test here enables validateWire, so a strict-mode test added later doesn't
+// fail on this fixture for an unrelated reason.
+const TID = '3jzfcijpj2z2a'
 
 // fake transport emitting v2 delete-commit frames then ending
 function fakeTransport(seqs: number[]): LiveTransport {
@@ -18,7 +22,7 @@ function fakeTransport(seqs: number[]): LiveTransport {
             seq,
             did: 'did:plc:a',
             time: '2024-09-09T19:46:02.329308Z',
-            rev: 'v',
+            rev: TID,
             operation: 'delete',
             collection: 'app.test.rec',
             rkey: 'r' + seq,

--- a/packages/jetstream/tests/jetstream/surface.test.ts
+++ b/packages/jetstream/tests/jetstream/surface.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, expectTypeOf, it } from 'vitest'
-import { Jetstream, JetstreamV1, type RawEventV1 } from '../../src/index.js'
+import {
+  Jetstream,
+  JetstreamV1,
+  type RawEvent,
+  type RawEventV1,
+} from '../../src/index.js'
 
 describe('class surfaces', () => {
   it('Jetstream drives v2 and owns the runner path', () => {
@@ -32,10 +37,16 @@ describe('class surfaces', () => {
     expectTypeOf(v1.live({ raw: true })).toEqualTypeOf<
       AsyncGenerator<RawEventV1>
     >()
-    // The matching Jetstream/RawEvent assertion lands in Task 10: Jetstream
-    // is still pinned to the v1 wire (see the TEMPORARY marker in
-    // jetstream.ts) until that task flips it, so today its raw arm is also
-    // typed AsyncGenerator<RawEventV1> — asserting RawEvent here would fail.
+    const v2 = new Jetstream('https://h')
+    expectTypeOf(v2.live({ raw: true })).toEqualTypeOf<
+      AsyncGenerator<RawEvent>
+    >()
+  })
+
+  it('the kinds filter is available on v2', () => {
+    const v2 = new Jetstream('https://h')
+    void v2.live({ kinds: ['commit', 'sync'] })
+    expectTypeOf(v2.live).toBeFunction()
   })
 
   it('typed v1 events carry no sync arm', () => {

--- a/packages/jetstream/tests/jetstream/surface.test.ts
+++ b/packages/jetstream/tests/jetstream/surface.test.ts
@@ -70,4 +70,10 @@ describe('class surfaces', () => {
     // @ts-expect-error LiveV1Opts has no kinds — the v1 wire has no such param
     void v1.live({ kinds: ['commit'] })
   })
+
+  it('onInfo is rejected on v1', () => {
+    const v1 = new JetstreamV1('https://h')
+    // @ts-expect-error LiveV1Opts has no onInfo — the v1 wire has no #info frame
+    void v1.live({ onInfo: () => {} })
+  })
 })

--- a/packages/jetstream/tests/jetstream/surface.test.ts
+++ b/packages/jetstream/tests/jetstream/surface.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { Jetstream, JetstreamV1, type RawEventV1 } from '../../src/index.js'
+
+describe('class surfaces', () => {
+  it('Jetstream drives v2 and owns the runner path', () => {
+    const js = new Jetstream('https://h')
+    expect(typeof js.live).toBe('function')
+    expect(typeof js.runner).toBe('function')
+    expect(typeof js.liveRawBatches).toBe('function')
+  })
+
+  it('JetstreamV1 offers live() only', () => {
+    const js = new JetstreamV1('https://h')
+    expect(typeof js.live).toBe('function')
+    // v1 cannot support the runner/consumer path, so it does not express it.
+    expect('runner' in js).toBe(false)
+    expect('liveRawBatches' in js).toBe(false)
+    expect('snapshot' in js).toBe(false)
+    expect('replay' in js).toBe(false)
+  })
+
+  it('accepts a bare service string or an options object', () => {
+    expect(new JetstreamV1('https://h').service).toBe('https://h')
+    expect(
+      new JetstreamV1({ service: 'https://h', validateWire: true }).opts
+        .validateWire,
+    ).toBe(true)
+  })
+
+  it('raw yields narrow by version', () => {
+    const v1 = new JetstreamV1('https://h')
+    expectTypeOf(v1.live({ raw: true })).toEqualTypeOf<
+      AsyncGenerator<RawEventV1>
+    >()
+    // The matching Jetstream/RawEvent assertion lands in Task 10: Jetstream
+    // is still pinned to the v1 wire (see the TEMPORARY marker in
+    // jetstream.ts) until that task flips it, so today its raw arm is also
+    // typed AsyncGenerator<RawEventV1> — asserting RawEvent here would fail.
+  })
+
+  it('typed v1 events carry no sync arm', () => {
+    const v1 = new JetstreamV1('https://h')
+    const gen = v1.live()
+    void gen // referenced only in a type position below; keep it "used"
+    // Narrow to the yield branch before reading `value` — IteratorResult's
+    // done branch has `value: any`, which would otherwise structurally
+    // satisfy `{ kind: 'sync' }` and make the Extract below never resolve to
+    // never regardless of what v1 actually yields.
+    type V1Yielded = Extract<
+      Awaited<ReturnType<typeof gen.next>>,
+      { done?: false }
+    >['value']
+    // v1 never emits sync, so a v1 consumer never switches on it.
+    expectTypeOf<Extract<V1Yielded, { kind: 'sync' }>>().toBeNever()
+  })
+
+  it('the kinds filter is rejected on v1', () => {
+    const v1 = new JetstreamV1('https://h')
+    // @ts-expect-error LiveV1Opts has no kinds — the v1 wire has no such param
+    void v1.live({ kinds: ['commit'] })
+  })
+})

--- a/packages/jetstream/tests/jetstream/v1-types.test.ts
+++ b/packages/jetstream/tests/jetstream/v1-types.test.ts
@@ -11,7 +11,7 @@ import {
   type RawRecordJson,
   type SeqEvent,
   type Sync,
-  type TypedEventV1,
+  type TypedEvent,
 } from '../../src/index.js'
 
 describe('the two wires have their own envelopes', () => {
@@ -79,15 +79,15 @@ describe('consumer seam', () => {
   })
 })
 
-describe('Jetstream is still v1-backed', () => {
-  it('live()/liveRawBatches() promise v1 shapes, not the v2 seam types', () => {
+describe('Jetstream is v2-backed', () => {
+  it('live()/liveRawBatches() promise v2 shapes, matching the seam types', () => {
     const js = new Jetstream('https://h')
     expectTypeOf(js.live({ raw: true })).toEqualTypeOf<
-      AsyncGenerator<RawEventV1>
+      AsyncGenerator<RawEvent>
     >()
-    expectTypeOf(js.live()).toEqualTypeOf<AsyncGenerator<TypedEventV1>>()
+    expectTypeOf(js.live()).toEqualTypeOf<AsyncGenerator<TypedEvent>>()
     expectTypeOf(js.liveRawBatches({})).toEqualTypeOf<
-      AsyncGenerator<EventBatch<RawEventV1>>
+      AsyncGenerator<EventBatch<RawEvent>>
     >()
   })
 })

--- a/packages/jetstream/tests/jetstream/v1-types.test.ts
+++ b/packages/jetstream/tests/jetstream/v1-types.test.ts
@@ -1,58 +1,78 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import type {
   Ack,
+  EventBase,
+  EventBaseV1,
   EventBatch,
   JetstreamConsumer,
+  RawEvent,
   RawEventV1,
+  RawRecordJson,
   SeqEvent,
-  TypedEvent,
+  Sync,
 } from '../../src/index.js'
-import { Jetstream } from '../../src/index.js'
-import { liveEvents } from '../../src/live/source.js'
 
-describe('live() types', () => {
-  it('raw live yields RawEventV1; typed live yields TypedEvent', () => {
-    const js = new Jetstream('https://h')
-
-    expectTypeOf(js.live({ raw: true })).toEqualTypeOf<
-      AsyncGenerator<RawEventV1>
-    >()
-    expectTypeOf(js.live()).toEqualTypeOf<AsyncGenerator<TypedEvent>>()
-  })
-})
-
-describe('SeqEvent envelope', () => {
-  it('liveEvents declares RawEventV1', () => {
-    expectTypeOf(liveEvents({ host: 'https://h' })).toEqualTypeOf<
-      AsyncGenerator<RawEventV1>
-    >()
+describe('the two wires have their own envelopes', () => {
+  it('v1 carries timeUs (which is its cursor); v2 carries a datetime string', () => {
+    expectTypeOf<EventBaseV1['timeUs']>().toEqualTypeOf<number>()
+    expectTypeOf<EventBase['time']>().toBeString()
+    // No cross-contamination: neither envelope carries the other's field.
+    expectTypeOf<EventBase>().not.toHaveProperty('timeUs')
+    expectTypeOf<EventBaseV1>().not.toHaveProperty('time')
   })
 
-  it('the consumer seam element is RawEventV1 and satisfies SeqEvent', () => {
-    type SeamStream = Parameters<JetstreamConsumer['run']>[0]
-    expectTypeOf<SeamStream>().toEqualTypeOf<
-      AsyncIterable<EventBatch<RawEventV1>>
+  it('kind sets differ — only v2 emits sync', () => {
+    expectTypeOf<RawEventV1['kind']>().toEqualTypeOf<
+      'commit' | 'identity' | 'account'
     >()
-    // Every seam element satisfies the minimal envelope.
-    expectTypeOf<RawEventV1>().toMatchTypeOf<SeqEvent>()
+    expectTypeOf<RawEvent['kind']>().toEqualTypeOf<
+      'commit' | 'identity' | 'account' | 'sync'
+    >()
+    type SyncArm = Extract<RawEvent, { kind: 'sync' }>
+    expectTypeOf<SyncArm['sync']>().toEqualTypeOf<Sync>()
   })
 
-  it('a consumer cannot read recordCbor (v1 carries parsed JSON records)', () => {
-    const readCbor = (ev: RawEventV1): Uint8Array | undefined => {
-      if (ev.kind !== 'commit') return undefined
-      // @ts-expect-error recordCbor is not present on v1 commits; reading it
-      // is a compile error — the honest surface.
+  it('a v1 event is deliberately NOT a RawEvent', () => {
+    // The envelopes diverge, so the v2-only consumer path cannot be fed v1
+    // events by accident.
+    expectTypeOf<RawEventV1>().not.toExtend<RawEvent>()
+  })
+
+  it('both satisfy the minimal tracking envelope', () => {
+    expectTypeOf<RawEvent>().toExtend<SeqEvent>()
+    expectTypeOf<RawEventV1>().toExtend<SeqEvent>()
+  })
+
+  it('the commit payload is shared', () => {
+    type V1Commit = Extract<RawEventV1, { kind: 'commit' }>['commit']
+    type V2Commit = Extract<
+      RawEvent<RawRecordJson>,
+      { kind: 'commit' }
+    >['commit']
+    expectTypeOf<V1Commit>().toEqualTypeOf<V2Commit>()
+  })
+
+  it('a put record is wire JSON, and recordCbor does not exist', () => {
+    const readCbor = (ev: RawEvent): unknown => {
+      if (ev.kind !== 'commit' || ev.commit.operation === 'delete') return
+      // @ts-expect-error the v2 wire has no recordCbor field
       return ev.commit.recordCbor
     }
     expectTypeOf(readCbor).toBeFunction()
   })
+})
+
+describe('consumer seam', () => {
+  it('the seam element is the v2 RawEvent', () => {
+    type SeamStream = Parameters<JetstreamConsumer['run']>[0]
+    expectTypeOf<SeamStream>().toEqualTypeOf<
+      AsyncIterable<EventBatch<RawEvent>>
+    >()
+  })
 
   it('Ack accepts any { seq: number }', () => {
-    // Ack only reads the cursor, so it takes the minimal SeqEvent — any object
-    // carrying a numeric seq is assignable.
     expectTypeOf<Ack>().parameter(0).toEqualTypeOf<SeqEvent>()
     const ack = ((_evt: SeqEvent) => {}) as Ack
-    ack({ seq: 1 }) // a bare { seq } — not a full RawEventV1
     expectTypeOf(ack).toBeCallableWith({ seq: 42 })
   })
 })

--- a/packages/jetstream/tests/jetstream/v1-types.test.ts
+++ b/packages/jetstream/tests/jetstream/v1-types.test.ts
@@ -1,15 +1,17 @@
 import { describe, expectTypeOf, it } from 'vitest'
-import type {
-  Ack,
-  EventBase,
-  EventBaseV1,
-  EventBatch,
-  JetstreamConsumer,
-  RawEvent,
-  RawEventV1,
-  RawRecordJson,
-  SeqEvent,
-  Sync,
+import {
+  type Ack,
+  type EventBase,
+  type EventBaseV1,
+  type EventBatch,
+  Jetstream,
+  type JetstreamConsumer,
+  type RawEvent,
+  type RawEventV1,
+  type RawRecordJson,
+  type SeqEvent,
+  type Sync,
+  type TypedEventV1,
 } from '../../src/index.js'
 
 describe('the two wires have their own envelopes', () => {
@@ -74,5 +76,18 @@ describe('consumer seam', () => {
     expectTypeOf<Ack>().parameter(0).toEqualTypeOf<SeqEvent>()
     const ack = ((_evt: SeqEvent) => {}) as Ack
     expectTypeOf(ack).toBeCallableWith({ seq: 42 })
+  })
+})
+
+describe('Jetstream is still v1-backed', () => {
+  it('live()/liveRawBatches() promise v1 shapes, not the v2 seam types', () => {
+    const js = new Jetstream('https://h')
+    expectTypeOf(js.live({ raw: true })).toEqualTypeOf<
+      AsyncGenerator<RawEventV1>
+    >()
+    expectTypeOf(js.live()).toEqualTypeOf<AsyncGenerator<TypedEventV1>>()
+    expectTypeOf(js.liveRawBatches({})).toEqualTypeOf<
+      AsyncGenerator<EventBatch<RawEventV1>>
+    >()
   })
 })

--- a/packages/jetstream/tests/jetstream/validate-wire.test.ts
+++ b/packages/jetstream/tests/jetstream/validate-wire.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { MalformedError } from '../../src/errors.js'
+import { type TypedEventV1 } from '../../src/event.js'
+import { RecordValidationError } from '../../src/index.js'
 import { Jetstream } from '../../src/jetstream.js'
 import type { LiveTransport } from '../../src/live/transport.js'
 
 const TID = '3jzfcijpj2z2a'
+const CID = 'bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a'
 
 const frame = (did: string, time_us: number) =>
   JSON.stringify({
@@ -15,6 +18,21 @@ const frame = (did: string, time_us: number) =>
       collection: 'app.bsky.feed.like',
       rkey: TID,
       rev: TID,
+    },
+  })
+
+const putFrame = (did: string, rec: unknown) =>
+  JSON.stringify({
+    did,
+    time_us: 1,
+    kind: 'commit',
+    commit: {
+      operation: 'create',
+      collection: 'app.bsky.feed.like',
+      rkey: TID,
+      rev: TID,
+      cid: CID,
+      record: rec,
     },
   })
 
@@ -115,5 +133,50 @@ describe('validateWire strict mode', () => {
       seqs.push(ev.seq)
     }
     expect(seqs).toEqual([2])
+  })
+
+  it('typed mode: strict tightens record conversion; default mode does not', async () => {
+    // 1.5 is a non-integer number: strict conversion (matching validateWire)
+    // rejects it, loose conversion accepts it as-is.
+    const float = { $type: 'app.bsky.feed.like', n: 1.5 }
+
+    const strictErrors: Error[] = []
+    const strictJs = new Jetstream({
+      service: 'https://js.example',
+      validateWire: true,
+    })
+    const strictOut: unknown[] = []
+    for await (const ev of strictJs.live({
+      liveTransport: transportOf([putFrame('did:plc:a', float)]),
+      onError: (err) => strictErrors.push(err),
+    })) {
+      strictOut.push(ev)
+    }
+    // The conversion failure is skipped and reported, never delivered — this
+    // also exercises the fix for skipInvalid() reporting conversion failures
+    // regardless of whether the collection has a registered schema.
+    expect(strictOut).toHaveLength(0)
+    expect(strictErrors).toHaveLength(1)
+    expect(strictErrors[0]).toBeInstanceOf(RecordValidationError)
+
+    const defaultJs = new Jetstream({ service: 'https://js.example' })
+    const defaultOut: TypedEventV1[] = []
+    for await (const ev of defaultJs.live({
+      liveTransport: transportOf([putFrame('did:plc:a', float)]),
+      onError: () => {
+        throw new Error('default mode must not report a conversion error')
+      },
+    })) {
+      defaultOut.push(ev)
+    }
+    expect(defaultOut).toHaveLength(1)
+    const defaultEv = defaultOut[0]
+    if (
+      defaultEv.kind !== 'commit' ||
+      defaultEv.commit.operation === 'delete'
+    ) {
+      throw new Error('expected a put commit')
+    }
+    expect(defaultEv.commit.validationError).toBeUndefined()
   })
 })

--- a/packages/jetstream/tests/jetstream/validate-wire.test.ts
+++ b/packages/jetstream/tests/jetstream/validate-wire.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { MalformedError } from '../../src/errors.js'
 import { type TypedEventV1 } from '../../src/event.js'
 import { RecordValidationError } from '../../src/index.js'
-import { Jetstream } from '../../src/jetstream.js'
+import { JetstreamV1 } from '../../src/jetstream-v1.js'
 import type { LiveTransport } from '../../src/live/transport.js'
 
 const TID = '3jzfcijpj2z2a'
@@ -46,7 +46,7 @@ function transportOf(frames: string[]): LiveTransport {
 
 describe('validateWire strict mode', () => {
   it('live: throws MalformedError on a mangled did (raw mode, fatal)', async () => {
-    const js = new Jetstream({
+    const js = new JetstreamV1({
       service: 'https://js.example',
       validateWire: true,
     })
@@ -62,7 +62,7 @@ describe('validateWire strict mode', () => {
   })
 
   it('live: accepts well-formed frames and yields them', async () => {
-    const js = new Jetstream({
+    const js = new JetstreamV1({
       service: 'https://js.example',
       validateWire: true,
     })
@@ -80,7 +80,7 @@ describe('validateWire strict mode', () => {
   })
 
   it('default mode: the same mangled frame passes through untouched', async () => {
-    const js = new Jetstream({ service: 'https://js.example' })
+    const js = new JetstreamV1({ service: 'https://js.example' })
     const dids: string[] = []
     for await (const ev of js.live({
       raw: true,
@@ -92,7 +92,7 @@ describe('validateWire strict mode', () => {
   })
 
   it('strict mode throws on a missing required field (commit without rev)', async () => {
-    const js = new Jetstream({
+    const js = new JetstreamV1({
       service: 'https://js.example',
       validateWire: true,
     })
@@ -118,7 +118,7 @@ describe('validateWire strict mode', () => {
   })
 
   it('unknown kinds still SKIP_FRAME in strict mode (pre-discrimination)', async () => {
-    const js = new Jetstream({
+    const js = new JetstreamV1({
       service: 'https://js.example',
       validateWire: true,
     })
@@ -141,7 +141,7 @@ describe('validateWire strict mode', () => {
     const float = { $type: 'app.bsky.feed.like', n: 1.5 }
 
     const strictErrors: Error[] = []
-    const strictJs = new Jetstream({
+    const strictJs = new JetstreamV1({
       service: 'https://js.example',
       validateWire: true,
     })
@@ -159,7 +159,7 @@ describe('validateWire strict mode', () => {
     expect(strictErrors).toHaveLength(1)
     expect(strictErrors[0]).toBeInstanceOf(RecordValidationError)
 
-    const defaultJs = new Jetstream({ service: 'https://js.example' })
+    const defaultJs = new JetstreamV1({ service: 'https://js.example' })
     const defaultOut: TypedEventV1[] = []
     for await (const ev of defaultJs.live({
       liveTransport: transportOf([putFrame('did:plc:a', float)]),

--- a/packages/jetstream/tests/live/decode-v1.test.ts
+++ b/packages/jetstream/tests/live/decode-v1.test.ts
@@ -109,6 +109,32 @@ describe('decodeLiveFrameV1', () => {
     expect(acc.account.active).toBe(true)
   })
 
+  it('throws when account is missing the required active field, in every mode', () => {
+    // active is the takedown/deactivation signal on v1's #account frame. A
+    // missing value must never default to false ("deactivated") — it must
+    // throw, in both default and strict mode.
+    const bad = () =>
+      enc({
+        did: 'did:plc:abc',
+        time_us: 6,
+        kind: 'account',
+        account: { did: 'did:plc:abc' },
+      })
+    expect(() => decodeLiveFrameV1(bad())).toThrow(MalformedError)
+    expect(() => decodeLiveFrameV1(bad(), true)).toThrow(MalformedError)
+  })
+
+  it('throws when account.active is present but not a boolean, in every mode', () => {
+    const bad = () =>
+      enc({
+        did: 'did:plc:abc',
+        time_us: 6,
+        kind: 'account',
+        account: { did: 'did:plc:abc', active: 'nope' },
+      })
+    expect(() => decodeLiveFrameV1(bad())).toThrow(MalformedError)
+  })
+
   it('skips unknown kinds (incl. prototype short codes); throws on error frames and non-JSON', () => {
     expect(decodeLiveFrameV1(enc({ did: 'd', time_us: 4, kind: 'wat' }))).toBe(
       SKIP_FRAME,

--- a/packages/jetstream/tests/live/decode.test.ts
+++ b/packages/jetstream/tests/live/decode.test.ts
@@ -5,6 +5,10 @@ import { SKIP_FRAME, decodeLiveFrame } from '../../src/live/decode.js'
 const NSID = 'network.bsky.jetstream.subscribeEvents'
 const CID = 'bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a'
 const TIME = '2024-09-09T19:46:02.329308Z'
+// A well-formed TID (13-char base32-sortable) — required so strict-mode
+// tests that are NOT about `rev` don't spuriously fail on it, and so the
+// positive strict-mode test actually exercises acceptance of valid wire.
+const TID = '3jzfcijpj2z2a'
 
 const msg = (payload: unknown): string =>
   JSON.stringify({ $type: 'message', payload })
@@ -15,7 +19,7 @@ const commit = (over: Record<string, unknown> = {}): string =>
     seq: 7,
     did: 'did:plc:a',
     time: TIME,
-    rev: '3kabc',
+    rev: TID,
     operation: 'create',
     collection: 'app.bsky.feed.post',
     rkey: 'r1',
@@ -36,7 +40,7 @@ describe('decodeLiveFrame commits', () => {
         operation: 'create',
         collection: 'app.bsky.feed.post',
         rkey: 'r1',
-        rev: '3kabc',
+        rev: TID,
         cid: CID,
         record: { $type: 'app.bsky.feed.post', text: 'hi' },
       },
@@ -77,7 +81,7 @@ describe('decodeLiveFrame commits', () => {
       operation: 'delete',
       collection: 'app.bsky.feed.post',
       rkey: 'r1',
-      rev: '3kabc',
+      rev: TID,
     })
   })
 
@@ -98,14 +102,24 @@ describe('decodeLiveFrame commits', () => {
 })
 
 describe('decodeLiveFrame non-commit kinds', () => {
-  it('unwraps identity, letting the envelope seq win', () => {
+  it('unwraps identity, letting the envelope seq/time win', () => {
+    // The nested identity.time deliberately differs from the envelope TIME
+    // so this test can tell "envelope wins" from "nested value leaked
+    // through" — using the same value for both would let a decoder bug that
+    // reads identity.time for the envelope's `time` pass unnoticed.
+    const NESTED_TIME = '2020-01-01T00:00:00.000Z'
     const ev = decodeLiveFrame(
       msg({
         $type: `${NSID}#identity`,
         seq: 7,
         did: 'did:plc:a',
         time: TIME,
-        identity: { seq: 999, did: 'did:plc:a', handle: 'a.test', time: TIME },
+        identity: {
+          seq: 999,
+          did: 'did:plc:a',
+          handle: 'a.test',
+          time: NESTED_TIME,
+        },
       }),
     )
     expect(ev).toEqual({
@@ -113,7 +127,7 @@ describe('decodeLiveFrame non-commit kinds', () => {
       seq: 7,
       time: TIME,
       kind: 'identity',
-      identity: { did: 'did:plc:a', handle: 'a.test', time: TIME },
+      identity: { did: 'did:plc:a', handle: 'a.test', time: NESTED_TIME },
     })
   })
 
@@ -141,6 +155,22 @@ describe('decodeLiveFrame non-commit kinds', () => {
     })
   })
 
+  it('throws when account is missing the required active field, in every mode', () => {
+    // active is the takedown/deactivation signal on subscribeRepos#account.
+    // A missing value must never default to false ("deactivated") — it must
+    // throw, in both default and strict mode.
+    const bad = () =>
+      msg({
+        $type: `${NSID}#account`,
+        seq: 8,
+        did: 'did:plc:a',
+        time: TIME,
+        account: { did: 'did:plc:a' },
+      })
+    expect(() => decodeLiveFrame(bad())).toThrow(MalformedError)
+    expect(() => decodeLiveFrame(bad(), true)).toThrow(MalformedError)
+  })
+
   it('unwraps sync and discards blocks', () => {
     const ev = decodeLiveFrame(
       msg({
@@ -151,7 +181,7 @@ describe('decodeLiveFrame non-commit kinds', () => {
         sync: {
           seq: 999,
           did: 'did:plc:a',
-          rev: '3kabc',
+          rev: TID,
           blocks: { $bytes: 'AA' },
         },
       }),
@@ -161,7 +191,7 @@ describe('decodeLiveFrame non-commit kinds', () => {
       seq: 9,
       time: TIME,
       kind: 'sync',
-      sync: { did: 'did:plc:a', rev: '3kabc', time: undefined },
+      sync: { did: 'did:plc:a', rev: TID, time: undefined },
     })
   })
 })
@@ -207,6 +237,13 @@ describe('decodeLiveFrame control frames', () => {
     expect(decodeLiveFrame(JSON.stringify({ $type: 'hello' }))).toBe(SKIP_FRAME)
     expect(decodeLiveFrame(JSON.stringify({ kind: 'commit' }))).toBe(SKIP_FRAME)
   })
+
+  it('throws MalformedError (not TypeError) on a null frame', () => {
+    // `null` is valid JSON but not an object: without an explicit guard,
+    // reading `.{$type}` off it throws TypeError, and strict-mode callers
+    // (source.ts rethrows) would see the wrong error type.
+    expect(() => decodeLiveFrame('null')).toThrow(MalformedError)
+  })
 })
 
 describe('decodeLiveFrame always-on checks', () => {
@@ -246,6 +283,35 @@ describe('decodeLiveFrame always-on checks', () => {
 })
 
 describe('decodeLiveFrame validateWire', () => {
+  it('accepts a well-formed commit in strict mode', () => {
+    // Positive control for the negative tests below: without this, a wire
+    // schema that rejects every real frame (e.g. a bogus required field)
+    // would leave the whole suite green.
+    expect(() => decodeLiveFrame(commit(), true)).not.toThrow()
+  })
+
+  it('accepts a record with blob $link/$bytes values in strict mode, wire-faithful', () => {
+    const ev = decodeLiveFrame(
+      commit({
+        record: {
+          $type: 'app.test.rec',
+          img: { $link: CID },
+          sig: { $bytes: 'AA==' },
+        },
+      }),
+      true,
+    )
+    if (ev === SKIP_FRAME || 'info' in ev) expect.unreachable('expected commit')
+    if (ev.kind !== 'commit' || ev.commit.operation === 'delete') {
+      expect.unreachable('expected a put commit')
+    }
+    expect(ev.commit.record).toEqual({
+      $type: 'app.test.rec',
+      img: { $link: CID },
+      sig: { $bytes: 'AA==' },
+    })
+  })
+
   it('throws on a schema violation only in strict mode', () => {
     const bad = commit({ collection: 'NOT AN NSID' })
     expect(() => decodeLiveFrame(bad)).not.toThrow()

--- a/packages/jetstream/tests/live/decode.test.ts
+++ b/packages/jetstream/tests/live/decode.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from 'vitest'
+import { MalformedError, XrpcSubscriptionError } from '../../src/errors.js'
+import { SKIP_FRAME, decodeLiveFrame } from '../../src/live/decode.js'
+
+const NSID = 'network.bsky.jetstream.subscribeEvents'
+const CID = 'bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a'
+const TIME = '2024-09-09T19:46:02.329308Z'
+
+const msg = (payload: unknown): string =>
+  JSON.stringify({ $type: 'message', payload })
+
+const commit = (over: Record<string, unknown> = {}): string =>
+  msg({
+    $type: `${NSID}#commit`,
+    seq: 7,
+    did: 'did:plc:a',
+    time: TIME,
+    rev: '3kabc',
+    operation: 'create',
+    collection: 'app.bsky.feed.post',
+    rkey: 'r1',
+    cid: CID,
+    record: { $type: 'app.bsky.feed.post', text: 'hi' },
+    ...over,
+  })
+
+describe('decodeLiveFrame commits', () => {
+  it('maps a flat payload onto a nested commit', () => {
+    const ev = decodeLiveFrame(commit())
+    expect(ev).toEqual({
+      did: 'did:plc:a',
+      seq: 7,
+      time: TIME,
+      kind: 'commit',
+      commit: {
+        operation: 'create',
+        collection: 'app.bsky.feed.post',
+        rkey: 'r1',
+        rev: '3kabc',
+        cid: CID,
+        record: { $type: 'app.bsky.feed.post', text: 'hi' },
+      },
+    })
+  })
+
+  it('keeps the record wire-faithful', () => {
+    const ev = decodeLiveFrame(
+      commit({ record: { $type: 'app.test.rec', img: { $link: CID } } }),
+    )
+    if (ev === SKIP_FRAME || 'info' in ev) expect.unreachable('expected commit')
+    if (ev.kind !== 'commit' || ev.commit.operation === 'delete') {
+      expect.unreachable('expected a put commit')
+    }
+    // Not converted here — the typed layer owns conversion.
+    expect(ev.commit.record).toEqual({
+      $type: 'app.test.rec',
+      img: { $link: CID },
+    })
+  })
+
+  it('uses the wire cid verbatim and ignores a stray recordCbor', () => {
+    const ev = decodeLiveFrame(commit({ recordCbor: 'AAAA' }))
+    if (ev === SKIP_FRAME || 'info' in ev) expect.unreachable('expected commit')
+    if (ev.kind !== 'commit' || ev.commit.operation === 'delete') {
+      expect.unreachable('expected a put commit')
+    }
+    expect(ev.commit.cid).toBe(CID)
+    expect('recordCbor' in ev.commit).toBe(false)
+  })
+
+  it('decodes a delete with no record or cid', () => {
+    const ev = decodeLiveFrame(
+      commit({ operation: 'delete', record: undefined, cid: undefined }),
+    )
+    if (ev === SKIP_FRAME || 'info' in ev) expect.unreachable('expected commit')
+    expect(ev.kind === 'commit' && ev.commit).toEqual({
+      operation: 'delete',
+      collection: 'app.bsky.feed.post',
+      rkey: 'r1',
+      rev: '3kabc',
+    })
+  })
+
+  it('throws when a put is missing record or cid', () => {
+    expect(() => decodeLiveFrame(commit({ record: undefined }))).toThrow(
+      MalformedError,
+    )
+    expect(() => decodeLiveFrame(commit({ cid: undefined }))).toThrow(
+      MalformedError,
+    )
+  })
+
+  it('throws on an unknown operation', () => {
+    expect(() => decodeLiveFrame(commit({ operation: 'merge' }))).toThrow(
+      MalformedError,
+    )
+  })
+})
+
+describe('decodeLiveFrame non-commit kinds', () => {
+  it('unwraps identity, letting the envelope seq win', () => {
+    const ev = decodeLiveFrame(
+      msg({
+        $type: `${NSID}#identity`,
+        seq: 7,
+        did: 'did:plc:a',
+        time: TIME,
+        identity: { seq: 999, did: 'did:plc:a', handle: 'a.test', time: TIME },
+      }),
+    )
+    expect(ev).toEqual({
+      did: 'did:plc:a',
+      seq: 7,
+      time: TIME,
+      kind: 'identity',
+      identity: { did: 'did:plc:a', handle: 'a.test', time: TIME },
+    })
+  })
+
+  it('unwraps account', () => {
+    const ev = decodeLiveFrame(
+      msg({
+        $type: `${NSID}#account`,
+        seq: 8,
+        did: 'did:plc:a',
+        time: TIME,
+        account: { seq: 999, did: 'did:plc:a', active: true },
+      }),
+    )
+    expect(ev).toEqual({
+      did: 'did:plc:a',
+      seq: 8,
+      time: TIME,
+      kind: 'account',
+      account: {
+        did: 'did:plc:a',
+        active: true,
+        status: undefined,
+        time: undefined,
+      },
+    })
+  })
+
+  it('unwraps sync and discards blocks', () => {
+    const ev = decodeLiveFrame(
+      msg({
+        $type: `${NSID}#sync`,
+        seq: 9,
+        did: 'did:plc:a',
+        time: TIME,
+        sync: {
+          seq: 999,
+          did: 'did:plc:a',
+          rev: '3kabc',
+          blocks: { $bytes: 'AA' },
+        },
+      }),
+    )
+    expect(ev).toEqual({
+      did: 'did:plc:a',
+      seq: 9,
+      time: TIME,
+      kind: 'sync',
+      sync: { did: 'did:plc:a', rev: '3kabc', time: undefined },
+    })
+  })
+})
+
+describe('decodeLiveFrame control frames', () => {
+  it('returns an info variant for #info, which carries no seq', () => {
+    const ev = decodeLiveFrame(
+      msg({
+        $type: `${NSID}#info`,
+        name: 'OutdatedCursor',
+        message: 'clamped',
+      }),
+    )
+    expect(ev).toEqual({ info: { name: 'OutdatedCursor', message: 'clamped' } })
+  })
+
+  it('accepts #info without a message and with an unknown name', () => {
+    expect(
+      decodeLiveFrame(msg({ $type: `${NSID}#info`, name: 'Whatever' })),
+    ).toEqual({ info: { name: 'Whatever', message: undefined } })
+  })
+
+  it('throws XrpcSubscriptionError on a terminal error frame', () => {
+    const frame = JSON.stringify({
+      $type: 'error',
+      error: 'ConsumerTooSlow',
+      message: 'too slow',
+    })
+    try {
+      decodeLiveFrame(frame)
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(XrpcSubscriptionError)
+      expect((err as XrpcSubscriptionError).error).toBe('ConsumerTooSlow')
+      expect((err as Error).message).toBe('too slow')
+    }
+  })
+
+  it('skips unknown payload types and non-message envelopes', () => {
+    expect(decodeLiveFrame(msg({ $type: `${NSID}#future`, seq: 1 }))).toBe(
+      SKIP_FRAME,
+    )
+    expect(decodeLiveFrame(JSON.stringify({ $type: 'hello' }))).toBe(SKIP_FRAME)
+    expect(decodeLiveFrame(JSON.stringify({ kind: 'commit' }))).toBe(SKIP_FRAME)
+  })
+})
+
+describe('decodeLiveFrame always-on checks', () => {
+  it('rejects a non-positive or unsafe seq in every mode', () => {
+    for (const seq of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 2]) {
+      expect(() => decodeLiveFrame(commit({ seq }))).toThrow(MalformedError)
+      expect(() => decodeLiveFrame(commit({ seq }), true)).toThrow(
+        MalformedError,
+      )
+    }
+  })
+
+  it('passes a malformed time through in default mode and rejects it in strict', () => {
+    // No parsing: `time` is optimistically cast like any other branded string.
+    const ev = decodeLiveFrame(commit({ time: 'nope' }))
+    if (ev === SKIP_FRAME || 'info' in ev) expect.unreachable('expected commit')
+    expect(ev.time).toBe('nope')
+    expect(() => decodeLiveFrame(commit({ time: 'nope' }), true)).toThrow(
+      MalformedError,
+    )
+  })
+
+  it('reports malformed JSON with the SyntaxError as cause', () => {
+    try {
+      decodeLiveFrame('{not json')
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(MalformedError)
+      expect((err as MalformedError).cause).toBeInstanceOf(SyntaxError)
+    }
+  })
+
+  it('accepts both string and Uint8Array frames', () => {
+    const bytes = new TextEncoder().encode(commit())
+    expect(decodeLiveFrame(bytes)).toEqual(decodeLiveFrame(commit()))
+  })
+})
+
+describe('decodeLiveFrame validateWire', () => {
+  it('throws on a schema violation only in strict mode', () => {
+    const bad = commit({ collection: 'NOT AN NSID' })
+    expect(() => decodeLiveFrame(bad)).not.toThrow()
+    expect(() => decodeLiveFrame(bad, true)).toThrow(MalformedError)
+  })
+
+  it('rejects a missing required field in strict mode', () => {
+    const bad = commit({ rev: undefined })
+    expect(() => decodeLiveFrame(bad, true)).toThrow(MalformedError)
+  })
+
+  it('still accepts #info in strict mode', () => {
+    expect(
+      decodeLiveFrame(
+        msg({ $type: `${NSID}#info`, name: 'OutdatedCursor' }),
+        true,
+      ),
+    ).toEqual({ info: { name: 'OutdatedCursor', message: undefined } })
+  })
+})

--- a/packages/jetstream/tests/live/handshake-rejection.test.ts
+++ b/packages/jetstream/tests/live/handshake-rejection.test.ts
@@ -1,0 +1,34 @@
+import { type Server, createServer } from 'node:http'
+import { afterEach, expect, test } from 'vitest'
+import { liveEvents } from '../../src/live/source.js'
+
+let server: Server | undefined
+
+afterEach(async () => {
+  if (server) await new Promise((res) => server!.close(() => res(undefined)))
+  server = undefined
+})
+
+test('a pre-upgrade 400 ends the stream after exactly one dial', async () => {
+  let dials = 0
+  server = createServer((_req, res) => {
+    dials++
+    res.writeHead(400, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ error: 'CursorTooOld', message: 'too old' }))
+  })
+  const port = await new Promise<number>((res) => {
+    server!.listen(0, () => {
+      const addr = server!.address()
+      res(typeof addr === 'object' && addr ? addr.port : 0)
+    })
+  })
+
+  await expect(async () => {
+    for await (const _ of liveEvents({ host: `http://127.0.0.1:${port}` })) {
+      void _
+    }
+  }).rejects.toThrow()
+
+  // The whole point: a permanent rejection must not become a redial loop.
+  expect(dials).toBe(1)
+})

--- a/packages/jetstream/tests/live/raw-record.test.ts
+++ b/packages/jetstream/tests/live/raw-record.test.ts
@@ -1,0 +1,62 @@
+import { isCid } from '@atproto/lex'
+import { describe, expect, it } from 'vitest'
+import { MalformedError } from '../../src/errors.js'
+import { parseRawRecord } from '../../src/raw-record.js'
+
+const CID = 'bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a'
+
+describe('parseRawRecord', () => {
+  it('converts $link to a Cid and $bytes to a Uint8Array', () => {
+    const out = parseRawRecord({
+      $type: 'app.test.rec',
+      img: { $link: CID },
+      blob: { $bytes: 'aGVsbG8=' },
+    })
+    expect(isCid(out.img)).toBe(true)
+    expect(out.blob).toBeInstanceOf(Uint8Array)
+  })
+
+  it('passes a plain record through unchanged', () => {
+    const out = parseRawRecord({ $type: 'app.test.rec', text: 'hi', n: 3 })
+    expect(out).toEqual({ $type: 'app.test.rec', text: 'hi', n: 3 })
+  })
+
+  it("rejects records that are not $type'd objects", () => {
+    expect(() => parseRawRecord([1, 2])).toThrow(MalformedError)
+    expect(() => parseRawRecord(null)).toThrow(MalformedError)
+    expect(() => parseRawRecord('nope')).toThrow(MalformedError)
+    expect(() => parseRawRecord({ text: 'no $type' })).toThrow(MalformedError)
+    expect(() => parseRawRecord({ $type: '' })).toThrow(MalformedError)
+  })
+
+  it('rejects a __proto__ key in either mode', () => {
+    const evil = JSON.parse('{"$type":"app.test.rec","__proto__":{"bad":1}}')
+    expect(() => parseRawRecord(evil)).toThrow(MalformedError)
+    const nested = JSON.parse(
+      '{"$type":"app.test.rec","a":{"__proto__":{"b":1}}}',
+    )
+    expect(() => parseRawRecord(nested)).toThrow(MalformedError)
+  })
+
+  it('strict mode rejects non-integer numbers and malformed $link', () => {
+    const float = { $type: 'app.test.rec', n: 1.5 }
+    expect(parseRawRecord(float)).toEqual(float) // allowed by default
+    expect(() => parseRawRecord(float, { strict: true })).toThrow(
+      MalformedError,
+    )
+    const badLink = { $type: 'app.test.rec', c: { $link: 5 } }
+    expect(() => parseRawRecord(badLink, { strict: true })).toThrow(
+      MalformedError,
+    )
+  })
+
+  it('wraps the underlying failure as the error cause', () => {
+    try {
+      parseRawRecord({ $type: 'app.test.rec', n: 1.5 }, { strict: true })
+      expect.unreachable('should have thrown')
+    } catch (err) {
+      expect(err).toBeInstanceOf(MalformedError)
+      expect((err as MalformedError).cause).toBeInstanceOf(Error)
+    }
+  })
+})

--- a/packages/jetstream/tests/live/source-v1.test.ts
+++ b/packages/jetstream/tests/live/source-v1.test.ts
@@ -1,0 +1,181 @@
+import { expect, test } from 'vitest'
+import { type LiveTransport, liveEvents } from '../../src/live/source.js'
+
+const commitFrame = (time_us: number) =>
+  JSON.stringify({
+    did: 'did:plc:a',
+    time_us,
+    kind: 'commit',
+    commit: {
+      rev: 'r',
+      operation: 'create',
+      collection: 'app.bsky.feed.post',
+      rkey: `k${time_us}`,
+      record: { $type: 'app.bsky.feed.post', text: String(time_us) },
+      cid: 'cid1',
+    },
+  })
+
+// A transport that replays scripted "sessions": each session is a list of
+// frames; a new session begins on each getUrl() call (i.e. each reconnect).
+function scriptedTransport(sessions: string[][]): {
+  transport: LiveTransport
+  urls: string[]
+} {
+  const urls: string[] = []
+  let i = 0
+  const transport: LiveTransport = {
+    async *stream(getUrl) {
+      while (i < sessions.length) {
+        urls.push(getUrl())
+        const frames = sessions[i++]
+        for (const f of frames) yield new TextEncoder().encode(f)
+        // session ends -> loop calls getUrl again (simulates reconnect) until sessions exhausted
+      }
+    },
+  }
+  return { transport, urls }
+}
+
+test('yields decoded events and dedups across a reconnect', async () => {
+  // session 1: seqs 1,2 ; session 2 (reconnect, inclusive replay): 2,3,4
+  const { transport, urls } = scriptedTransport([
+    [commitFrame(1), commitFrame(2)],
+    [commitFrame(2), commitFrame(3), commitFrame(4)],
+  ])
+  const got: number[] = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    transport,
+    version: 1,
+  })) {
+    got.push(ev.seq)
+  }
+  expect(got).toEqual([1, 2, 3, 4]) // the replayed seq 2 is deduped
+  // second session's url resumes from the highest delivered seq (2)
+  expect(urls[1]).toContain('cursor=2')
+})
+
+test('builds the subscribe url with filters (no extended param)', async () => {
+  const { transport, urls } = scriptedTransport([[commitFrame(1)]])
+  for await (const _ of liveEvents({
+    host: 'https://h',
+    collections: ['app.bsky.feed.post'],
+    dids: ['did:plc:a'],
+    transport,
+    version: 1,
+  })) {
+    void _
+  }
+  expect(urls[0]).toContain('/subscribe')
+  expect(urls[0]).not.toContain('subscribe-v2')
+  expect(urls[0]).not.toContain('extended')
+  expect(urls[0]).toContain('wantedCollections=app.bsky.feed.post')
+  expect(urls[0]).toContain('wantedDids=did%3Aplc%3Aa')
+  expect(urls[0]).toMatch(/^wss:/) // https -> wss
+})
+
+test('cursor undefined omits the param (live from tip); 0 sends cursor=0', async () => {
+  const a = scriptedTransport([[commitFrame(1)]])
+  for await (const _ of liveEvents({
+    host: 'https://h',
+    transport: a.transport,
+    version: 1,
+  }))
+    void _
+  expect(a.urls[0]).not.toContain('cursor=')
+
+  const b = scriptedTransport([[commitFrame(1)]])
+  for await (const _ of liveEvents({
+    host: 'https://h',
+    cursor: 0,
+    transport: b.transport,
+    version: 1,
+  }))
+    void _
+  expect(b.urls[0]).toContain('cursor=0')
+})
+
+test('signal-driven teardown: aborting the signal stops iteration', async () => {
+  const ac = new AbortController()
+  // Transport that yields one frame, then checks the signal before yielding more.
+  // This keeps the test deterministic: no real timers, no races.
+  const transport: LiveTransport = {
+    async *stream(_getUrl, signal) {
+      yield new TextEncoder().encode(commitFrame(1))
+      // After the first frame is consumed the test aborts; honour it here.
+      if (signal.aborted) return
+      yield new TextEncoder().encode(commitFrame(2))
+    },
+  }
+  const got: number[] = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    transport,
+    signal: ac.signal,
+    version: 1,
+  })) {
+    got.push(ev.seq)
+    // Abort after the first event; the transport will see signal.aborted on next iteration.
+    ac.abort()
+  }
+  expect(got).toEqual([1]) // only the pre-abort frame was delivered; loop terminated
+})
+
+test('dedupFloor drops events at or below it; undefined lets seq 0 pass', async () => {
+  const a = scriptedTransport([[commitFrame(0), commitFrame(1)]])
+  const gotA: number[] = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    dedupFloor: undefined,
+    transport: a.transport,
+    version: 1,
+  }))
+    gotA.push(ev.seq)
+  expect(gotA).toEqual([0, 1]) // seq 0 passes when floor is undefined
+
+  const b = scriptedTransport([[commitFrame(0), commitFrame(1)]])
+  const gotB: number[] = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    dedupFloor: 0,
+    transport: b.transport,
+    version: 1,
+  }))
+    gotB.push(ev.seq)
+  expect(gotB).toEqual([1]) // seq 0 dropped when floor is 0
+})
+
+test('dedup on reconnect overlap is exact (unique monotonic time_us)', async () => {
+  const { transport } = scriptedTransport([
+    [commitFrame(100), commitFrame(101)],
+  ])
+  const events = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    dedupFloor: 100, // as if 100 already delivered
+    transport,
+    version: 1,
+  })) {
+    events.push(ev)
+  }
+  expect(events.map((e) => e.seq)).toEqual([101]) // 100 dropped (<= floor)
+})
+
+test('v1 seeds the dedup floor even for timestamp-magnitude values', async () => {
+  // v1's seq IS time_us, so a large floor is a real seq — it must still dedup.
+  const floor = 1_700_000_000_000_000
+  const { transport } = scriptedTransport([
+    [commitFrame(floor), commitFrame(floor + 1)],
+  ])
+  const got: number[] = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    dedupFloor: floor,
+    transport,
+    version: 1,
+  })) {
+    got.push(ev.seq)
+  }
+  expect(got).toEqual([floor + 1])
+})

--- a/packages/jetstream/tests/live/source.test.ts
+++ b/packages/jetstream/tests/live/source.test.ts
@@ -3,6 +3,10 @@ import { type LiveTransport, liveEvents } from '../../src/live/source.js'
 
 const NSID = 'network.bsky.jetstream.subscribeEvents'
 const CID = 'bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a'
+// A well-formed TID (13-char base32-sortable) — wire-valid even though no
+// test here enables validateWire, so a strict-mode test added later doesn't
+// fail on this fixture for an unrelated reason.
+const TID = '3jzfcijpj2z2a'
 
 const commitFrame = (seq: number): string =>
   JSON.stringify({
@@ -12,7 +16,7 @@ const commitFrame = (seq: number): string =>
       seq,
       did: 'did:plc:a',
       time: '2024-09-09T19:46:02.329308Z',
-      rev: '3kabc',
+      rev: TID,
       operation: 'create',
       collection: 'app.bsky.feed.post',
       rkey: `k${seq}`,
@@ -235,7 +239,7 @@ test('validateWire makes a malformed frame fatal', async () => {
       seq: 1,
       did: 'not-a-did',
       time: '2024-09-09T19:46:02.329308Z',
-      rev: '3kabc',
+      rev: TID,
       operation: 'create',
       collection: 'app.bsky.feed.post',
       rkey: 'k1',

--- a/packages/jetstream/tests/live/source.test.ts
+++ b/packages/jetstream/tests/live/source.test.ts
@@ -1,23 +1,34 @@
 import { expect, test } from 'vitest'
 import { type LiveTransport, liveEvents } from '../../src/live/source.js'
 
-const commitFrame = (time_us: number) =>
+const NSID = 'network.bsky.jetstream.subscribeEvents'
+const CID = 'bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a'
+
+const commitFrame = (seq: number): string =>
   JSON.stringify({
-    did: 'did:plc:a',
-    time_us,
-    kind: 'commit',
-    commit: {
-      rev: 'r',
+    $type: 'message',
+    payload: {
+      $type: `${NSID}#commit`,
+      seq,
+      did: 'did:plc:a',
+      time: '2024-09-09T19:46:02.329308Z',
+      rev: '3kabc',
       operation: 'create',
       collection: 'app.bsky.feed.post',
-      rkey: `k${time_us}`,
-      record: { $type: 'app.bsky.feed.post', text: String(time_us) },
-      cid: 'cid1',
+      rkey: `k${seq}`,
+      cid: CID,
+      record: { $type: 'app.bsky.feed.post', text: String(seq) },
     },
   })
 
-// A transport that replays scripted "sessions": each session is a list of
-// frames; a new session begins on each getUrl() call (i.e. each reconnect).
+const infoFrame = (name: string): string =>
+  JSON.stringify({
+    $type: 'message',
+    payload: { $type: `${NSID}#info`, name, message: 'clamped' },
+  })
+
+// Replays scripted sessions; a new session begins on each getUrl() call, which
+// is how a reconnect looks from here.
 function scriptedTransport(sessions: string[][]): {
   transport: LiveTransport
   urls: string[]
@@ -28,49 +39,50 @@ function scriptedTransport(sessions: string[][]): {
     async *stream(getUrl) {
       while (i < sessions.length) {
         urls.push(getUrl())
-        const frames = sessions[i++]
-        for (const f of frames) yield new TextEncoder().encode(f)
-        // session ends -> loop calls getUrl again (simulates reconnect) until sessions exhausted
+        for (const f of sessions[i++]) yield f
       }
     },
   }
   return { transport, urls }
 }
 
-test('yields decoded events and dedups across a reconnect', async () => {
-  // session 1: seqs 1,2 ; session 2 (reconnect, inclusive replay): 2,3,4
+test('defaults to the v2 endpoint and params', async () => {
+  const { transport, urls } = scriptedTransport([[commitFrame(1)]])
+  for await (const _ of liveEvents({
+    host: 'https://h',
+    collections: ['app.bsky.feed.post'],
+    dids: ['did:plc:a' as never],
+    kinds: ['commit', 'identity'],
+    transport,
+  })) {
+    void _
+  }
+  expect(urls[0]).toContain(`/xrpc/${NSID}`)
+  expect(urls[0]).toContain('collections=app.bsky.feed.post')
+  expect(urls[0]).toContain('dids=did%3Aplc%3Aa')
+  expect(urls[0]).toContain('kinds=commit')
+  expect(urls[0]).toContain('kinds=identity')
+  // The v1 vocabulary must never appear: v2 answers those names with a 400.
+  expect(urls[0]).not.toContain('wantedCollections')
+  expect(urls[0]).not.toContain('wantedDids')
+  expect(urls[0]).not.toContain('/subscribe?')
+  expect(urls[0]).toMatch(/^wss:/)
+})
+
+test('decodes events and dedups across a reconnect', async () => {
   const { transport, urls } = scriptedTransport([
     [commitFrame(1), commitFrame(2)],
-    [commitFrame(2), commitFrame(3), commitFrame(4)],
+    [commitFrame(2), commitFrame(3)],
   ])
   const got: number[] = []
   for await (const ev of liveEvents({ host: 'https://h', transport })) {
     got.push(ev.seq)
   }
-  expect(got).toEqual([1, 2, 3, 4]) // the replayed seq 2 is deduped
-  // second session's url resumes from the highest delivered seq (2)
+  expect(got).toEqual([1, 2, 3])
   expect(urls[1]).toContain('cursor=2')
 })
 
-test('builds the subscribe url with filters (no extended param)', async () => {
-  const { transport, urls } = scriptedTransport([[commitFrame(1)]])
-  for await (const _ of liveEvents({
-    host: 'https://h',
-    collections: ['app.bsky.feed.post'],
-    dids: ['did:plc:a'],
-    transport,
-  })) {
-    void _
-  }
-  expect(urls[0]).toContain('/subscribe')
-  expect(urls[0]).not.toContain('subscribe-v2')
-  expect(urls[0]).not.toContain('extended')
-  expect(urls[0]).toContain('wantedCollections=app.bsky.feed.post')
-  expect(urls[0]).toContain('wantedDids=did%3Aplc%3Aa')
-  expect(urls[0]).toMatch(/^wss:/) // https -> wss
-})
-
-test('cursor undefined omits the param (live from tip); 0 sends cursor=0', async () => {
+test('cursor undefined omits the param; 0 sends cursor=0', async () => {
   const a = scriptedTransport([[commitFrame(1)]])
   for await (const _ of liveEvents({
     host: 'https://h',
@@ -89,16 +101,148 @@ test('cursor undefined omits the param (live from tip); 0 sends cursor=0', async
   expect(b.urls[0]).toContain('cursor=0')
 })
 
-test('signal-driven teardown: aborting the signal stops iteration', async () => {
+test('a timestamp-domain cursor is wire-only and never seeds the dedup floor', async () => {
+  // >= 1e15 is a unix-µs timestamp to the server, not a seq. Seeding the floor
+  // with it would make every real seq compare as a duplicate.
+  const ts = 1_700_000_000_000_000
+  const { transport, urls } = scriptedTransport([
+    [commitFrame(1), commitFrame(2)],
+    [commitFrame(3)],
+  ])
+  const got: number[] = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    cursor: ts,
+    dedupFloor: ts,
+    transport,
+  })) {
+    got.push(ev.seq)
+  }
+  expect(got).toEqual([1, 2, 3])
+  expect(urls[0]).toContain(`cursor=${ts}`)
+  // Once something is delivered the resume cursor is a real seq.
+  expect(urls[1]).toContain('cursor=2')
+})
+
+test('a seq-domain dedupFloor drops events at or below it', async () => {
+  const { transport } = scriptedTransport([[commitFrame(5), commitFrame(6)]])
+  const got: number[] = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    dedupFloor: 5,
+    transport,
+  })) {
+    got.push(ev.seq)
+  }
+  expect(got).toEqual([6])
+})
+
+test('an #info advisory reaches onError and the stream continues', async () => {
+  const { transport } = scriptedTransport([
+    [infoFrame('OutdatedCursor'), commitFrame(1)],
+  ])
+  const errors: Error[] = []
+  const got: number[] = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    transport,
+    onError: (e) => errors.push(e),
+  })) {
+    got.push(ev.seq)
+  }
+  expect(got).toEqual([1])
+  expect(errors).toHaveLength(1)
+  expect(errors[0].message).toContain('OutdatedCursor')
+})
+
+test('an error frame is reported and the transport may redial', async () => {
+  const errorFrame = JSON.stringify({
+    $type: 'error',
+    error: 'ConsumerTooSlow',
+    message: 'too slow',
+  })
+  const { transport } = scriptedTransport([[errorFrame], [commitFrame(1)]])
+  const errors: Error[] = []
+  const got: number[] = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    transport,
+    onError: (e) => errors.push(e),
+  })) {
+    got.push(ev.seq)
+  }
+  expect(got).toEqual([1])
+  expect(errors[0].name).toBe('XrpcSubscriptionError')
+})
+
+test('validateWire makes a malformed frame fatal', async () => {
+  const bad = JSON.stringify({
+    $type: 'message',
+    payload: {
+      $type: `${NSID}#commit`,
+      seq: 1,
+      did: 'not-a-did',
+      time: '2024-09-09T19:46:02.329308Z',
+      rev: '3kabc',
+      operation: 'create',
+      collection: 'app.bsky.feed.post',
+      rkey: 'k1',
+      cid: CID,
+      record: { $type: 'app.bsky.feed.post' },
+    },
+  })
+  const { transport } = scriptedTransport([[bad]])
+  await expect(async () => {
+    for await (const _ of liveEvents({
+      host: 'https://h',
+      transport,
+      validateWire: true,
+    }))
+      void _
+  }).rejects.toThrow(/wire validation failed/)
+})
+
+test('rejects the kinds filter on v1', async () => {
+  const { transport } = scriptedTransport([[commitFrame(1)]])
+  await expect(async () => {
+    for await (const _ of liveEvents({
+      host: 'https://h',
+      transport,
+      version: 1,
+      kinds: ['commit'],
+    }))
+      void _
+  }).rejects.toThrow(/does not support the kinds filter/)
+})
+
+test('rejects parameter lists the server would refuse pre-upgrade', async () => {
+  const { transport } = scriptedTransport([[commitFrame(1)]])
+  const run = async (opts: Parameters<typeof liveEvents>[0]) => {
+    for await (const _ of liveEvents(opts)) void _
+  }
+  await expect(
+    run({
+      host: 'https://h',
+      transport,
+      dids: Array.from({ length: 10_001 }, (_, i) => `did:plc:${i}` as never),
+    }),
+  ).rejects.toThrow(RangeError)
+  await expect(
+    run({
+      host: 'https://h',
+      transport,
+      collections: Array.from({ length: 101 }, (_, i) => `app.test.c${i}`),
+    }),
+  ).rejects.toThrow(RangeError)
+})
+
+test('signal abort stops iteration', async () => {
   const ac = new AbortController()
-  // Transport that yields one frame, then checks the signal before yielding more.
-  // This keeps the test deterministic: no real timers, no races.
   const transport: LiveTransport = {
     async *stream(_getUrl, signal) {
-      yield new TextEncoder().encode(commitFrame(1))
-      // After the first frame is consumed the test aborts; honour it here.
+      yield commitFrame(1)
       if (signal.aborted) return
-      yield new TextEncoder().encode(commitFrame(2))
+      yield commitFrame(2)
     },
   }
   const got: number[] = []
@@ -108,45 +252,7 @@ test('signal-driven teardown: aborting the signal stops iteration', async () => 
     signal: ac.signal,
   })) {
     got.push(ev.seq)
-    // Abort after the first event; the transport will see signal.aborted on next iteration.
     ac.abort()
   }
-  expect(got).toEqual([1]) // only the pre-abort frame was delivered; loop terminated
-})
-
-test('dedupFloor drops events at or below it; undefined lets seq 0 pass', async () => {
-  const a = scriptedTransport([[commitFrame(0), commitFrame(1)]])
-  const gotA: number[] = []
-  for await (const ev of liveEvents({
-    host: 'https://h',
-    dedupFloor: undefined,
-    transport: a.transport,
-  }))
-    gotA.push(ev.seq)
-  expect(gotA).toEqual([0, 1]) // seq 0 passes when floor is undefined
-
-  const b = scriptedTransport([[commitFrame(0), commitFrame(1)]])
-  const gotB: number[] = []
-  for await (const ev of liveEvents({
-    host: 'https://h',
-    dedupFloor: 0,
-    transport: b.transport,
-  }))
-    gotB.push(ev.seq)
-  expect(gotB).toEqual([1]) // seq 0 dropped when floor is 0
-})
-
-test('dedup on reconnect overlap is exact (unique monotonic time_us)', async () => {
-  const { transport } = scriptedTransport([
-    [commitFrame(100), commitFrame(101)],
-  ])
-  const events = []
-  for await (const ev of liveEvents({
-    host: 'https://h',
-    dedupFloor: 100, // as if 100 already delivered
-    transport,
-  })) {
-    events.push(ev)
-  }
-  expect(events.map((e) => e.seq)).toEqual([101]) // 100 dropped (<= floor)
+  expect(got).toEqual([1])
 })

--- a/packages/jetstream/tests/live/source.test.ts
+++ b/packages/jetstream/tests/live/source.test.ts
@@ -124,6 +124,39 @@ test('a timestamp-domain cursor is wire-only and never seeds the dedup floor', a
   expect(urls[1]).toContain('cursor=2')
 })
 
+test('a dedupFloor exactly at the timestamp-domain threshold is not seeded', async () => {
+  // 1e15 itself is still the timestamp domain (>=), so it must not seed
+  // lastSeq — seeding it would make every real (small integer) seq compare
+  // as a duplicate forever.
+  const threshold = 1e15
+  const { transport } = scriptedTransport([[commitFrame(1), commitFrame(2)]])
+  const got: number[] = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    dedupFloor: threshold,
+    transport,
+  })) {
+    got.push(ev.seq)
+  }
+  expect(got).toEqual([1, 2])
+})
+
+test('a dedupFloor just below the timestamp-domain threshold seeds the floor', async () => {
+  // 1e15 - 1 is still in the seq domain, so it seeds lastSeq like any other
+  // seq-domain floor and every event compares against it.
+  const belowThreshold = 1e15 - 1
+  const { transport } = scriptedTransport([[commitFrame(1), commitFrame(2)]])
+  const got: number[] = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    dedupFloor: belowThreshold,
+    transport,
+  })) {
+    got.push(ev.seq)
+  }
+  expect(got).toEqual([])
+})
+
 test('a seq-domain dedupFloor drops events at or below it', async () => {
   const { transport } = scriptedTransport([[commitFrame(5), commitFrame(6)]])
   const got: number[] = []

--- a/packages/jetstream/tests/live/source.test.ts
+++ b/packages/jetstream/tests/live/source.test.ts
@@ -170,7 +170,27 @@ test('a seq-domain dedupFloor drops events at or below it', async () => {
   expect(got).toEqual([6])
 })
 
-test('an #info advisory reaches onError and the stream continues', async () => {
+test('an #info advisory reaches onInfo (not onError) and the stream continues', async () => {
+  const { transport } = scriptedTransport([
+    [infoFrame('OutdatedCursor'), commitFrame(1)],
+  ])
+  const errors: Error[] = []
+  const infos: Array<{ name: string; message?: string }> = []
+  const got: number[] = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    transport,
+    onError: (e) => errors.push(e),
+    onInfo: (info) => infos.push(info),
+  })) {
+    got.push(ev.seq)
+  }
+  expect(got).toEqual([1])
+  expect(errors).toEqual([])
+  expect(infos).toEqual([{ name: 'OutdatedCursor', message: 'clamped' }])
+})
+
+test('an #info advisory is dropped silently when no onInfo is registered', async () => {
   const { transport } = scriptedTransport([
     [infoFrame('OutdatedCursor'), commitFrame(1)],
   ])
@@ -184,8 +204,7 @@ test('an #info advisory reaches onError and the stream continues', async () => {
     got.push(ev.seq)
   }
   expect(got).toEqual([1])
-  expect(errors).toHaveLength(1)
-  expect(errors[0].message).toContain('OutdatedCursor')
+  expect(errors).toEqual([])
 })
 
 test('an error frame is reported and the transport may redial', async () => {

--- a/packages/jetstream/tests/live/transport.test.ts
+++ b/packages/jetstream/tests/live/transport.test.ts
@@ -69,6 +69,7 @@ describe('websocketTransport (real websocket)', () => {
         host: srv.host,
         transport: websocketTransport({ shouldReconnect: false }),
         onError: (err) => errors.push(err),
+        version: 1,
       })) {
         events.push(ev)
       }
@@ -101,6 +102,7 @@ describe('websocketTransport (real websocket)', () => {
           for await (const ev of liveEvents({
             host: srv.host,
             signal: ac.signal,
+            version: 1,
           })) {
             got.push(ev.seq)
             if (ev.seq === 200) ac.abort(new Error('test done'))
@@ -138,6 +140,7 @@ describe('websocketTransport (real websocket)', () => {
             host: srv.host,
             signal: ac.signal,
             transport: websocketTransport({ onReconnect }),
+            version: 1,
           })) {
             got.push(ev.seq)
             if (ev.seq === 100) conns[0].terminate() // abnormal close, no close frame
@@ -172,6 +175,7 @@ describe('websocketTransport (real websocket)', () => {
             host: srv.host,
             signal: ac.signal,
             transport: websocketTransport({ idleTimeoutMs: 50 }),
+            version: 1,
           })) {
             got.push(ev.seq)
             ac.abort(new Error('test done'))

--- a/packages/jetstream/tests/live/transport.test.ts
+++ b/packages/jetstream/tests/live/transport.test.ts
@@ -12,6 +12,11 @@ import { websocketTransport } from '../../src/live/transport.js'
 // coverage isn't lost.
 
 const NSID = 'network.bsky.jetstream.subscribeEvents'
+const CID = 'bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a'
+// A well-formed TID (13-char base32-sortable) — wire-valid even though no
+// test here enables validateWire, so a strict-mode test added later doesn't
+// fail on this fixture for an unrelated reason.
+const TID = '3jzfcijpj2z2a'
 
 const v1Frame = (time_us: number) =>
   JSON.stringify({
@@ -36,12 +41,12 @@ const v2Frame = (seq: number) =>
       seq,
       did: 'did:plc:a',
       time: '2024-09-09T19:46:02.329308Z',
-      rev: 'r',
+      rev: TID,
       operation: 'create',
       collection: 'app.bsky.feed.like',
       rkey: `rk${seq}`,
       record: { $type: 'app.bsky.feed.like' },
-      cid: 'cid1',
+      cid: CID,
     },
   })
 

--- a/packages/jetstream/tests/live/transport.test.ts
+++ b/packages/jetstream/tests/live/transport.test.ts
@@ -7,7 +7,11 @@ import { websocketTransport } from '../../src/live/transport.js'
 // End-to-end over a real websocket: jetstream frames are text frames, which
 // the transport (dataMode 'text') yields as strings. Exercises the real
 // websocketTransport so the decoder's string handling can't regress even
-// when fake-transport tests pass.
+// when fake-transport tests pass. v2 is the default wire (and gets most of
+// the coverage below); one v1 case is kept so the frozen wire's real-socket
+// coverage isn't lost.
+
+const NSID = 'network.bsky.jetstream.subscribeEvents'
 
 const v1Frame = (time_us: number) =>
   JSON.stringify({
@@ -19,6 +23,23 @@ const v1Frame = (time_us: number) =>
       operation: 'create',
       collection: 'app.bsky.feed.like',
       rkey: `rk${time_us}`,
+      record: { $type: 'app.bsky.feed.like' },
+      cid: 'cid1',
+    },
+  })
+
+const v2Frame = (seq: number) =>
+  JSON.stringify({
+    $type: 'message',
+    payload: {
+      $type: `${NSID}#commit`,
+      seq,
+      did: 'did:plc:a',
+      time: '2024-09-09T19:46:02.329308Z',
+      rev: 'r',
+      operation: 'create',
+      collection: 'app.bsky.feed.like',
+      rkey: `rk${seq}`,
       record: { $type: 'app.bsky.feed.like' },
       cid: 'cid1',
     },
@@ -84,11 +105,11 @@ describe('websocketTransport (real websocket)', () => {
   it('reconnects on a clean 1000 close by default, resuming from the cursor', async () => {
     const srv = await serveScript([
       (ws) => {
-        ws.send(v1Frame(100))
+        ws.send(v2Frame(100))
         ws.close(1000)
       },
       (ws) => {
-        ws.send(v1Frame(200))
+        ws.send(v2Frame(200))
         // stay open; the test ends by aborting
       },
     ])
@@ -98,11 +119,11 @@ describe('websocketTransport (real websocket)', () => {
       await expect(
         (async () => {
           // Default transport on purpose: pins that liveEvents' default IS
-          // websocketTransport() with the jetstream reconnect policy.
+          // websocketTransport() with the jetstream reconnect policy. Default
+          // version too: v2 is the default wire.
           for await (const ev of liveEvents({
             host: srv.host,
             signal: ac.signal,
-            version: 1,
           })) {
             got.push(ev.seq)
             if (ev.seq === 200) ac.abort(new Error('test done'))
@@ -122,12 +143,12 @@ describe('websocketTransport (real websocket)', () => {
     const srv = await serveScript([
       (ws) => {
         conns.push(ws)
-        ws.send(v1Frame(100))
+        ws.send(v2Frame(100))
         // terminated from the test body after the frame is observed —
         // avoids racing the frame against the drop
       },
       (ws) => {
-        ws.send(v1Frame(200))
+        ws.send(v2Frame(200))
       },
     ])
     try {
@@ -140,7 +161,6 @@ describe('websocketTransport (real websocket)', () => {
             host: srv.host,
             signal: ac.signal,
             transport: websocketTransport({ onReconnect }),
-            version: 1,
           })) {
             got.push(ev.seq)
             if (ev.seq === 100) conns[0].terminate() // abnormal close, no close frame
@@ -163,7 +183,7 @@ describe('websocketTransport (real websocket)', () => {
         // (IdleTimeoutError is retryable -> redial, not stream end)
       },
       (ws) => {
-        ws.send(v1Frame(100))
+        ws.send(v2Frame(100))
       },
     ])
     try {
@@ -175,7 +195,6 @@ describe('websocketTransport (real websocket)', () => {
             host: srv.host,
             signal: ac.signal,
             transport: websocketTransport({ idleTimeoutMs: 50 }),
-            version: 1,
           })) {
             got.push(ev.seq)
             ac.abort(new Error('test done'))

--- a/packages/jetstream/tests/live/websocket-transport.test.ts
+++ b/packages/jetstream/tests/live/websocket-transport.test.ts
@@ -1,6 +1,7 @@
 import { CloseError, HeartbeatTimeoutError } from '@atproto/ws-client'
 import { describe, expect, it } from 'vitest'
 import {
+  handshakeRejectionStatus,
   jetstreamShouldReconnect,
   resolveWebsocketOptions,
 } from '../../src/live/transport.js'
@@ -54,6 +55,11 @@ describe('resolveWebsocketOptions', () => {
       RangeError,
     )
   })
+  it('rejects a NaN idleTimeoutMs', () => {
+    expect(() => resolveWebsocketOptions({ idleTimeoutMs: NaN })).toThrow(
+      RangeError,
+    )
+  })
   it('shouldReconnect override passes through (false = never)', () => {
     const o = resolveWebsocketOptions({ shouldReconnect: false })
     expect(o.shouldReconnect).toBe(false)
@@ -63,5 +69,43 @@ describe('resolveWebsocketOptions', () => {
     const o = resolveWebsocketOptions({ onReconnect, maxReconnectSeconds: 32 })
     expect(o.onReconnect).toBe(onReconnect)
     expect(o.maxReconnectSeconds).toBe(32)
+  })
+})
+
+describe('handshakeRejectionStatus', () => {
+  it("extracts the status from ws's handshake error", () => {
+    expect(
+      handshakeRejectionStatus(new Error('Unexpected server response: 400')),
+    ).toBe(400)
+  })
+
+  it('walks the cause chain', () => {
+    const inner = new Error('Unexpected server response: 503')
+    const outer = new Error('socket failed', { cause: inner })
+    expect(handshakeRejectionStatus(outer)).toBe(503)
+  })
+
+  it('returns undefined for unrelated errors', () => {
+    expect(handshakeRejectionStatus(new Error('boom'))).toBeUndefined()
+    expect(handshakeRejectionStatus('nope')).toBeUndefined()
+  })
+})
+
+describe('jetstreamShouldReconnect handshake policy', () => {
+  it('does not reconnect after a 4xx rejection', () => {
+    // A 400 is a permanent statement about this request (bad cursor, rejected
+    // params); redialing repeats it forever.
+    expect(
+      jetstreamShouldReconnect(new Error('Unexpected server response: 400')),
+    ).toBe(false)
+    expect(
+      jetstreamShouldReconnect(new Error('Unexpected server response: 404')),
+    ).toBe(false)
+  })
+
+  it('reconnects after a 5xx rejection', () => {
+    expect(
+      jetstreamShouldReconnect(new Error('Unexpected server response: 502')),
+    ).toBe(true)
   })
 })

--- a/packages/jetstream/tests/live/websocket-transport.test.ts
+++ b/packages/jetstream/tests/live/websocket-transport.test.ts
@@ -1,4 +1,8 @@
-import { CloseError, HeartbeatTimeoutError } from '@atproto/ws-client'
+import {
+  CloseError,
+  HeartbeatTimeoutError,
+  SocketError,
+} from '@atproto/ws-client'
 import { describe, expect, it } from 'vitest'
 import {
   handshakeRejectionStatus,
@@ -75,17 +79,22 @@ describe('resolveWebsocketOptions', () => {
 describe('handshakeRejectionStatus', () => {
   it("extracts the status from ws's handshake error", () => {
     expect(
-      handshakeRejectionStatus(new Error('Unexpected server response: 400')),
+      handshakeRejectionStatus(
+        new SocketError(new Error('Unexpected server response: 400')),
+      ),
     ).toBe(400)
   })
 
-  it('walks the cause chain', () => {
-    const inner = new Error('Unexpected server response: 503')
-    const outer = new Error('socket failed', { cause: inner })
-    expect(handshakeRejectionStatus(outer)).toBe(503)
+  it('only looks at SocketError.cause, not a plain Error', () => {
+    expect(
+      handshakeRejectionStatus(new Error('Unexpected server response: 503')),
+    ).toBeUndefined()
   })
 
   it('returns undefined for unrelated errors', () => {
+    expect(
+      handshakeRejectionStatus(new SocketError(new Error('boom'))),
+    ).toBeUndefined()
     expect(handshakeRejectionStatus(new Error('boom'))).toBeUndefined()
     expect(handshakeRejectionStatus('nope')).toBeUndefined()
   })
@@ -96,16 +105,22 @@ describe('jetstreamShouldReconnect handshake policy', () => {
     // A 400 is a permanent statement about this request (bad cursor, rejected
     // params); redialing repeats it forever.
     expect(
-      jetstreamShouldReconnect(new Error('Unexpected server response: 400')),
+      jetstreamShouldReconnect(
+        new SocketError(new Error('Unexpected server response: 400')),
+      ),
     ).toBe(false)
     expect(
-      jetstreamShouldReconnect(new Error('Unexpected server response: 404')),
+      jetstreamShouldReconnect(
+        new SocketError(new Error('Unexpected server response: 404')),
+      ),
     ).toBe(false)
   })
 
   it('reconnects after a 5xx rejection', () => {
     expect(
-      jetstreamShouldReconnect(new Error('Unexpected server response: 502')),
+      jetstreamShouldReconnect(
+        new SocketError(new Error('Unexpected server response: 502')),
+      ),
     ).toBe(true)
   })
 })

--- a/packages/jetstream/tests/run/run-tracker.test.ts
+++ b/packages/jetstream/tests/run/run-tracker.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { type EventBatch, type RawEventV1 } from '../../src/event.js'
+import { type EventBatch, type RawEvent } from '../../src/event.js'
 import { type CursorStore } from '../../src/execute/cursor-store.js'
 import { trackedStream } from '../../src/run-tracker.js'
 
-function rawDelete(seq: number): RawEventV1 {
+function rawDelete(seq: number): RawEvent {
   return {
     did: 'did:plc:a',
     seq,
-    timeUs: 0,
+    time: '2024-09-09T19:46:02.329308Z',
     kind: 'commit',
     commit: {
       operation: 'delete',
@@ -18,7 +18,7 @@ function rawDelete(seq: number): RawEventV1 {
   }
 }
 
-async function* batches(...bs: EventBatch<RawEventV1>[]) {
+async function* batches(...bs: EventBatch<RawEvent>[]) {
   for (const b of bs) yield b
 }
 
@@ -56,7 +56,7 @@ describe('trackedStream', () => {
       store,
     )
     // Pull all (registers track(1),track(2),track(3) in order)
-    const events: RawEventV1[] = []
+    const events: RawEvent[] = []
     for await (const batch of ts.stream) events.push(...batch.events)
 
     // Ack out of order: 1, then 3 (2 still pending) — watermark must stay at 1

--- a/packages/jetstream/tests/shape.test.ts
+++ b/packages/jetstream/tests/shape.test.ts
@@ -6,9 +6,10 @@ import {
   type RawEventV1,
   type TypedEvent,
 } from '../src/event.js'
+import { type RawRecordJson } from '../src/raw-record.js'
 import { RecordValidationError, shape } from '../src/shape.js'
 
-function rawCreate(seq: number, record: unknown): RawEventV1 {
+function rawCreate(seq: number, record: RawRecordJson): RawEventV1 {
   return {
     did: 'did:plc:a',
     seq,
@@ -41,7 +42,7 @@ const likeSchema = record(
   l.object({ subject: l.string() }),
 )
 
-function putEvent(seq: number, rec: unknown): RawEventV1 {
+function putEvent(seq: number, rec: RawRecordJson): RawEventV1 {
   return {
     did: 'did:plc:a',
     seq,

--- a/packages/jetstream/tests/shape.test.ts
+++ b/packages/jetstream/tests/shape.test.ts
@@ -138,6 +138,27 @@ test('unregistered collections are never skipped and never reported', async () =
   expect(errors).toHaveLength(0)
 })
 
+test('conversion failures are skipped and reported even for unregistered collections', async () => {
+  // Regression: a record that fails CONVERSION (no $type here) must never
+  // reach a consumer as `record: undefined` — the static type promises a
+  // record is present — regardless of whether the collection has a
+  // registered schema. Unlike a schema-validation failure, this is not
+  // gated on schemasByNsid.has(collection).
+  const errors: Error[] = []
+  const out: TypedEvent[] = []
+  for await (const ev of shape(
+    oneBatch([putEvent(1, { hello: 'no $type' })]),
+    {},
+    new Map(), // no schema registered for app.test.like
+    (err) => errors.push(err),
+  )) {
+    out.push(ev as TypedEvent)
+  }
+  expect(out).toHaveLength(0)
+  expect(errors).toHaveLength(1)
+  expect(errors[0]).toBeInstanceOf(RecordValidationError)
+})
+
 test('raw paths never skip', async () => {
   const { schemasByNsid } = parseCollectionFilters([likeSchema])
   const out: unknown[] = []

--- a/packages/jetstream/tests/shape.test.ts
+++ b/packages/jetstream/tests/shape.test.ts
@@ -1,4 +1,4 @@
-import { l, record } from '@atproto/lex-schema'
+import { l, record } from '@atproto/lex'
 import { describe, expect, it, test } from 'vitest'
 import { parseCollectionFilters } from '../src/engine/collections.js'
 import {

--- a/packages/jetstream/tests/shape.test.ts
+++ b/packages/jetstream/tests/shape.test.ts
@@ -67,7 +67,10 @@ function oneBatch(events: RawEventV1[]): AsyncIterable<EventBatch<RawEventV1>> {
 
 describe('shape', () => {
   const b1: EventBatch<RawEventV1> = {
-    events: [rawCreate(1, {}), rawCreate(2, {})],
+    events: [
+      rawCreate(1, { $type: 'app.test.rec' }),
+      rawCreate(2, { $type: 'app.test.rec' }),
+    ],
     lastCursor: 2,
   }
 
@@ -89,7 +92,7 @@ describe('shape', () => {
       'delete',
     )
     if (out[0].kind === 'commit' && out[0].commit.operation !== 'delete') {
-      expect(out[0].commit.record).toEqual({})
+      expect(out[0].commit.record).toEqual({ $type: 'app.test.rec' })
     }
   })
 })

--- a/packages/jetstream/tests/typed-record.test.ts
+++ b/packages/jetstream/tests/typed-record.test.ts
@@ -75,17 +75,23 @@ describe('typedEventFromRaw record conversion', () => {
 
   it('strict mode tightens conversion', () => {
     const float = { $type: 'app.test.rec', n: 1.5 }
-    expect(typedEventFromRaw(putEvent(float), new Map()).kind).toBe('commit')
+    const loose = typedEventFromRaw(putEvent(float), new Map())
+    if (loose.kind !== 'commit' || loose.commit.operation === 'delete') {
+      expect.unreachable('expected a put commit')
+    }
+    // Loose (default) direction: the non-integer number is accepted as-is.
+    expect(loose.commit.validationError).toBeUndefined()
     const strict = typedEventFromRaw(putEvent(float), new Map(), {
       strict: true,
     })
     if (strict.kind !== 'commit' || strict.commit.operation === 'delete') {
       expect.unreachable('expected a put commit')
     }
+    // Strict direction: the same non-integer number is rejected.
     expect(strict.commit.validationError).toBeInstanceOf(Error)
   })
 
-  it('leaves cid readable and passes deletes through', () => {
+  it('leaves cid readable on a put commit', () => {
     const t = typedEventFromRaw(
       putEvent({ $type: 'app.test.rec', text: 'hi' }),
       new Map(),
@@ -94,5 +100,27 @@ describe('typedEventFromRaw record conversion', () => {
       expect.unreachable('expected a put commit')
     }
     expect(t.commit.cid).toBe(CID)
+  })
+
+  it('passes a delete commit through untouched (no record, no conversion)', () => {
+    const del: RawEvent<RawRecordJson> = {
+      did: 'did:plc:a' as never,
+      seq: 1,
+      time: '2024-01-01T00:00:00.000Z' as never,
+      kind: 'commit',
+      commit: {
+        operation: 'delete',
+        collection: 'app.test.rec' as never,
+        rkey: 'r1' as never,
+        rev: 'rev1' as never,
+      },
+    }
+    const t = typedEventFromRaw(del, new Map())
+    if (t.kind !== 'commit' || t.commit.operation !== 'delete') {
+      expect.unreachable('expected a delete commit')
+    }
+    expect(t.commit).not.toHaveProperty('record')
+    expect(t.commit).not.toHaveProperty('validationError')
+    expect(t.commit.rkey).toBe('r1')
   })
 })

--- a/packages/jetstream/tests/typed-record.test.ts
+++ b/packages/jetstream/tests/typed-record.test.ts
@@ -47,7 +47,7 @@ describe('typedEventFromRaw record conversion', () => {
     expect(t.commit.validationError).toBeInstanceOf(Error)
   })
 
-  it('adopts the schema-validated value so coercions survive', () => {
+  it('a valid record passes schema validation and comes back converted', () => {
     const schema = record('tid', 'app.test.rec', l.object({ text: l.string() }))
     const schemas = new Map([['app.test.rec', schema]])
     const t = typedEventFromRaw(

--- a/packages/jetstream/tests/typed-record.test.ts
+++ b/packages/jetstream/tests/typed-record.test.ts
@@ -1,0 +1,98 @@
+import { isCid, l, record } from '@atproto/lex'
+import { describe, expect, it } from 'vitest'
+import { typedEventFromRaw } from '../src/decode-typed.js'
+import { type RawEvent } from '../src/event.js'
+import { type RawRecordJson } from '../src/raw-record.js'
+
+const CID = 'bafyreidfayvfuwqa7qlnopdjiqrxzs6blmoeu4rujcjtnci5beludirz2a'
+
+// RawEvent is the v2 envelope (EventBase carries `time`, not v1's `timeUs` —
+// see event.ts's note on why the two envelopes are deliberately divergent).
+const putEvent = (rec: RawRecordJson): RawEvent<RawRecordJson> => ({
+  did: 'did:plc:a' as never,
+  seq: 1,
+  time: '2024-01-01T00:00:00.000Z' as never,
+  kind: 'commit',
+  commit: {
+    operation: 'create',
+    collection: 'app.test.rec' as never,
+    rkey: 'r1' as never,
+    rev: 'rev1' as never,
+    cid: CID as never,
+    record: rec,
+  },
+})
+
+describe('typedEventFromRaw record conversion', () => {
+  it('converts the record to lex data', () => {
+    const t = typedEventFromRaw(
+      putEvent({ $type: 'app.test.rec', img: { $link: CID } }),
+      new Map(),
+    )
+    if (t.kind !== 'commit' || t.commit.operation === 'delete') {
+      expect.unreachable('expected a put commit')
+    }
+    const rec = t.commit.record as unknown as { img: unknown }
+    expect(isCid(rec.img)).toBe(true)
+    expect(t.commit.validationError).toBeUndefined()
+  })
+
+  it('reports a conversion failure as validationError with no record', () => {
+    const evil = JSON.parse('{"$type":"app.test.rec","__proto__":{"b":1}}')
+    const t = typedEventFromRaw(putEvent(evil), new Map())
+    if (t.kind !== 'commit' || t.commit.operation === 'delete') {
+      expect.unreachable('expected a put commit')
+    }
+    expect(t.commit.record).toBeUndefined()
+    expect(t.commit.validationError).toBeInstanceOf(Error)
+  })
+
+  it('adopts the schema-validated value so coercions survive', () => {
+    const schema = record('tid', 'app.test.rec', l.object({ text: l.string() }))
+    const schemas = new Map([['app.test.rec', schema]])
+    const t = typedEventFromRaw(
+      putEvent({ $type: 'app.test.rec', text: 'hi' }),
+      schemas,
+    )
+    if (t.kind !== 'commit' || t.commit.operation === 'delete') {
+      expect.unreachable('expected a put commit')
+    }
+    expect(t.commit.validationError).toBeUndefined()
+    expect(t.commit.record).toMatchObject({ text: 'hi' })
+  })
+
+  it('does not schema-validate when conversion already failed', () => {
+    const schema = record('tid', 'app.test.rec', l.object({ text: l.string() }))
+    const schemas = new Map([['app.test.rec', schema]])
+    const evil = JSON.parse('{"$type":"app.test.rec","__proto__":{"b":1}}')
+    const t = typedEventFromRaw(putEvent(evil), schemas)
+    if (t.kind !== 'commit' || t.commit.operation === 'delete') {
+      expect.unreachable('expected a put commit')
+    }
+    // The conversion error is reported, not a downstream validation error.
+    expect(t.commit.validationError?.message).toMatch(/parse raw record/)
+  })
+
+  it('strict mode tightens conversion', () => {
+    const float = { $type: 'app.test.rec', n: 1.5 }
+    expect(typedEventFromRaw(putEvent(float), new Map()).kind).toBe('commit')
+    const strict = typedEventFromRaw(putEvent(float), new Map(), {
+      strict: true,
+    })
+    if (strict.kind !== 'commit' || strict.commit.operation === 'delete') {
+      expect.unreachable('expected a put commit')
+    }
+    expect(strict.commit.validationError).toBeInstanceOf(Error)
+  })
+
+  it('leaves cid readable and passes deletes through', () => {
+    const t = typedEventFromRaw(
+      putEvent({ $type: 'app.test.rec', text: 'hi' }),
+      new Map(),
+    )
+    if (t.kind !== 'commit' || t.commit.operation === 'delete') {
+      expect.unreachable('expected a put commit')
+    }
+    expect(t.commit.cid).toBe(CID)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,9 +269,9 @@ importers:
 
   packages/jetstream:
     dependencies:
-      '@atproto/lex-schema':
-        specifier: ^0.2.2
-        version: 0.2.2
+      '@atproto/lex':
+        specifier: ^0.3.0
+        version: 0.3.3
       '@atproto/ws-client':
         specifier: ^0.2.0
         version: 0.2.0
@@ -449,10 +449,6 @@ packages:
     resolution: {integrity: sha512-4AMwaB0HumrQuaXmYQDHeeZGKj8x6ACiIb8fX96Y0ZZaiM/JUmgZl0LTl/1kbQ7cGPfG+NoGsiuz1iJuFhTjxw==}
     engines: {node: '>=22'}
 
-  '@atproto/lex-schema@0.2.2':
-    resolution: {integrity: sha512-UFK0EH8pw31dvL27aoZ5K78z+UMiD3ybIgkCyd7Idm267KM1IpycerTDeABqo4CYP3/IAnzjGpQaUaVc12bELA==}
-    engines: {node: '>=22'}
-
   '@atproto/lex-schema@0.2.4':
     resolution: {integrity: sha512-60c4aiHVYJQfmLF397d/NUYgrl7XYsnpGZjVLthsLpyn6gBiiFVaL/Pd+azLf/Uztn5ydbGbCxHEsoHsvUZLIg==}
     engines: {node: '>=22'}
@@ -472,10 +468,6 @@ packages:
 
   '@atproto/syntax@0.6.4':
     resolution: {integrity: sha512-ELgpShRGMF65cvLXcoMCZFL0HBzy67yz/Nlhox3yOtTh120B09KjjvZYXhMysVog3nUJqv2EW5rf1VRYCeM/hw==}
-    engines: {node: '>=22'}
-
-  '@atproto/syntax@0.7.2':
-    resolution: {integrity: sha512-tZ1Tr0R9pK4bI4Zs69t29cjMlCFQvRNBeNkqJC5pGeNuCt64D0eoF7s/AlqeVmYppClmQ0xJquggGgsMDP6j7w==}
     engines: {node: '>=22'}
 
   '@atproto/syntax@0.7.3':
@@ -2552,13 +2544,6 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       tslib: 2.8.1
 
-  '@atproto/lex-schema@0.2.2':
-    dependencies:
-      '@atproto/lex-data': 0.1.7
-      '@atproto/syntax': 0.7.2
-      '@standard-schema/spec': 1.1.0
-      tslib: 2.8.1
-
   '@atproto/lex-schema@0.2.4':
     dependencies:
       '@atproto/lex-data': 0.1.7
@@ -2600,11 +2585,6 @@ snapshots:
       zod: 3.25.76
 
   '@atproto/syntax@0.6.4':
-    dependencies:
-      iso-datestring-validator: 2.2.2
-      tslib: 2.8.1
-
-  '@atproto/syntax@0.7.2':
     dependencies:
       iso-datestring-validator: 2.2.2
       tslib: 2.8.1


### PR DESCRIPTION
Stacked on #3.

`Jetstream` now speaks the v2 wire (`/xrpc/network.bsky.jetstream.subscribeEvents`) by default and keeps `live()`, `runner()`, and `liveRawBatches()`. The frozen v1 wire moves to a new `JetstreamV1`, which exposes `live()` only — v1 has no sealed archive and no consumer/indexer path, so version mismatches are compile errors instead of runtime guards. The public `jetstream*.bsky.network` hosts speak v1 today, so `JetstreamV1` is what works against them right now.

What consumers get:

- `sync` events end to end — raw, typed, and a `LexIndexer.sync()` handler.
- Typed records are converted lex data (`Cid`, `Uint8Array`, `BlobRef`), while `live({ raw: true })` records stay wire-faithful with `{$link}`/`{$bytes}` intact.
- A `kinds` filter (`commit`/`identity`/`account`/`sync`), v2 only. `collections` constrains commit events only, so a commits-only stream needs `kinds: ['commit']`.
- v2 cursors are `seq` values and are **not portable** to or from v1's `time_us` cursors. A cursor `>= 1e15` is read by the server as a unix-microsecond timestamp; the SDK treats such a value as wire-only and never seeds its dedup floor from it, so a stale timestamp cannot silently empty the stream. A clamped timestamp surfaces an `OutdatedCursor` advisory through `onError` without ending the stream.
- A pre-upgrade 4xx handshake rejection is now fatal rather than an infinite redial loop; 5xx stays retryable.
- Records that are not `$type`'d maps are reported and skipped rather than delivered, even on a collection with no schema registered — previously they could reach a consumer as `undefined` while the type promised a record was present.

One deliberate behavior change to the frozen v1 path, worth a look: a v1 `#account` frame missing `active` used to decode as `active: false`, fabricating a deactivation. It is now reported through `onError` and the frame skipped. The canonical lexicon requires `active` and indigo's generated struct does not use `omitempty` for required bools, so a genuinely deactivated account should arrive as `active: false` rather than field-less — but this is the one change worth confirming against a live v1 host.

Also drops the direct `@atproto/lex-schema` dependency in favor of `@atproto/lex`, which re-exports everything the package used and removes the version-skew hazard between the two.
