### PR TITLE
Jetstream v1 prep: event narrowing helpers, @atproto/lex peer dependency

### DIFF
--- a/.changeset/breezy-dingos-attend.md
+++ b/.changeset/breezy-dingos-attend.md
@@ -1,0 +1,4 @@
+---
+---
+
+Jetstream v1 prep: `isCreate()`/`isUpdate()`/`isDelete()`/`isPut()` event narrowing helpers, and `@atproto/lex` as a peer dependency. No published-package changes — `@bsky/jetstream` is unreleased and its pending initial-release changeset already covers this work.

--- a/.changeset/jetstream-initial-release.md
+++ b/.changeset/jetstream-initial-release.md
@@ -6,10 +6,11 @@ Client library for Jetstream, a friendly way to consume data published to AT Pro
 
 - `Jetstream` with three consumption modes: `live()` streams events in realtime, `snapshot()` streams the sealed archive of past events, and `replay()` streams the archive then hands off seamlessly to the live stream — no gap, no duplicate, recovering on its own when a long replay falls behind the live retention window.
 - Typed events by default: records arrive as lex data, validated against schemas when collections are given as lexicon schema filters. `raw: true` yields wire-faithful events instead (parsed JSON from the live stream, DAG-CBOR bytes from snapshots, with lazily computed CIDs).
+- `isCreate()`, `isUpdate()`, `isDelete()`, and `isPut()` narrow an event to a commit with that operation, and to one collection's records when given a lexicon — the same narrowing `$isTypeOf()` performs.
 - Filtering by `collections` (exact NSIDs or `ns.*` wildcards), `dids`, and `kinds`, applied consistently across all three modes.
 - `LexIndexer` — register per-collection put/delete handlers plus identity, account, and sync handlers, with record validation and per-record ordered concurrency.
 - `JetstreamRunner` — drive a consumer such as `LexIndexer` through any mode with durable cursor tracking: progress persists through a `CursorStore` and resumes where it left off.
 - Resilience built in: the live stream reconnects and resumes from its cursor, snapshot downloads retry with backoff and resume mid-file, and interrupted snapshots re-plan without re-delivering.
 - `apiKey` option for hosts that require auth — sent on snapshot downloads and the live websocket handshake alike.
-- Works in Node.js (>= 22.15) and the browser. Live streaming is fully browser-capable; snapshot and replay need `decompressor` and `sha256` options supplied in the browser, where the platform lacks zstd and synchronous hashing.
+- Works in Node.js (>= 22.15) and the browser, with `@atproto/lex` as a peer dependency. Live streaming is fully browser-capable; snapshot and replay need `decompressor` and `sha256` options supplied in the browser, where the platform lacks zstd and synchronous hashing.
 - `JetstreamV1` — a live-only client for hosts still speaking the original Jetstream wire protocol.

--- a/packages/jetstream/README.md
+++ b/packages/jetstream/README.md
@@ -7,8 +7,10 @@ Client library for [Jetstream](https://github.com/bluesky-social/jetstream), a f
 Install the Jetstream client:
 
 ```
-npm install @bsky/jetstream
+npm install @bsky/jetstream @atproto/lex
 ```
+
+`@atproto/lex` is a peer dependency providing the lexicon type system that events are typed with.
 
 This package speaks Jetstream's v2 wire and supports all three of its consumption modes: `live()` for realtime events, `snapshot()` for the sealed archive of past events, and `replay()` for the archive followed by a seamless handoff to realtime. Consuming live events looks like:
 

--- a/packages/jetstream/README.md
+++ b/packages/jetstream/README.md
@@ -15,12 +15,12 @@ npm install @bsky/jetstream @atproto/lex
 This package speaks Jetstream's v2 wire and supports all three of its consumption modes: `live()` for realtime events, `snapshot()` for the sealed archive of past events, and `replay()` for the archive followed by a seamless handoff to realtime. Consuming live events looks like:
 
 ```ts
-import { Jetstream } from '@bsky/jetstream'
+import { Jetstream, isCreate } from '@bsky/jetstream'
 
 const js = new Jetstream('https://jetstream.us-east.bsky.network')
 
 for await (const evt of js.live({ collections: ['app.bsky.feed.post'] })) {
-  if (evt.kind === 'commit' && evt.commit.operation === 'create') {
+  if (isCreate(evt)) {
     console.log(evt.commit.collection, evt.commit.record)
   }
 }
@@ -31,17 +31,19 @@ for await (const evt of js.live({ collections: ['app.bsky.feed.post'] })) {
 Using a lexicon as your collection filter will validate and type the events for you:
 
 ```ts
-import { Jetstream } from '@bsky/jetstream'
+import { Jetstream, isCreate } from '@bsky/jetstream'
 import { app } from '@bsky/sdk/lexicons'
 
 const js = new Jetstream('https://jetstream.us-east.bsky.network')
 
 for await (const evt of js.live({ collections: [app.bsky.feed.post] })) {
-  if (evt.kind === 'commit' && evt.commit.operation === 'create') {
+  if (isCreate(evt)) {
     console.log(evt.commit.collection, evt.commit.record.text)
   }
 }
 ```
+
+`isCreate()`, `isUpdate()`, `isDelete()`, and `isPut()` (create-or-update) narrow an event to a commit with that operation. Pass a lexicon — or a bare NSID — as a second argument to also narrow to its collection: `isCreate(evt, app.bsky.feed.post)`. The record narrows exactly as `app.bsky.feed.post.$isTypeOf()` would narrow it, so a record the event already types precisely keeps that type. Like `$isTypeOf()`, these helpers narrow types without validating; when shape guarantees matter, use a validating collection filter as above.
 
 Typed records are converted lex data — `Cid`, `Uint8Array`, and `BlobRef` values rather than wire JSON's `{$link}` / `{$bytes}` shapes. Pass `live({ raw: true })` when you want the wire-faithful record instead (its `$link`/`$bytes` markers intact).
 

--- a/packages/jetstream/package.json
+++ b/packages/jetstream/package.json
@@ -36,15 +36,18 @@
     "node": ">=22.15.0"
   },
   "dependencies": {
-    "@atproto/lex": "^0.3.0",
     "@atproto/lex-cbor": "^0.1.6",
     "@atproto/ws-client": "^0.2.0"
+  },
+  "peerDependencies": {
+    "@atproto/lex": "^0.3.0"
   },
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
     "test": "vitest --run && vitest --run --config vitest.browser.config.ts"
   },
   "devDependencies": {
+    "@atproto/lex": "^0.3.0",
     "@types/ws": "^8.18.1",
     "ws": "^8.21.0"
   }

--- a/packages/jetstream/src/index.ts
+++ b/packages/jetstream/src/index.ts
@@ -8,6 +8,8 @@ export type {
 export { JetstreamV1 } from './jetstream-v1.js'
 export type { LiveV1Opts } from './jetstream-v1.js'
 export { typedEventFromRaw } from './decode-typed.js'
+export { isCreate, isDelete, isPut, isUpdate } from './narrow.js'
+export type { EventLexicon, NarrowedEvent } from './narrow.js'
 export { parseRawRecord } from './raw-record.js'
 export type { RawRecord, RawRecordCbor, RawRecordJson } from './raw-record.js'
 export { websocketTransport } from './live/transport.js'

--- a/packages/jetstream/src/narrow.ts
+++ b/packages/jetstream/src/narrow.ts
@@ -1,0 +1,174 @@
+import {
+  type Main,
+  type NsidString,
+  type RecordSchema,
+  type TypedLexMap,
+  type TypedRecord,
+  getMain,
+} from '@atproto/lex'
+import { type Operation } from './event.js'
+
+/**
+ * The optional lexicon argument to the narrowing helpers: a record schema
+ * (bare or namespace form, like collection filters) or a bare NSID literal.
+ */
+export type EventLexicon = NsidString | Main<RecordSchema>
+
+// Unwrap Main<S> = S | { main: S } to the schema itself.
+type MainOf<M> = M extends { main: infer S } ? S : M
+
+// The collection literal a lexicon argument narrows to.
+type CollectionOf<L extends EventLexicon> = L extends string
+  ? L
+  : MainOf<L> extends { $type: infer T extends string }
+    ? T
+    : never
+
+/**
+ * A commit arm narrowed by operation and (optionally) collection. Purely
+ * type-level, mirroring $isTypeOf. An arm survives only if its operation and
+ * collection can overlap the target; `collection` and `record` then narrow to
+ * whichever of the arm's own type and the target is more specific. A
+ * non-overlapping arm is eliminated.
+ */
+type NarrowedCommit<C, O extends Operation, T extends string> = C extends {
+  operation: infer P extends Operation
+  collection: infer K extends string
+}
+  ? [Extract<P, O>] extends [never]
+    ? never
+    : [K] extends [T]
+      ? Narrowed<C, Extract<P, O>, K, T>
+      : [T] extends [K]
+        ? Narrowed<C, Extract<P, O>, T, T>
+        : never
+  : never
+
+// Rebuild a commit arm, keeping whichever of the arm's collection (KOut) and
+// the target is more specific. A put arm whose record type cannot be the
+// target collection's record is dropped whole: matching it would be a
+// contradiction, not a wider match.
+type Narrowed<C, P, KOut extends string, T extends string> = C extends {
+  record: infer R
+}
+  ? [NarrowedRecord<R, T>] extends [never]
+    ? never
+    : Omit<C, 'operation' | 'collection' | 'record'> & {
+        operation: P
+        collection: KOut
+        record: NarrowedRecord<R, T>
+      }
+  : Omit<C, 'operation' | 'collection'> & { operation: P; collection: KOut }
+
+/**
+ * Narrow a put commit's record to the target collection, delegating to
+ * @atproto/lex's `TypedRecord` — the narrowing `$isTypeOf` performs. A lexicon
+ * therefore narrows a jetstream record exactly as it narrows a record
+ * anywhere else in the ecosystem: an arm already typed with the target keeps
+ * its type, a wider `$type` (`TypedLexMap<NsidString>`, a wildcard template)
+ * tightens to the target while keeping the record's own shape, an arm whose
+ * `$type` contradicts the target drops out, and so does an open union's
+ * unknown arm.
+ *
+ * Only `$type`'d lex maps go through it. A raw wire record (JSON or CBOR) was
+ * never decoded, so giving it a lex type would be a lie — it is left alone. A
+ * call with no lexicon (T is `string`, not an NSID) narrows nothing.
+ */
+type NarrowedRecord<R, T extends string> = T extends NsidString
+  ? R extends TypedLexMap
+    ? TypedRecord<T, R>
+    : R
+  : R
+
+/**
+ * An event union narrowed to commit arms matching an operation and optional
+ * collection. Distributes over the event union (v1 and v2 envelopes both
+ * survive intact) and over each arm's commit union; arms with no matching
+ * commit disappear entirely.
+ */
+export type NarrowedEvent<
+  E,
+  O extends Operation,
+  T extends string = string,
+> = E extends { kind: 'commit'; commit: infer C }
+  ? [NarrowedCommit<C, O, T>] extends [never]
+    ? never
+    : Omit<E, 'commit'> & { commit: NarrowedCommit<C, O, T> }
+  : never
+
+// The widest event shape the helpers inspect at runtime. Optional commit:
+// non-commit kinds carry none.
+interface AnyEvent {
+  kind: string
+  commit?: { operation: string; collection: string }
+}
+
+// Shared runtime for all four helpers: three cheap checks, no validation.
+function isCommitOp(
+  ev: AnyEvent,
+  lexicon: EventLexicon | undefined,
+  op1: Operation,
+  op2?: Operation,
+): boolean {
+  if (ev.kind !== 'commit' || ev.commit === undefined) return false
+  const { operation, collection } = ev.commit
+  if (operation !== op1 && operation !== op2) return false
+  if (lexicon === undefined) return true
+  const nsid = typeof lexicon === 'string' ? lexicon : getMain(lexicon).$type
+  return collection === nsid
+}
+
+/**
+ * Narrows an event to a create commit, optionally for one lexicon. Type
+ * narrowing only — the record is NOT validated; pair with a validating
+ * collection filter (or validate the record) when shape guarantees matter.
+ */
+export function isCreate<E extends AnyEvent>(
+  ev: E,
+): ev is NarrowedEvent<E, 'create'>
+export function isCreate<E extends AnyEvent, L extends EventLexicon>(
+  ev: E,
+  lexicon: L,
+): ev is NarrowedEvent<E, 'create', CollectionOf<L>>
+export function isCreate(ev: AnyEvent, lexicon?: EventLexicon): boolean {
+  return isCommitOp(ev, lexicon, 'create')
+}
+
+/** Narrows an event to an update commit. See {@link isCreate}. */
+export function isUpdate<E extends AnyEvent>(
+  ev: E,
+): ev is NarrowedEvent<E, 'update'>
+export function isUpdate<E extends AnyEvent, L extends EventLexicon>(
+  ev: E,
+  lexicon: L,
+): ev is NarrowedEvent<E, 'update', CollectionOf<L>>
+export function isUpdate(ev: AnyEvent, lexicon?: EventLexicon): boolean {
+  return isCommitOp(ev, lexicon, 'update')
+}
+
+/** Narrows an event to a delete commit. See {@link isCreate}. */
+export function isDelete<E extends AnyEvent>(
+  ev: E,
+): ev is NarrowedEvent<E, 'delete'>
+export function isDelete<E extends AnyEvent, L extends EventLexicon>(
+  ev: E,
+  lexicon: L,
+): ev is NarrowedEvent<E, 'delete', CollectionOf<L>>
+export function isDelete(ev: AnyEvent, lexicon?: EventLexicon): boolean {
+  return isCommitOp(ev, lexicon, 'delete')
+}
+
+/**
+ * Narrows an event to a put (create or update) commit — the arms that carry
+ * a record. See {@link isCreate}.
+ */
+export function isPut<E extends AnyEvent>(
+  ev: E,
+): ev is NarrowedEvent<E, 'create' | 'update'>
+export function isPut<E extends AnyEvent, L extends EventLexicon>(
+  ev: E,
+  lexicon: L,
+): ev is NarrowedEvent<E, 'create' | 'update', CollectionOf<L>>
+export function isPut(ev: AnyEvent, lexicon?: EventLexicon): boolean {
+  return isCommitOp(ev, lexicon, 'create', 'update')
+}

--- a/packages/jetstream/tests/narrow.test.ts
+++ b/packages/jetstream/tests/narrow.test.ts
@@ -1,0 +1,305 @@
+import { type InferOutput, type TypedLexMap, l, record } from '@atproto/lex'
+import { expect, expectTypeOf, test } from 'vitest'
+import {
+  type RawEvent,
+  type RawEventV1,
+  type TypedEvent,
+  type TypedEventV1,
+} from '../src/event.js'
+import { type TypedEventFor } from '../src/filter-types.js'
+import { isCreate, isDelete, isPut, isUpdate } from '../src/narrow.js'
+import { type RawRecord, type RawRecordJson } from '../src/raw-record.js'
+
+const likeSchema = record(
+  'tid',
+  'app.test.like',
+  l.object({ subject: l.string() }),
+)
+type Like = InferOutput<typeof likeSchema>
+
+// postSchema is consumed only via `typeof postSchema`; the runtime value is
+// required for that type query, so eslint's no-unused-vars is a false positive.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const postSchema = record(
+  'tid',
+  'app.test.post',
+  l.object({ text: l.string() }),
+)
+type Post = InferOutput<typeof postSchema>
+
+// A record carrying a non-JSON lex value (bytes). Records made only of JSON
+// values structurally satisfy the raw wire-JSON type, so a raw-vs-lex
+// distinction drawn from the record type alone behaves differently for this
+// schema than for `Post` — these two must narrow identically.
+const bytesSchema = record(
+  'tid',
+  'app.test.bytes',
+  l.object({ payload: l.bytes() }),
+)
+type Bytes = InferOutput<typeof bytesSchema>
+
+// The shape real generated records have: optional properties and a blob.
+const profileSchema = record(
+  'literal:self',
+  'app.test.profile',
+  l.object({
+    handle: l.string(),
+    avatar: l.optional(l.blob()),
+    description: l.optional(l.string()),
+  }),
+)
+type Profile = InferOutput<typeof profileSchema>
+
+const base = {
+  did: 'did:example:alice',
+  seq: 1,
+  time: '2024-01-01T00:00:00.000Z',
+}
+
+function commitEvent(
+  operation: 'create' | 'update' | 'delete',
+  collection = 'app.test.like',
+): Extract<TypedEvent, { kind: 'commit' }> {
+  const commit =
+    operation === 'delete'
+      ? { operation, collection, rkey: '3jt5tlqcwvk24', rev: '3jt5tlqcwvk2a' }
+      : {
+          operation,
+          collection,
+          rkey: '3jt5tlqcwvk24',
+          rev: '3jt5tlqcwvk2a',
+          cid: 'bafyreib2rxk3rybk3aobmv5cjuql3bm2twh4jo5uxgf5kpqrsqxi3jjq3u',
+          record: { $type: collection, subject: 'at://did:example:bob' },
+        }
+  return { ...base, kind: 'commit', commit } as Extract<
+    TypedEvent,
+    { kind: 'commit' }
+  >
+}
+
+const identityEvent = {
+  ...base,
+  kind: 'identity',
+  identity: { did: base.did, handle: 'alice.test' },
+} as TypedEvent
+
+const accountEvent = {
+  ...base,
+  kind: 'account',
+  account: { did: base.did, active: true },
+} as TypedEvent
+
+test('isCreate matches only create commits', () => {
+  expect(isCreate(commitEvent('create'))).toBe(true)
+  expect(isCreate(commitEvent('update'))).toBe(false)
+  expect(isCreate(commitEvent('delete'))).toBe(false)
+  expect(isCreate(identityEvent)).toBe(false)
+  expect(isCreate(accountEvent)).toBe(false)
+})
+
+test('isUpdate matches only update commits', () => {
+  expect(isUpdate(commitEvent('update'))).toBe(true)
+  expect(isUpdate(commitEvent('create'))).toBe(false)
+  expect(isUpdate(commitEvent('delete'))).toBe(false)
+  expect(isUpdate(identityEvent)).toBe(false)
+})
+
+test('isDelete matches only delete commits', () => {
+  expect(isDelete(commitEvent('delete'))).toBe(true)
+  expect(isDelete(commitEvent('create'))).toBe(false)
+  expect(isDelete(commitEvent('update'))).toBe(false)
+  expect(isDelete(identityEvent)).toBe(false)
+})
+
+test('isPut matches create and update commits, not delete', () => {
+  expect(isPut(commitEvent('create'))).toBe(true)
+  expect(isPut(commitEvent('update'))).toBe(true)
+  expect(isPut(commitEvent('delete'))).toBe(false)
+  expect(isPut(identityEvent)).toBe(false)
+})
+
+test('a lexicon schema restricts matches to its collection', () => {
+  expect(isCreate(commitEvent('create'), likeSchema)).toBe(true)
+  expect(isCreate(commitEvent('create', 'app.test.post'), likeSchema)).toBe(
+    false,
+  )
+  expect(isDelete(commitEvent('delete'), likeSchema)).toBe(true)
+  expect(isDelete(commitEvent('delete', 'app.test.post'), likeSchema)).toBe(
+    false,
+  )
+})
+
+test('the lexicon accepts a namespace ({ main }) form', () => {
+  expect(isPut(commitEvent('update'), { main: likeSchema })).toBe(true)
+  expect(
+    isPut(commitEvent('update', 'app.test.post'), { main: likeSchema }),
+  ).toBe(false)
+})
+
+test('the lexicon accepts a bare NSID string', () => {
+  expect(isCreate(commitEvent('create'), 'app.test.like')).toBe(true)
+  expect(isCreate(commitEvent('create'), 'app.test.post')).toBe(false)
+})
+
+test('matching does not validate the record', () => {
+  const ev = {
+    ...base,
+    kind: 'commit',
+    commit: {
+      operation: 'create',
+      collection: 'app.test.like',
+      rkey: '3jt5tlqcwvk24',
+      rev: '3jt5tlqcwvk2a',
+      cid: 'bafyreib2rxk3rybk3aobmv5cjuql3bm2twh4jo5uxgf5kpqrsqxi3jjq3u',
+      // not a valid app.test.like record: `subject` is missing
+      record: { $type: 'app.test.like' },
+    },
+  } as TypedEvent
+  expect(isCreate(ev, likeSchema)).toBe(true)
+})
+
+test('narrows a plain TypedEvent by operation', () => {
+  const ev = {} as TypedEvent
+  if (isCreate(ev)) {
+    expectTypeOf(ev.kind).toEqualTypeOf<'commit'>()
+    expectTypeOf(ev.commit.operation).toEqualTypeOf<'create'>()
+    expectTypeOf(ev.commit.record).toEqualTypeOf<TypedLexMap>()
+  }
+  if (isPut(ev)) {
+    expectTypeOf(ev.commit.operation).toEqualTypeOf<'create' | 'update'>()
+    expectTypeOf(ev.commit.record).toEqualTypeOf<TypedLexMap>()
+  }
+  if (isDelete(ev)) {
+    expectTypeOf(ev.commit.operation).toEqualTypeOf<'delete'>()
+    expectTypeOf(ev.commit).not.toHaveProperty('record')
+  }
+})
+
+// A record whose $type was wider than the lexicon tightens to the lexicon's
+// NSID and stays a lex map, but gains no validated shape — the match did not
+// validate. Asserted behaviorally rather than against one exact type: the
+// result is lex's `Simplify`-flattened object, not a `TypedLexMap`
+// intersection.
+test('narrows a plain TypedEvent with a schema: floor-typed record', () => {
+  const ev = {} as TypedEvent
+  if (isPut(ev, likeSchema)) {
+    expectTypeOf(ev.commit.operation).toEqualTypeOf<'create' | 'update'>()
+    expectTypeOf(ev.commit.collection).toEqualTypeOf<'app.test.like'>()
+    expectTypeOf(ev.commit.record.$type).toEqualTypeOf<'app.test.like'>()
+    expectTypeOf(ev.commit.record).toExtend<TypedLexMap<'app.test.like'>>()
+    expectTypeOf(ev.commit.record).not.toEqualTypeOf<Like>()
+  }
+  if (isDelete(ev, likeSchema)) {
+    expectTypeOf(ev.commit.collection).toEqualTypeOf<'app.test.like'>()
+  }
+})
+
+test('narrows with a bare NSID string like a schema', () => {
+  const ev = {} as TypedEvent
+  if (isCreate(ev, 'app.test.like')) {
+    expectTypeOf(ev.commit.collection).toEqualTypeOf<'app.test.like'>()
+    expectTypeOf(ev.commit.record.$type).toEqualTypeOf<'app.test.like'>()
+    expectTypeOf(ev.commit.record).toExtend<TypedLexMap<'app.test.like'>>()
+    expectTypeOf(ev.commit.record).not.toEqualTypeOf<Like>()
+  }
+})
+
+test('preserves a schema-filtered union arm, including its validated record', () => {
+  const ev = {} as TypedEventFor<[typeof likeSchema, 'app.test.post']>
+  if (isPut(ev, likeSchema)) {
+    expectTypeOf(ev.commit.collection).toEqualTypeOf<'app.test.like'>()
+    expectTypeOf(ev.commit.record).toEqualTypeOf<Like>()
+  }
+  if (isCreate(ev, 'app.test.post')) {
+    expectTypeOf(ev.commit.collection).toEqualTypeOf<'app.test.post'>()
+    expectTypeOf(ev.commit.record.$type).toEqualTypeOf<'app.test.post'>()
+    expectTypeOf(ev.commit.record).toExtend<TypedLexMap<'app.test.post'>>()
+  }
+})
+
+test('force-narrows a wildcard-filtered arm to the lexicon literal', () => {
+  const ev = {} as TypedEventFor<['app.test.*']>
+  if (isCreate(ev, likeSchema)) {
+    expectTypeOf(ev.commit.collection).toEqualTypeOf<'app.test.like'>()
+    expectTypeOf(ev.commit.record.$type).toEqualTypeOf<'app.test.like'>()
+    expectTypeOf(ev.commit.record).toExtend<TypedLexMap<'app.test.like'>>()
+    expectTypeOf(ev.commit.record).not.toEqualTypeOf<Like>()
+  }
+})
+
+test('narrows a record union already on the event down to the lexicon arm', () => {
+  const ev = {} as TypedEvent<Post | Like>
+  if (isPut(ev, likeSchema)) {
+    expectTypeOf(ev.commit.collection).toEqualTypeOf<'app.test.like'>()
+    expectTypeOf(ev.commit.record).toEqualTypeOf<Like>()
+  }
+})
+
+test('narrows a record union whose arms carry non-JSON lex values', () => {
+  const ev = {} as TypedEvent<Bytes | Like>
+  if (isPut(ev, bytesSchema)) {
+    expectTypeOf(ev.commit.collection).toEqualTypeOf<'app.test.bytes'>()
+    expectTypeOf(ev.commit.record).toEqualTypeOf<Bytes>()
+  }
+})
+
+test('narrows a record union whose arms have optional properties and blobs', () => {
+  const ev = {} as TypedEvent<Profile | Like>
+  if (isPut(ev, profileSchema)) {
+    expectTypeOf(ev.commit.collection).toEqualTypeOf<'app.test.profile'>()
+    expectTypeOf(ev.commit.record).toEqualTypeOf<Profile>()
+  }
+})
+
+test('floor-types a wide record for a realistic lexicon', () => {
+  const ev = {} as TypedEvent
+  if (isPut(ev, profileSchema)) {
+    expectTypeOf(ev.commit.record.$type).toEqualTypeOf<'app.test.profile'>()
+    expectTypeOf(ev.commit.record).toExtend<TypedLexMap<'app.test.profile'>>()
+    expectTypeOf(ev.commit.record).not.toEqualTypeOf<Profile>()
+  }
+})
+
+test('a lexicon foreign to the event record union narrows to never', () => {
+  const ev = {} as TypedEvent<Post | Like>
+  if (isCreate(ev, 'com.example.other')) {
+    expectTypeOf(ev).toBeNever()
+  }
+})
+
+test('a lexicon foreign to the filtered union narrows to never', () => {
+  const ev = {} as TypedEventFor<[typeof likeSchema]>
+  if (isCreate(ev, 'com.example.other')) {
+    expectTypeOf(ev).toBeNever()
+  }
+})
+
+test('narrows v1 events, keeping the v1 envelope', () => {
+  const ev = {} as TypedEventV1
+  if (isPut(ev, likeSchema)) {
+    expectTypeOf(ev.timeUs).toEqualTypeOf<number>()
+    expectTypeOf(ev.commit.collection).toEqualTypeOf<'app.test.like'>()
+  }
+  const v1 = {
+    did: base.did,
+    seq: 1,
+    timeUs: 1,
+    kind: 'commit',
+    commit: commitEvent('create').commit,
+  } as TypedEventV1
+  expect(isCreate(v1)).toBe(true)
+  expect(isDelete(v1)).toBe(false)
+})
+
+test('narrows raw events without retyping the raw record', () => {
+  const ev = {} as RawEvent
+  if (isPut(ev, likeSchema)) {
+    expectTypeOf(ev.commit.collection).toEqualTypeOf<'app.test.like'>()
+    expectTypeOf(ev.commit.record).toEqualTypeOf<RawRecord>()
+  }
+  const v1 = {} as RawEventV1
+  if (isCreate(v1)) {
+    expectTypeOf(v1.commit.operation).toEqualTypeOf<'create'>()
+    expectTypeOf(v1.commit.record).toEqualTypeOf<RawRecordJson>()
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,9 +269,6 @@ importers:
 
   packages/jetstream:
     dependencies:
-      '@atproto/lex':
-        specifier: ^0.3.0
-        version: 0.3.3
       '@atproto/lex-cbor':
         specifier: ^0.1.6
         version: 0.1.6
@@ -279,6 +276,9 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0
     devDependencies:
+      '@atproto/lex':
+        specifier: ^0.3.0
+        version: 0.3.3
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1


### PR DESCRIPTION
Two small bits of prep before we tag `@bsky/jetstream` v1.

`@atproto/lex` moves from a regular dependency to a peer dependency, matching `@bsky/sdk`. Installing is now `npm install @bsky/jetstream @atproto/lex`.

New `isCreate()`, `isUpdate()`, `isDelete()`, and `isPut()` (create or update) helpers stand in for hand-written `evt.kind === 'commit' && evt.commit.operation === 'create'` checks:

```ts
for await (const evt of js.live({ collections: [app.bsky.feed.post] })) {
  if (isCreate(evt, app.bsky.feed.post)) {
    console.log(evt.commit.record.text)
  }
}
```

The second argument is optional. Pass a lexicon (or a bare NSID) and the helper also matches on the collection and narrows the record, the same way that lexicon's `$isTypeOf()` would — it delegates to lex's `TypedRecord`, so a record the event already types precisely keeps that type, a wider record type tightens to the lexicon, and a lexicon that can't appear in the stream narrows the event away entirely. Raw events narrow too, keeping their wire record type.

Like `$isTypeOf()`, none of this validates anything — it's types only. Validation is still the job of a validating collection filter.

No changeset yet. Worth noting the peer dependency move is breaking for anyone relying on the transitive install, so it should land in the release notes.