### PR TITLE
Add actor block actions to SDK

### DIFF
--- a/.changeset/petite-bottles-brake.md
+++ b/.changeset/petite-bottles-brake.md
@@ -1,5 +1,5 @@
 ---
-'@bsky/sdk': patch
+'@bsky/sdk': minor
 ---
 
 Add `blockActor` and `unblockActor` sugar actions

--- a/.changeset/petite-bottles-brake.md
+++ b/.changeset/petite-bottles-brake.md
@@ -1,0 +1,5 @@
+---
+'@bsky/sdk': patch
+---
+
+Add `blockActor` and `unblockActor` sugar actions

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -126,6 +126,7 @@ client with `client.call(action, input)`:
 
 ```typescript
 import {
+  blockActor,
   blockActorList,
   deleteFollow,
   deleteLike,
@@ -138,6 +139,7 @@ import {
   muteActorList,
   post,
   repost,
+  unblockActor,
   unblockActorList,
   unmuteActor,
   unmuteActorList,
@@ -162,6 +164,8 @@ await bskyClient.call(follow, { did })
 await bskyClient.call(deleteFollow, followUri)
 await bskyClient.call(muteActor, { actor })
 await bskyClient.call(unmuteActor, { actor })
+await bskyClient.call(blockActor, { did })
+await bskyClient.call(unblockActor, blockUri)
 await bskyClient.call(muteActorList, { list })
 await bskyClient.call(unmuteActorList, { list })
 await bskyClient.call(blockActorList, { list })

--- a/packages/sdk/src/actions/graph.ts
+++ b/packages/sdk/src/actions/graph.ts
@@ -2,6 +2,7 @@ import {
   type Action,
   type AtIdentifierString,
   type CreateOutput,
+  type DidString,
 } from '@atproto/lex'
 import { AtUri, type AtUriString, currentDatetimeString } from '@atproto/syntax'
 import { app as appLexicons } from '../lexicons/index.js'
@@ -34,6 +35,33 @@ export const unmuteActor: Action<{ actor: AtIdentifierString }, void> = async (
   { actor },
 ) => {
   await client.call(appLexicons.bsky.graph.unmuteActor.main, { actor })
+}
+
+/**
+ * Block an actor (user) by creating a block record.
+ */
+export const blockActor: Action<{ did: DidString }, CreateOutput> = async (
+  client,
+  { did },
+) => {
+  return client.create(appLexicons.bsky.graph.block.main, {
+    subject: did,
+    createdAt: currentDatetimeString(),
+  })
+}
+
+/**
+ * Unblock an actor (user) by deleting a block record by URI.
+ */
+export const unblockActor: Action<AtUriString, void> = async (
+  client,
+  blockUri,
+) => {
+  const urip = new AtUri(blockUri)
+  await client.delete(appLexicons.bsky.graph.block.main, {
+    rkey: urip.rkeySafe,
+    repo: urip.hostname,
+  })
 }
 
 /**

--- a/packages/sdk/tests/actions-records.test.ts
+++ b/packages/sdk/tests/actions-records.test.ts
@@ -1,6 +1,14 @@
 import { Client } from '@atproto/lex'
 import { describe, expect, it } from 'vitest'
-import { follow, like, muteActor, post, upsertProfile } from '../src/index.js'
+import {
+  blockActor,
+  follow,
+  like,
+  muteActor,
+  post,
+  unblockActor,
+  upsertProfile,
+} from '../src/index.js'
 
 function fakeClient(
   routes: Record<string, (init: { url: URL; body?: unknown }) => unknown>,
@@ -149,6 +157,38 @@ describe('record actions', () => {
       actor: 'did:plc:bad',
       onlyReposts: true,
       onlyQuoteposts: true,
+    })
+  })
+
+  it('blockActor creates a graph block record', async () => {
+    const { client, calls } = fakeClient({
+      'com.atproto.repo.createRecord': () => ({
+        uri: 'at://did:plc:test/app.bsky.graph.block/1',
+        cid: 'b',
+      }),
+    })
+    await client.call(blockActor, { did: 'did:plc:blocked' })
+    const body = calls[0].body as any
+    expect(body.collection).toBe('app.bsky.graph.block')
+    expect(body.record.subject).toBe('did:plc:blocked')
+    expect(body.record.createdAt).toBeTruthy()
+  })
+
+  it('unblockActor deletes a graph block record by URI', async () => {
+    const { client, calls } = fakeClient({
+      'com.atproto.repo.deleteRecord': () => ({}),
+    })
+    await client.call(
+      unblockActor,
+      'at://did:plc:test/app.bsky.graph.block/3jqfcqzm3fo2j',
+    )
+    expect(calls.map((call) => call.nsid)).toEqual([
+      'com.atproto.repo.deleteRecord',
+    ])
+    expect(calls[0].body).toMatchObject({
+      repo: 'did:plc:test',
+      collection: 'app.bsky.graph.block',
+      rkey: '3jqfcqzm3fo2j',
     })
   })
 


### PR DESCRIPTION
## Summary

- add `blockActor` sugar for creating `app.bsky.graph.block` records
- add `unblockActor` sugar for deleting a block by record URI
- document both actions and cover them with tests

## Test plan

- `pnpm --filter @bsky/sdk exec vitest run tests/actions-records.test.ts`
- `pnpm --filter @bsky/sdk build`