### PR TITLE
Add known likers to post viewer state

### DIFF
--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -52,7 +52,29 @@
         "threadMuted": { "type": "boolean" },
         "replyDisabled": { "type": "boolean" },
         "embeddingDisabled": { "type": "boolean" },
-        "pinned": { "type": "boolean" }
+        "pinned": { "type": "boolean" },
+        "knownLikers": {
+          "description": "This property is present only in selected cases, as an optimization.",
+          "type": "ref",
+          "ref": "#knownLikers"
+        }
+      }
+    },
+    "knownLikers": {
+      "type": "object",
+      "description": "The post's likers whom you also follow",
+      "required": ["count", "likers"],
+      "properties": {
+        "count": { "type": "integer" },
+        "likers": {
+          "type": "array",
+          "minLength": 0,
+          "maxLength": 5,
+          "items": {
+            "type": "ref",
+            "ref": "app.bsky.actor.defs#profileViewBasic"
+          }
+        }
       }
     },
     "threadContext": {

--- a/lexicons/app/bsky/feed/defs.json
+++ b/lexicons/app/bsky/feed/defs.json
@@ -63,10 +63,10 @@
     "knownLikers": {
       "type": "object",
       "description": "The post's likers whom you also follow",
-      "required": ["count", "likers"],
+      "required": ["count", "actors"],
       "properties": {
         "count": { "type": "integer" },
-        "likers": {
+        "actors": {
           "type": "array",
           "minLength": 0,
           "maxLength": 5,


### PR DESCRIPTION
## Summary
- add the knownLikers viewer-state lexicon definition
- expose the sampled count and up to five liker profiles
- update the SDK's packaged lexicon copy

https://linear.app/blueskyweb/issue/APP-2887