### PR TITLE
Preserve lab view preferences in SDK

### DIFF
--- a/.changeset/chilly-queens-search.md
+++ b/.changeset/chilly-queens-search.md
@@ -1,0 +1,5 @@
+---
+'@bsky/sdk': patch
+---
+
+Fix `lab_treeViewEnabled` and `lab_mergeFeedEnabled` preferences

--- a/packages/sdk/src/actions/preferences.ts
+++ b/packages/sdk/src/actions/preferences.ts
@@ -341,12 +341,16 @@ export const getPreferences: Action<
   // Build feedViewPrefs
   const feedViewPrefs: Record<string, BskyFeedViewPreference> = {}
   for (const fvp of feedViewPrefsArr) {
+    const appFeedViewPref: Partial<BskyFeedViewPreference> = fvp
     feedViewPrefs[fvp.feed] = {
       hideReplies: fvp.hideReplies ?? false,
       hideRepliesByUnfollowed: fvp.hideRepliesByUnfollowed ?? true,
       hideRepliesByLikeCount: fvp.hideRepliesByLikeCount ?? 0,
       hideReposts: fvp.hideReposts ?? false,
       hideQuotePosts: fvp.hideQuotePosts ?? false,
+      ...(typeof appFeedViewPref.lab_mergeFeedEnabled === 'boolean' && {
+        lab_mergeFeedEnabled: appFeedViewPref.lab_mergeFeedEnabled,
+      }),
     }
   }
   // Always have 'home' defaults
@@ -360,8 +364,13 @@ export const getPreferences: Action<
     }
   }
 
+  const appThreadViewPref: Partial<BskyThreadViewPreference> | undefined =
+    threadView
   const threadViewPrefs: BskyThreadViewPreference = {
     sort: threadView?.sort ?? 'hotness',
+    ...(typeof appThreadViewPref?.lab_treeViewEnabled === 'boolean' && {
+      lab_treeViewEnabled: appThreadViewPref.lab_treeViewEnabled,
+    }),
   }
 
   // Build labelers list: app labelers + user's labeler prefs

--- a/packages/sdk/src/actions/types.ts
+++ b/packages/sdk/src/actions/types.ts
@@ -8,11 +8,13 @@ export interface BskyFeedViewPreference {
   hideRepliesByLikeCount: number
   hideReposts: boolean
   hideQuotePosts: boolean
+  lab_mergeFeedEnabled?: boolean
   [key: string]: unknown
 }
 
 export interface BskyThreadViewPreference {
   sort: string
+  lab_treeViewEnabled?: boolean
   [key: string]: unknown
 }
 

--- a/packages/sdk/tests/actions-preferences.test.ts
+++ b/packages/sdk/tests/actions-preferences.test.ts
@@ -103,6 +103,31 @@ describe('getPreferences', () => {
     expect(prefs.threadViewPrefs.sort).toBe('hotness')
   })
 
+  it.each([true, false])(
+    'interprets app-specific view preferences set to %s',
+    async (enabled) => {
+      const { client } = fakeClient({
+        'app.bsky.actor.getPreferences': () => ({
+          preferences: [
+            {
+              $type: 'app.bsky.actor.defs#feedViewPref',
+              feed: 'home',
+              lab_mergeFeedEnabled: enabled,
+            },
+            {
+              $type: 'app.bsky.actor.defs#threadViewPref',
+              lab_treeViewEnabled: enabled,
+            },
+          ],
+        }),
+        'app.bsky.actor.putPreferences': () => ({}),
+      })
+      const prefs = await client.call(getPreferences)
+      expect(prefs.feedViewPrefs.home.lab_mergeFeedEnabled).toBe(enabled)
+      expect(prefs.threadViewPrefs.lab_treeViewEnabled).toBe(enabled)
+    },
+  )
+
   it('interprets adult content + label prefs', async () => {
     const { client } = fakeClient({
       'app.bsky.actor.getPreferences': () => ({


### PR DESCRIPTION
## Summary

- expose lab_mergeFeedEnabled and lab_treeViewEnabled as explicit SDK preference properties
- preserve boolean values when normalizing server preferences
- cover enabled and disabled values and publish as a patch release

## Test plan

- In social-app, enable threaded replies, leave the thread preferences screen, and confirm the setting remains enabled when returning