### PR TITLE
Push the Jetstream kinds filter down to planSnapshot

### DIFF
--- a/.changeset/plan-kinds-filter.md
+++ b/.changeset/plan-kinds-filter.md
@@ -1,0 +1,4 @@
+---
+---
+
+Push the `kinds` filter down to `planSnapshot` so `snapshot()`/`replay()` skip whole archive blocks server-side instead of downloading and discarding them, and reject filter combinations the server refuses (over-cap `kinds`/`dids`/`collections` lists, and `collections` paired with a `kinds` list that excludes `commit`) locally rather than as an opaque handshake failure. No published-package changes — `@bsky/jetstream` is unreleased and its pending initial-release changeset already covers filtering.

--- a/packages/jetstream/README.md
+++ b/packages/jetstream/README.md
@@ -26,7 +26,7 @@ for await (const evt of js.live({ collections: ['app.bsky.feed.post'] })) {
 }
 ```
 
-`collections` constrains **commit** events only — identity, account, and sync events flow regardless — so a commits-only stream also needs `kinds: ['commit']`. `kinds` accepts `commit`, `identity`, `account`, and `sync`, and omitting it means all kinds.
+`collections` constrains **commit** events only — identity, account, and sync events flow regardless — so a commits-only stream also needs `kinds: ['commit']`. `kinds` accepts `commit`, `identity`, `account`, and `sync`, and omitting it means all kinds. Conversely, a `kinds` list without `commit` leaves `collections` with nothing to constrain: that pair is rejected rather than silently ignoring either side.
 
 Using a lexicon as your collection filter will validate and type the events for you:
 

--- a/packages/jetstream/src/engine/planner.ts
+++ b/packages/jetstream/src/engine/planner.ts
@@ -1,10 +1,13 @@
 import { type DidString } from '@atproto/lex'
+import { type Kind } from '../event.js'
 import { type Plan, planSnapshot } from '../xrpc/plan.js'
 
 export interface PlanPagesOpts {
   host: string
   dids?: DidString[]
   collections: string[]
+  /** Forwarded verbatim; see PlanRequest.kinds for the marker-safe default. */
+  kinds?: Kind[]
   afterSeq?: number
   beforeSeq?: number
   fetchImpl: typeof fetch
@@ -29,6 +32,7 @@ export async function* planPages(opts: PlanPagesOpts): AsyncGenerator<Plan> {
     const page = await planSnapshot(
       {
         host: opts.host,
+        kinds: opts.kinds,
         dids: opts.dids,
         collections: opts.collections,
         afterSeq: cursor,

--- a/packages/jetstream/src/filter-limits.ts
+++ b/packages/jetstream/src/filter-limits.ts
@@ -1,0 +1,54 @@
+import { type Kind } from './event.js'
+
+/**
+ * Server-side caps on the v2 filter axes, shared by the live wire
+ * (`subscribeEvents` params) and the archive planner (`planSnapshot` input).
+ * Both lexicons declare the same maxLengths.
+ */
+export const MAX_FILTER_KINDS = 4
+export const MAX_FILTER_DIDS = 10_000
+export const MAX_FILTER_COLLECTIONS = 100
+
+export interface WireFilters {
+  kinds?: readonly Kind[]
+  dids?: readonly string[]
+  collections?: readonly string[]
+}
+
+/**
+ * Checks a filter triple against the rules the server enforces, so a violation
+ * fails locally with a message naming the fix.
+ *
+ * Both endpoints answer a violation with InvalidRequest, but neither surfaces
+ * it usefully: the live wire rejects pre-upgrade with an HTTP 400 whose body
+ * the default websocket transport discards, and inside `cutoverReplay` a bare
+ * 400 handshake is classified as cursor-too-old — so a bad filter would burn
+ * the whole re-plan budget before failing with the wrong reason.
+ */
+export function assertWireFilters(f: WireFilters): void {
+  if ((f.kinds?.length ?? 0) > MAX_FILTER_KINDS) {
+    throw new RangeError(
+      `kinds filter exceeds the server limit of ${MAX_FILTER_KINDS}`,
+    )
+  }
+  if ((f.dids?.length ?? 0) > MAX_FILTER_DIDS) {
+    throw new RangeError(
+      `dids filter exceeds the server limit of ${MAX_FILTER_DIDS}`,
+    )
+  }
+  if ((f.collections?.length ?? 0) > MAX_FILTER_COLLECTIONS) {
+    throw new RangeError(
+      `collections filter exceeds the server limit of ${MAX_FILTER_COLLECTIONS}`,
+    )
+  }
+  // The collections axis constrains commits only, so a kinds list without
+  // 'commit' makes it unsatisfiable. The server rejects the pair rather than
+  // silently ignoring either side, and so do we.
+  if (f.collections?.length && f.kinds?.length && !f.kinds.includes('commit')) {
+    throw new Error(
+      "collections filter can never apply: kinds excludes 'commit' " +
+        '(add commit to kinds, or drop the collections filter — it does not ' +
+        'constrain identity/account/sync events)',
+    )
+  }
+}

--- a/packages/jetstream/src/jetstream.ts
+++ b/packages/jetstream/src/jetstream.ts
@@ -94,7 +94,9 @@ export interface LiveOpts<
   dids?: DidString[]
   /**
    * Event kinds to receive. Omitted means all kinds. The collections filter
-   * constrains only commits, so a commits-only stream needs kinds: ['commit'].
+   * constrains only commits, so a commits-only stream needs kinds: ['commit'] —
+   * and conversely, a kinds list without 'commit' makes a collections filter
+   * unsatisfiable and is rejected rather than silently ignored.
    */
   kinds?: Kind[]
   cursor?: CursorStore
@@ -116,8 +118,13 @@ export interface ReplayOpts<
   collections?: F
   dids?: DidString[]
   /**
-   * Event kinds to receive, uniform across both phases: sent on the live
-   * wire, applied client-side over the snapshot phase.
+   * Event kinds to receive, uniform across both phases: sent on the live wire
+   * and to the snapshot planner, then re-applied client-side (the plan only
+   * narrows which blocks are downloaded).
+   *
+   * Note the interaction with `collections`, which constrains commits only: a
+   * `kinds` list without `'commit'` makes a collections filter unsatisfiable
+   * and is rejected rather than silently ignored.
    */
   kinds?: Kind[]
   /**
@@ -157,9 +164,13 @@ export interface SnapshotOpts<
   collections?: F
   dids?: DidString[]
   /**
-   * Event kinds to receive. The snapshot plan has no kinds filter, so this
-   * is applied client-side after download — same semantics as replay's
-   * snapshot phase.
+   * Event kinds to receive. Sent to the planner so whole blocks can be skipped
+   * before download, then re-applied client-side (the plan may still ship
+   * other kinds from a selected block).
+   *
+   * Note the interaction with `collections`, which constrains commits only: a
+   * `kinds` list without `'commit'` makes a collections filter unsatisfiable
+   * and is rejected rather than silently ignored.
    */
   kinds?: Kind[]
   /**
@@ -349,9 +360,11 @@ export class Jetstream {
     const sha256 = this.opts.sha256 ?? defaultRuntime.sha256()
     const { nsids } = parseCollectionFilters(opts.collections ?? [])
     const maxReplans = opts.maxReplans ?? 50
-    // The plan has no kinds filter, so kinds prune client-side. lastCursor is
-    // preserved so the watermark advances past pruned events, and an
-    // empty-after-filter batch still yields (same rule as replay's phase).
+    // kinds also goes to the planner (below), but the plan is a one-sided
+    // transport hint — a selected block can still carry other kinds — so the
+    // client-side prune stays authoritative. lastCursor is preserved so the
+    // watermark advances past pruned events, and an empty-after-filter batch
+    // still yields (same rule as replay's phase).
     const kindsFilter =
       opts.kinds && opts.kinds.length > 0 ? new Set(opts.kinds) : undefined
 
@@ -377,6 +390,7 @@ export class Jetstream {
       try {
         for await (const page of planPages({
           host,
+          kinds: opts.kinds,
           dids: opts.dids,
           collections: nsids,
           afterSeq: resume,

--- a/packages/jetstream/src/live/cutover.ts
+++ b/packages/jetstream/src/live/cutover.ts
@@ -85,9 +85,11 @@ export async function* cutoverReplay(
     collections: ctx.nsids,
     window,
   })
-  // The archive has no server-side kinds filter (unlike the live tail, which
-  // sends `kinds=` on the wire), so filter client-side to make kinds uniform
-  // across both phases. Only when non-empty: no kinds pays zero overhead.
+  // kinds goes on the wire in both phases (live params, plan input), but the
+  // plan is a one-sided transport hint — a selected block can still carry
+  // other kinds — so the client-side prune is what makes kinds exact and
+  // uniform across the two phases. Only when non-empty: no kinds pays zero
+  // overhead.
   const kindsFilter =
     ctx.kinds && ctx.kinds.length > 0 ? new Set(ctx.kinds) : undefined
 
@@ -105,6 +107,7 @@ export async function* cutoverReplay(
       try {
         for await (const page of planPages({
           host: ctx.host,
+          kinds: ctx.kinds,
           dids: ctx.dids,
           collections: ctx.nsids,
           afterSeq: snapshotResume,

--- a/packages/jetstream/src/live/source.ts
+++ b/packages/jetstream/src/live/source.ts
@@ -1,5 +1,6 @@
 import { type DidString } from '@atproto/lex'
 import { type Kind, type RawEvent, type RawEventV1 } from '../event.js'
+import { assertWireFilters } from '../filter-limits.js'
 import { type RawRecordJson } from '../raw-record.js'
 import { decodeLiveFrameV1 } from './decode-v1.js'
 import { type LiveInfoFrame, SKIP_FRAME, decodeLiveFrame } from './decode.js'
@@ -20,11 +21,6 @@ const V2_NSID = 'network.bsky.jetstream.subscribeEvents'
 // never seed the dedup floor — it is not a seq, so every real seq would compare
 // as a duplicate. v1 has no split: there, seq IS time_us.
 const V2_CURSOR_SEQ_MAX_THRESHOLD = 1e15
-
-// Server-side caps on the v2 filter params. Exceeding one is a pre-upgrade 400
-// whose body `ws` discards, so check locally and say why.
-const V2_MAX_DIDS = 10_000
-const V2_MAX_COLLECTIONS = 100
 
 export interface LiveEventsOpts {
   host: string
@@ -78,18 +74,8 @@ export async function* liveEvents(
       'jetstream v1 does not support the kinds filter (v1 /subscribe has no equivalent parameter)',
     )
   }
-  if (version === 2) {
-    if ((opts.dids?.length ?? 0) > V2_MAX_DIDS) {
-      throw new RangeError(
-        `dids filter exceeds the server limit of ${V2_MAX_DIDS}`,
-      )
-    }
-    if ((opts.collections?.length ?? 0) > V2_MAX_COLLECTIONS) {
-      throw new RangeError(
-        `collections filter exceeds the server limit of ${V2_MAX_COLLECTIONS}`,
-      )
-    }
-  }
+  // v2 only: v1's wanted* params have their own (looser) server contract.
+  if (version === 2) assertWireFilters(opts)
   // The decoder-select union is the truth: the v1 decoder yields RawEventV1 (a
   // subtype), the v2 decoder yields RawEvent plus LiveInfoFrame, and both can
   // yield SKIP_FRAME.

--- a/packages/jetstream/src/xrpc/plan.ts
+++ b/packages/jetstream/src/xrpc/plan.ts
@@ -1,4 +1,6 @@
 import { type DidString, type InferOutput, l, xrpc } from '@atproto/lex'
+import { type Kind } from '../event.js'
+import { assertWireFilters } from '../filter-limits.js'
 
 // The planSnapshot wire contract, declared once by hand (this package does
 // not generate lexicon clients). `mode` stays an open string so a newer
@@ -27,7 +29,10 @@ const stats = l.object({
 })
 
 const params = l.params()
+// `kinds` stays an open string array for the same reason as `mode` above: a
+// kind this build does not know is the server's to reject, not ours.
 const input = l.jsonPayload({
+  kinds: l.optional(l.array(l.string())),
   dids: l.optional(l.array(l.string({ format: 'did' }))),
   collections: l.optional(l.array(l.string())),
   afterSeq: l.optional(l.integer({ minimum: 0 })),
@@ -59,6 +64,15 @@ export type Plan = {
 
 export interface PlanRequest {
   host: string
+  /**
+   * Event kinds to plan for. Omitting it (or passing an empty array) keeps the
+   * server's marker-safe default: the `$account`/`$identity`/`$sync` sentinel
+   * blocks are admitted under a collections filter, so a collection-filtered
+   * snapshot still receives the DID-level markers it must fold. An explicit
+   * `['commit']` drops that baseline — correct only when the caller discards
+   * non-commit events anyway.
+   */
+  kinds?: Kind[]
   dids?: DidString[]
   collections?: string[]
   afterSeq?: number
@@ -70,7 +84,9 @@ export async function planSnapshot(
   fetchImpl: typeof fetch = fetch,
   signal?: AbortSignal,
 ): Promise<Plan> {
+  assertWireFilters(req)
   const body: l.InferPayloadBody<typeof input, l.BinaryData> = {}
+  if (req.kinds?.length) body.kinds = req.kinds
   if (req.dids?.length) body.dids = req.dids
   if (req.collections?.length) body.collections = req.collections
   if (req.afterSeq !== undefined) body.afterSeq = req.afterSeq

--- a/packages/jetstream/tests/engine/planner.test.ts
+++ b/packages/jetstream/tests/engine/planner.test.ts
@@ -7,16 +7,24 @@ import type { Plan } from '../../src/xrpc/plan.js'
 // the afterSeq/beforeSeq pagination wiring.
 function fakePlanFetch(pages: Array<Partial<Plan>>): {
   fetch: typeof fetch
-  bodies: Array<{ afterSeq?: number; beforeSeq?: number }>
+  bodies: Array<{ afterSeq?: number; beforeSeq?: number; kinds?: string[] }>
 } {
-  const bodies: Array<{ afterSeq?: number; beforeSeq?: number }> = []
+  const bodies: Array<{
+    afterSeq?: number
+    beforeSeq?: number
+    kinds?: string[]
+  }> = []
   let i = 0
   const fetch: typeof globalThis.fetch = async (_url, init) => {
     const body =
       (init as RequestInit | undefined)?.body != null
         ? JSON.parse(String((init as RequestInit).body))
         : {}
-    bodies.push({ afterSeq: body.afterSeq, beforeSeq: body.beforeSeq })
+    bodies.push({
+      afterSeq: body.afterSeq,
+      beforeSeq: body.beforeSeq,
+      kinds: body.kinds,
+    })
     const page = pages[Math.min(i, pages.length - 1)]
     i++
     const full = {
@@ -121,6 +129,39 @@ describe('planPages', () => {
     )
     expect(bodies[0].beforeSeq).toBe(250)
     expect(bodies[1].beforeSeq).toBe(100)
+  })
+
+  it('forwards the kinds filter on every page', async () => {
+    const { fetch, bodies } = fakePlanFetch([
+      { plannedThroughSeq: 50, sealedTipSeq: 100 },
+      { plannedThroughSeq: 100, sealedTipSeq: 100 },
+    ])
+    await collect(
+      planPages({
+        host: 'https://h',
+        collections: [],
+        kinds: ['commit'],
+        fetchImpl: fetch,
+      }),
+    )
+    expect(bodies.map((b) => b.kinds)).toEqual([['commit'], ['commit']])
+  })
+
+  it('omits kinds when unset, keeping the marker-safe planner default', async () => {
+    // With kinds omitted the server admits the $account/$identity/$sync
+    // sentinel blocks under a collection filter, so a collection-filtered
+    // snapshot still receives the DID-level markers it must fold.
+    const { fetch, bodies } = fakePlanFetch([
+      { plannedThroughSeq: 100, sealedTipSeq: 100 },
+    ])
+    await collect(
+      planPages({
+        host: 'https://h',
+        collections: ['app.bsky.feed.post'],
+        fetchImpl: fetch,
+      }),
+    )
+    expect(bodies[0].kinds).toBeUndefined()
   })
 
   it('throws fatally if the cursor fails to advance (anti-spin)', async () => {

--- a/packages/jetstream/tests/jetstream/snapshot-raw.test.ts
+++ b/packages/jetstream/tests/jetstream/snapshot-raw.test.ts
@@ -231,6 +231,34 @@ test('snapshot: beforeSeq mid-block prunes rows above the ceiling', async () => 
   expect(seqs).toEqual([1, 2]) // seq 3 excluded (inclusive upper bound)
 })
 
+test('snapshot: forwards kinds to the plan AND still prunes client-side', async () => {
+  // The plan is a transport planner with a one-sided contract, so the server
+  // may ship non-commit rows inside a selected block even with kinds=commit.
+  // Pushing kinds down cuts download volume; the client filter stays
+  // authoritative. golden_block.bin: seq 2 is an identity event.
+  const planBodies: Record<string, unknown>[] = []
+  const capturingFetch = (async (
+    url: string | URL,
+    init?: Parameters<typeof fetch>[1],
+  ) => {
+    if (String(url).includes('planSnapshot')) {
+      planBodies.push(init?.body != null ? JSON.parse(String(init.body)) : {})
+    }
+    return fetchImpl(url, init)
+  }) as unknown as typeof fetch
+
+  const js = new Jetstream({
+    service: 'https://js.example',
+    fetchImpl: capturingFetch,
+  })
+  const seqs: number[] = []
+  for await (const b of js.snapshotRawBatches({ kinds: ['commit'] })) {
+    for (const e of b.events) seqs.push(e.seq)
+  }
+  expect(planBodies[0].kinds).toEqual(['commit'])
+  expect(seqs).toEqual([1, 3]) // seq 2 (identity) pruned by the kinds filter
+})
+
 test('snapshot: onError DownloadError names the failed plan entry', async () => {
   failOnce = true
   const errored: Error[] = []

--- a/packages/jetstream/tests/live/cutover-replay.test.ts
+++ b/packages/jetstream/tests/live/cutover-replay.test.ts
@@ -183,6 +183,40 @@ test('cutoverReplay: a backfilled DELETE is delivered as an ordinary event', asy
   expect(seqs).toEqual([2, 3])
 })
 
+test('cutoverReplay: kinds reaches both phases — the plan body and the live wire', async () => {
+  const planBodies: Record<string, unknown>[] = []
+  const base = makeFetch([
+    { plannedThroughSeq: 3, sealedTipSeq: 3, segments: [SEALED_ENTRY] },
+  ])
+  const fetchImpl = (async (
+    url: string | URL,
+    init?: Parameters<typeof fetch>[1],
+  ) => {
+    if (String(url).includes('planSnapshot')) {
+      planBodies.push(init?.body != null ? JSON.parse(String(init.body)) : {})
+    }
+    return base(url, init)
+  }) as unknown as typeof fetch
+
+  let liveUrl: string | undefined
+  const seqs = await drain(
+    cutoverReplay({
+      host: 'https://h',
+      nsids: ['app.bsky.feed.post', 'app.bsky.feed.like'],
+      kinds: ['commit'],
+      fetchImpl,
+      transport: liveTransport([liveCommit(4)], (url) => {
+        liveUrl = url
+      }),
+    }),
+  )
+  expect(planBodies[0].kinds).toEqual(['commit'])
+  expect(new URL(liveUrl!).searchParams.getAll('kinds')).toEqual(['commit'])
+  // Backfill 1 and 3 (commits); 2 (identity) pruned client-side despite the
+  // one-sided plan shipping it. Live 4 delivered.
+  expect(seqs).toEqual([1, 3, 4])
+})
+
 test('cutoverReplay: empty archive (tip 0) — live owns the whole stream from the first seq', async () => {
   // v2 wire seq must be >= 1 (decodeLiveFrame rejects seq <= 0), so this
   // exercises the undefined-dedupFloor path at seq 1 rather than seq 0.
@@ -234,7 +268,9 @@ test('cutoverReplay: an empty-after-filter batch still yields (lastCursor preser
   const batches: { events: unknown[]; lastCursor: number }[] = []
   for await (const b of cutoverReplay({
     host: 'https://h',
-    nsids: ['app.bsky.feed.post', 'app.bsky.feed.like'],
+    // No collections filter: pairing one with a kinds list that excludes
+    // 'commit' is unsatisfiable and rejected (see assertWireFilters).
+    nsids: [],
     kinds: ['identity'], // inverse: keep ONLY the identity, drop both commits
     fetchImpl: makeFetch([
       { plannedThroughSeq: 2, sealedTipSeq: 3, segments: [SEALED_ENTRY] },

--- a/packages/jetstream/tests/live/source.test.ts
+++ b/packages/jetstream/tests/live/source.test.ts
@@ -290,6 +290,46 @@ test('rejects parameter lists the server would refuse pre-upgrade', async () => 
       collections: Array.from({ length: 101 }, (_, i) => `app.test.c${i}`),
     }),
   ).rejects.toThrow(RangeError)
+  await expect(
+    run({
+      host: 'https://h',
+      transport,
+      kinds: ['commit', 'commit', 'commit', 'commit', 'commit'],
+    }),
+  ).rejects.toThrow(RangeError)
+})
+
+test('rejects a collections filter that can never apply (kinds excludes commit)', async () => {
+  // The server refuses this pair pre-upgrade with a 400 the default websocket
+  // transport cannot read the body of; inside a replay cutover a bare 400 is
+  // even classified as cursor-too-old and burns the re-plan budget. Say why
+  // here instead.
+  const { transport, urls } = scriptedTransport([[commitFrame(1)]])
+  await expect(async () => {
+    for await (const _ of liveEvents({
+      host: 'https://h',
+      transport,
+      collections: ['app.bsky.feed.post'],
+      kinds: ['account'],
+    }))
+      void _
+  }).rejects.toThrow(/can never apply/)
+  expect(urls).toEqual([]) // never dialed
+})
+
+test('accepts collections together with a kinds list that includes commit', async () => {
+  const { transport, urls } = scriptedTransport([[commitFrame(1)]])
+  const got: number[] = []
+  for await (const ev of liveEvents({
+    host: 'https://h',
+    transport,
+    collections: ['app.bsky.feed.post'],
+    kinds: ['commit', 'account'],
+  })) {
+    got.push(ev.seq)
+  }
+  expect(got).toEqual([1])
+  expect(urls[0]).toContain('collections=app.bsky.feed.post')
 })
 
 test('signal abort stops iteration', async () => {

--- a/packages/jetstream/tests/xrpc/plan.test.ts
+++ b/packages/jetstream/tests/xrpc/plan.test.ts
@@ -1,3 +1,4 @@
+import { type DidString } from '@atproto/lex'
 import { expect, test } from 'vitest'
 import { planSnapshot } from '../../src/xrpc/plan.js'
 
@@ -7,6 +8,37 @@ function jsonFetch(payload: unknown, status = 200): typeof fetch {
       status,
       headers: { 'content-type': 'application/json' },
     })) as unknown as typeof fetch
+}
+
+const EMPTY_PLAN = {
+  plannedThroughSeq: 0,
+  sealedTipSeq: 0,
+  segments: [],
+  stats: {
+    segmentsExamined: 0,
+    segmentsMatched: 0,
+    blocksMatched: 0,
+    entries: 0,
+  },
+}
+
+// Captures the JSON request bodies so the sent filter axes can be asserted.
+function capturingFetch(): {
+  fetch: typeof fetch
+  bodies: Record<string, unknown>[]
+} {
+  const bodies: Record<string, unknown>[] = []
+  const impl = (async (
+    _url: string | URL,
+    init?: Parameters<typeof globalThis.fetch>[1],
+  ) => {
+    bodies.push(init?.body != null ? JSON.parse(String(init.body)) : {})
+    return new Response(JSON.stringify(EMPTY_PLAN), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  }) as unknown as typeof globalThis.fetch
+  return { fetch: impl, bodies }
 }
 
 test('parses a plan response into typed entries', async () => {
@@ -48,4 +80,84 @@ test('parses a plan response into typed entries', async () => {
   expect(plan.segments).toHaveLength(2)
   expect(plan.segments[1].mode).toBe('blocks')
   expect(plan.segments[1].blocks).toEqual([{ first: 2, last: 4 }])
+})
+
+test('sends the kinds filter so the server prunes the plan', async () => {
+  const { fetch, bodies } = capturingFetch()
+  await planSnapshot(
+    {
+      host: 'https://js.example',
+      kinds: ['commit', 'identity'],
+      dids: ['did:plc:a' as DidString],
+      collections: ['app.bsky.feed.post'],
+      afterSeq: 5,
+    },
+    fetch,
+  )
+  expect(bodies[0]).toEqual({
+    kinds: ['commit', 'identity'],
+    dids: ['did:plc:a'],
+    collections: ['app.bsky.feed.post'],
+    afterSeq: 5,
+  })
+})
+
+test('omits empty filter axes — an empty array is match-all, but so is absence', async () => {
+  // Sending kinds: [] would be accepted, but omission keeps the request
+  // minimal and the wire honest about "no filter was expressed".
+  const { fetch, bodies } = capturingFetch()
+  await planSnapshot(
+    { host: 'https://js.example', kinds: [], dids: [], collections: [] },
+    fetch,
+  )
+  expect(bodies[0]).toEqual({})
+})
+
+test('rejects filter lists the server would refuse with InvalidRequest', async () => {
+  const { fetch } = capturingFetch()
+  await expect(
+    planSnapshot(
+      {
+        host: 'https://js.example',
+        kinds: ['commit', 'commit', 'commit', 'commit', 'commit'],
+      },
+      fetch,
+    ),
+  ).rejects.toThrow(RangeError)
+  await expect(
+    planSnapshot(
+      {
+        host: 'https://js.example',
+        dids: Array.from(
+          { length: 10_001 },
+          (_, i) => `did:plc:${i}` as DidString,
+        ),
+      },
+      fetch,
+    ),
+  ).rejects.toThrow(RangeError)
+  await expect(
+    planSnapshot(
+      {
+        host: 'https://js.example',
+        collections: Array.from({ length: 101 }, (_, i) => `app.test.c${i}`),
+      },
+      fetch,
+    ),
+  ).rejects.toThrow(RangeError)
+})
+
+test('rejects a collections filter that can never apply (kinds excludes commit)', async () => {
+  const { fetch, bodies } = capturingFetch()
+  await expect(
+    planSnapshot(
+      {
+        host: 'https://js.example',
+        kinds: ['identity'],
+        collections: ['app.bsky.feed.post'],
+      },
+      fetch,
+    ),
+  ).rejects.toThrow(/can never apply/)
+  expect(bodies).toEqual([]) // rejected before any request went out
 })


### PR DESCRIPTION
Upstream jetstream `11e399d` added a `kinds` input to `planSnapshot` and made the server reject a `collections` filter that can never apply. This takes both into account.

`snapshot()` and `replay()` now send `kinds` to the planner, so the server skips whole archive blocks instead of us downloading and discarding them. The client-side prune stays authoritative — the plan is a one-sided transport hint, and a selected block can still carry other kinds. Omitting `kinds` continues to send nothing, which is what makes the server admit the `$account`/`$identity`/`$sync` sentinel blocks under a collections filter, so a collection-filtered snapshot still receives the DID-level markers it has to fold.

Filter combinations the server refuses now fail locally with a message naming the fix, rather than as an opaque failure: the per-axis caps (kinds 4, dids 10 000, collections 100, previously checked only on the live path) and `collections` paired with a `kinds` list that excludes `commit`. That last pair was accepted by the snapshot path before and has always been a 400 on the live wire; rejecting it uniformly is what `replay()` needs, since it spans both phases. It also matters for diagnosis — `cutoverReplay` reads a bare 400 handshake as cursor-too-old, so a bad filter pair would have burned the whole re-plan budget and then failed for the wrong reason.

New coverage for the plan body per page, the rejections on both paths, and — for the first time — that `snapshot()`/`replay()` still prune non-commit events client-side.