### PR TITLE
add getGroupedNotifications lexicon

### DIFF
--- a/lexicons/app/bsky/authManageNotifications.json
+++ b/lexicons/app/bsky/authManageNotifications.json
@@ -14,6 +14,7 @@
           "resource": "rpc",
           "inheritAud": true,
           "lxm": [
+            "app.bsky.notification.getGroupedNotifications",
             "app.bsky.notification.getPreferences",
             "app.bsky.notification.getUnreadCount",
             "app.bsky.notification.listActivitySubscriptions",

--- a/lexicons/app/bsky/notification/getGroupedNotifications.json
+++ b/lexicons/app/bsky/notification/getGroupedNotifications.json
@@ -21,6 +21,13 @@
             ],
             "default": "all"
           },
+          "utcOffset": {
+            "type": "integer",
+            "description": "Offset from UTC in minutes, positive east, used to determine local day boundaries when grouping. Groups never span a local day boundary. Defaults to UTC.",
+            "minimum": -720,
+            "maximum": 840,
+            "default": 0
+          },
           "limit": {
             "type": "integer",
             "description": "Maximum number of groups to return.",

--- a/lexicons/app/bsky/notification/getGroupedNotifications.json
+++ b/lexicons/app/bsky/notification/getGroupedNotifications.json
@@ -4,7 +4,7 @@
   "defs": {
     "main": {
       "type": "query",
-      "description": "Enumerate notifications for the requesting account, pre-grouped for rendering. Supercedes listNotifications. Requires auth.",
+      "description": "Enumerate notifications for the requesting account, pre-grouped for rendering. Supersedes listNotifications. Requires auth.",
       "parameters": {
         "type": "params",
         "properties": {

--- a/lexicons/app/bsky/notification/getGroupedNotifications.json
+++ b/lexicons/app/bsky/notification/getGroupedNotifications.json
@@ -11,6 +11,7 @@
           "filter": {
             "type": "string",
             "description": "Which notification feed to return. Grouping behavior and the application of the account's notification preferences vary per feed: 'all' and 'people-i-follow' respect notification preferences, while dedicated feeds do not.",
+            "maxLength": 32,
             "knownValues": [
               "all",
               "people-i-follow",
@@ -27,7 +28,7 @@
             "maximum": 50,
             "default": 30
           },
-          "cursor": { "type": "string" }
+          "cursor": { "type": "string", "maxLength": 1024 }
         }
       },
       "output": {
@@ -36,7 +37,7 @@
           "type": "object",
           "required": ["groups"],
           "properties": {
-            "cursor": { "type": "string" },
+            "cursor": { "type": "string", "maxLength": 1024 },
             "groups": {
               "type": "array",
               "description": "Notification groups, newest first. Clients should ignore group types they do not recognize.",
@@ -73,7 +74,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it."
+          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it.",
+          "maxLength": 256
         },
         "isRead": {
           "type": "boolean",
@@ -108,7 +110,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it."
+          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it.",
+          "maxLength": 256
         },
         "isRead": {
           "type": "boolean",
@@ -143,7 +146,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it."
+          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it.",
+          "maxLength": 256
         },
         "isRead": {
           "type": "boolean",
@@ -178,7 +182,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it."
+          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it.",
+          "maxLength": 256
         },
         "isRead": {
           "type": "boolean",
@@ -213,7 +218,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it."
+          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it.",
+          "maxLength": 256
         },
         "isRead": {
           "type": "boolean",
@@ -248,7 +254,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it."
+          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it.",
+          "maxLength": 256
         },
         "isRead": {
           "type": "boolean",
@@ -278,7 +285,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it."
+          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it.",
+          "maxLength": 256
         },
         "isRead": {
           "type": "boolean",
@@ -313,7 +321,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it."
+          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it.",
+          "maxLength": 256
         },
         "isRead": {
           "type": "boolean",
@@ -347,7 +356,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it."
+          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it.",
+          "maxLength": 256
         },
         "isRead": {
           "type": "boolean",
@@ -381,7 +391,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it."
+          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it.",
+          "maxLength": 256
         },
         "isRead": {
           "type": "boolean",
@@ -415,7 +426,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it."
+          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it.",
+          "maxLength": 256
         },
         "isRead": {
           "type": "boolean",
@@ -440,7 +452,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it."
+          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it.",
+          "maxLength": 256
         },
         "isRead": {
           "type": "boolean",
@@ -465,7 +478,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it."
+          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it.",
+          "maxLength": 256
         },
         "isRead": {
           "type": "boolean",
@@ -490,7 +504,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it."
+          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it.",
+          "maxLength": 256
         },
         "isRead": {
           "type": "boolean",
@@ -520,7 +535,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it."
+          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it.",
+          "maxLength": 256
         },
         "isRead": {
           "type": "boolean",

--- a/lexicons/app/bsky/notification/getGroupedNotifications.json
+++ b/lexicons/app/bsky/notification/getGroupedNotifications.json
@@ -1,0 +1,542 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.notification.getGroupedNotifications",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Enumerate notifications for the requesting account, pre-grouped for rendering. Supercedes listNotifications. Requires auth.",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "filter": {
+            "type": "string",
+            "description": "Which notification feed to return. Grouping behavior and the application of the account's notification preferences vary per feed: 'all' and 'people-i-follow' respect notification preferences, while dedicated feeds do not.",
+            "knownValues": [
+              "all",
+              "people-i-follow",
+              "conversations",
+              "followers",
+              "activity"
+            ],
+            "default": "all"
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum number of groups to return.",
+            "minimum": 1,
+            "maximum": 50,
+            "default": 30
+          },
+          "cursor": { "type": "string" }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["groups"],
+          "properties": {
+            "cursor": { "type": "string" },
+            "groups": {
+              "type": "array",
+              "description": "Notification groups, newest first. Clients should ignore group types they do not recognize.",
+              "items": {
+                "type": "union",
+                "refs": [
+                  "#likeGroup",
+                  "#repostGroup",
+                  "#likeViaRepostGroup",
+                  "#repostViaRepostGroup",
+                  "#followGroup",
+                  "#subscribedPostGroup",
+                  "#generatorLikeGroup",
+                  "#replyNotification",
+                  "#quoteNotification",
+                  "#mentionNotification",
+                  "#followBackNotification",
+                  "#verifiedNotification",
+                  "#unverifiedNotification",
+                  "#starterPackJoinedNotification",
+                  "#contactMatchNotification"
+                ]
+              }
+            },
+            "seenAt": { "type": "string", "format": "datetime" }
+          }
+        }
+      }
+    },
+    "likeGroup": {
+      "type": "object",
+      "description": "One or more likes on the same post.",
+      "required": ["id", "isRead", "indexedAt", "post", "actors", "count"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it."
+        },
+        "isRead": {
+          "type": "boolean",
+          "description": "True when every notification in this group has been seen."
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp of the newest notification in this group."
+        },
+        "post": {
+          "type": "ref",
+          "ref": "app.bsky.feed.defs#postView",
+          "description": "The post that was liked."
+        },
+        "actors": {
+          "type": "array",
+          "description": "Sample of the actors who liked the post, newest first. May contain fewer entries than count.",
+          "items": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
+        },
+        "count": {
+          "type": "integer",
+          "description": "Total number of likes in this group.",
+          "minimum": 1
+        }
+      }
+    },
+    "repostGroup": {
+      "type": "object",
+      "description": "One or more reposts of the same post.",
+      "required": ["id", "isRead", "indexedAt", "post", "actors", "count"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it."
+        },
+        "isRead": {
+          "type": "boolean",
+          "description": "True when every notification in this group has been seen."
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp of the newest notification in this group."
+        },
+        "post": {
+          "type": "ref",
+          "ref": "app.bsky.feed.defs#postView",
+          "description": "The post that was reposted."
+        },
+        "actors": {
+          "type": "array",
+          "description": "Sample of the actors who reposted the post, newest first. May contain fewer entries than count.",
+          "items": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
+        },
+        "count": {
+          "type": "integer",
+          "description": "Total number of reposts in this group.",
+          "minimum": 1
+        }
+      }
+    },
+    "likeViaRepostGroup": {
+      "type": "object",
+      "description": "One or more likes on a repost of the same post.",
+      "required": ["id", "isRead", "indexedAt", "post", "actors", "count"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it."
+        },
+        "isRead": {
+          "type": "boolean",
+          "description": "True when every notification in this group has been seen."
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp of the newest notification in this group."
+        },
+        "post": {
+          "type": "ref",
+          "ref": "app.bsky.feed.defs#postView",
+          "description": "The subject post of the repost that was liked."
+        },
+        "actors": {
+          "type": "array",
+          "description": "Sample of the actors who liked the repost, newest first. May contain fewer entries than count.",
+          "items": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
+        },
+        "count": {
+          "type": "integer",
+          "description": "Total number of likes in this group.",
+          "minimum": 1
+        }
+      }
+    },
+    "repostViaRepostGroup": {
+      "type": "object",
+      "description": "One or more reposts of a repost of the same post.",
+      "required": ["id", "isRead", "indexedAt", "post", "actors", "count"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it."
+        },
+        "isRead": {
+          "type": "boolean",
+          "description": "True when every notification in this group has been seen."
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp of the newest notification in this group."
+        },
+        "post": {
+          "type": "ref",
+          "ref": "app.bsky.feed.defs#postView",
+          "description": "The subject post of the repost that was reposted."
+        },
+        "actors": {
+          "type": "array",
+          "description": "Sample of the actors who reposted the repost, newest first. May contain fewer entries than count.",
+          "items": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
+        },
+        "count": {
+          "type": "integer",
+          "description": "Total number of reposts in this group.",
+          "minimum": 1
+        }
+      }
+    },
+    "followGroup": {
+      "type": "object",
+      "description": "One or more accounts followed the requesting account.",
+      "required": ["id", "isRead", "indexedAt", "actors", "count"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it."
+        },
+        "isRead": {
+          "type": "boolean",
+          "description": "True when every notification in this group has been seen."
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp of the newest notification in this group."
+        },
+        "actors": {
+          "type": "array",
+          "description": "Sample of the accounts that followed, newest first. May contain fewer entries than count.",
+          "items": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
+        },
+        "count": {
+          "type": "integer",
+          "description": "Total number of follows in this group.",
+          "minimum": 1
+        },
+        "starterPack": {
+          "type": "ref",
+          "ref": "app.bsky.graph.defs#starterPackViewBasic",
+          "description": "Present when the follows in this group all originated from the same starter pack. Follows via different starter packs are never grouped together."
+        }
+      }
+    },
+    "subscribedPostGroup": {
+      "type": "object",
+      "description": "One or more new posts from accounts the requesting account has an activity subscription to.",
+      "required": ["id", "isRead", "indexedAt", "posts", "count"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it."
+        },
+        "isRead": {
+          "type": "boolean",
+          "description": "True when every notification in this group has been seen."
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp of the newest notification in this group."
+        },
+        "posts": {
+          "type": "array",
+          "description": "Sample of the new posts, newest first. May contain fewer entries than count.",
+          "items": { "type": "ref", "ref": "app.bsky.feed.defs#postView" }
+        },
+        "count": {
+          "type": "integer",
+          "description": "Total number of posts in this group.",
+          "minimum": 1
+        }
+      }
+    },
+    "generatorLikeGroup": {
+      "type": "object",
+      "description": "One or more likes on the same feed generator.",
+      "required": ["id", "isRead", "indexedAt", "generator", "actors", "count"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it."
+        },
+        "isRead": {
+          "type": "boolean",
+          "description": "True when every notification in this group has been seen."
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp of the newest notification in this group."
+        },
+        "generator": {
+          "type": "ref",
+          "ref": "app.bsky.feed.defs#generatorView",
+          "description": "The feed generator that was liked."
+        },
+        "actors": {
+          "type": "array",
+          "description": "Sample of the actors who liked the feed generator, newest first. May contain fewer entries than count.",
+          "items": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
+        },
+        "count": {
+          "type": "integer",
+          "description": "Total number of likes in this group.",
+          "minimum": 1
+        }
+      }
+    },
+    "replyNotification": {
+      "type": "object",
+      "description": "A reply to a post by the requesting account, or to a thread they are participating in.",
+      "required": ["id", "isRead", "indexedAt", "post", "parent"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it."
+        },
+        "isRead": {
+          "type": "boolean",
+          "description": "True when this notification has been seen."
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp of the notification."
+        },
+        "post": {
+          "type": "ref",
+          "ref": "app.bsky.feed.defs#postView",
+          "description": "The reply post."
+        },
+        "parent": {
+          "type": "union",
+          "refs": [
+            "app.bsky.feed.defs#postView",
+            "app.bsky.feed.defs#notFoundPost",
+            "app.bsky.feed.defs#blockedPost"
+          ],
+          "description": "The post being replied to."
+        }
+      }
+    },
+    "quoteNotification": {
+      "type": "object",
+      "description": "A post quoting a post by the requesting account.",
+      "required": ["id", "isRead", "indexedAt", "post"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it."
+        },
+        "isRead": {
+          "type": "boolean",
+          "description": "True when this notification has been seen."
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp of the notification."
+        },
+        "post": {
+          "type": "ref",
+          "ref": "app.bsky.feed.defs#postView",
+          "description": "The post containing the quote. Its embed includes the quoted post."
+        },
+        "parent": {
+          "type": "union",
+          "refs": [
+            "app.bsky.feed.defs#postView",
+            "app.bsky.feed.defs#notFoundPost",
+            "app.bsky.feed.defs#blockedPost"
+          ],
+          "description": "The post being replied to, when the quoting post is itself a reply."
+        }
+      }
+    },
+    "mentionNotification": {
+      "type": "object",
+      "description": "A post mentioning the requesting account.",
+      "required": ["id", "isRead", "indexedAt", "post"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it."
+        },
+        "isRead": {
+          "type": "boolean",
+          "description": "True when this notification has been seen."
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp of the notification."
+        },
+        "post": {
+          "type": "ref",
+          "ref": "app.bsky.feed.defs#postView",
+          "description": "The post containing the mention."
+        },
+        "parent": {
+          "type": "union",
+          "refs": [
+            "app.bsky.feed.defs#postView",
+            "app.bsky.feed.defs#notFoundPost",
+            "app.bsky.feed.defs#blockedPost"
+          ],
+          "description": "The post being replied to, when the mentioning post is itself a reply."
+        }
+      }
+    },
+    "followBackNotification": {
+      "type": "object",
+      "description": "An account followed the requesting account back.",
+      "required": ["id", "isRead", "indexedAt", "actor"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it."
+        },
+        "isRead": {
+          "type": "boolean",
+          "description": "True when this notification has been seen."
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp of the notification."
+        },
+        "actor": {
+          "type": "ref",
+          "ref": "app.bsky.actor.defs#profileView",
+          "description": "The account that followed back."
+        }
+      }
+    },
+    "verifiedNotification": {
+      "type": "object",
+      "description": "The requesting account was verified.",
+      "required": ["id", "isRead", "indexedAt", "actor"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it."
+        },
+        "isRead": {
+          "type": "boolean",
+          "description": "True when this notification has been seen."
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp of the notification."
+        },
+        "actor": {
+          "type": "ref",
+          "ref": "app.bsky.actor.defs#profileView",
+          "description": "The account that issued the verification."
+        }
+      }
+    },
+    "unverifiedNotification": {
+      "type": "object",
+      "description": "A verification of the requesting account was removed.",
+      "required": ["id", "isRead", "indexedAt", "actor"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it."
+        },
+        "isRead": {
+          "type": "boolean",
+          "description": "True when this notification has been seen."
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp of the notification."
+        },
+        "actor": {
+          "type": "ref",
+          "ref": "app.bsky.actor.defs#profileView",
+          "description": "The account that removed the verification."
+        }
+      }
+    },
+    "starterPackJoinedNotification": {
+      "type": "object",
+      "description": "An account joined Bluesky via a starter pack created by the requesting account.",
+      "required": ["id", "isRead", "indexedAt", "actor", "starterPack"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it."
+        },
+        "isRead": {
+          "type": "boolean",
+          "description": "True when this notification has been seen."
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp of the notification."
+        },
+        "actor": {
+          "type": "ref",
+          "ref": "app.bsky.actor.defs#profileView",
+          "description": "The account that joined."
+        },
+        "starterPack": {
+          "type": "ref",
+          "ref": "app.bsky.graph.defs#starterPackViewBasic",
+          "description": "The starter pack that was joined."
+        }
+      }
+    },
+    "contactMatchNotification": {
+      "type": "object",
+      "description": "A contact of the requesting account joined Bluesky.",
+      "required": ["id", "isRead", "indexedAt", "actor"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Opaque identifier for this notification, unique within the notification feed. Clients must not attempt to derive meaning from it."
+        },
+        "isRead": {
+          "type": "boolean",
+          "description": "True when this notification has been seen."
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp of the notification."
+        },
+        "actor": {
+          "type": "ref",
+          "ref": "app.bsky.actor.defs#profileView",
+          "description": "The contact that joined."
+        }
+      }
+    }
+  }
+}

--- a/lexicons/app/bsky/notification/getGroupedNotifications.json
+++ b/lexicons/app/bsky/notification/getGroupedNotifications.json
@@ -93,6 +93,7 @@
         },
         "actors": {
           "type": "array",
+          "minLength": 1,
           "description": "Sample of the actors who liked the post, newest first. May contain fewer entries than count.",
           "items": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
         },
@@ -129,6 +130,7 @@
         },
         "actors": {
           "type": "array",
+          "minLength": 1,
           "description": "Sample of the actors who reposted the post, newest first. May contain fewer entries than count.",
           "items": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
         },
@@ -165,6 +167,7 @@
         },
         "actors": {
           "type": "array",
+          "minLength": 1,
           "description": "Sample of the actors who liked the repost, newest first. May contain fewer entries than count.",
           "items": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
         },
@@ -201,6 +204,7 @@
         },
         "actors": {
           "type": "array",
+          "minLength": 1,
           "description": "Sample of the actors who reposted the repost, newest first. May contain fewer entries than count.",
           "items": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
         },
@@ -232,6 +236,7 @@
         },
         "actors": {
           "type": "array",
+          "minLength": 1,
           "description": "Sample of the accounts that followed, newest first. May contain fewer entries than count.",
           "items": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
         },
@@ -268,6 +273,7 @@
         },
         "posts": {
           "type": "array",
+          "minLength": 1,
           "description": "Sample of the new posts, newest first. May contain fewer entries than count.",
           "items": { "type": "ref", "ref": "app.bsky.feed.defs#postView" }
         },
@@ -304,6 +310,7 @@
         },
         "actors": {
           "type": "array",
+          "minLength": 1,
           "description": "Sample of the actors who liked the feed generator, newest first. May contain fewer entries than count.",
           "items": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
         },

--- a/lexicons/app/bsky/notification/getGroupedNotifications.json
+++ b/lexicons/app/bsky/notification/getGroupedNotifications.json
@@ -52,6 +52,7 @@
                 "type": "union",
                 "refs": [
                   "#likeGroup",
+                  "#multiPostLikeGroup",
                   "#repostGroup",
                   "#likeViaRepostGroup",
                   "#repostViaRepostGroup",
@@ -103,6 +104,57 @@
           "minLength": 1,
           "description": "Sample of the actors who liked the post, newest first. May contain fewer entries than count.",
           "items": { "type": "ref", "ref": "app.bsky.actor.defs#profileView" }
+        },
+        "count": {
+          "type": "integer",
+          "description": "Total number of likes in this group.",
+          "minimum": 1
+        }
+      }
+    },
+    "multiPostLikeGroup": {
+      "type": "object",
+      "description": "One actor liked multiple posts by the requesting account.",
+      "required": [
+        "id",
+        "isRead",
+        "indexedAt",
+        "actor",
+        "posts",
+        "postUris",
+        "count"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Opaque identifier for this group, unique within the notification feed. Clients must not attempt to derive meaning from it.",
+          "maxLength": 256
+        },
+        "isRead": {
+          "type": "boolean",
+          "description": "True when every notification in this group has been seen."
+        },
+        "indexedAt": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp of the newest notification in this group."
+        },
+        "actor": {
+          "type": "ref",
+          "ref": "app.bsky.actor.defs#profileView",
+          "description": "The actor who liked the posts."
+        },
+        "posts": {
+          "type": "array",
+          "minLength": 1,
+          "description": "Sample of the liked posts, newest first. May contain fewer entries than count.",
+          "items": { "type": "ref", "ref": "app.bsky.feed.defs#postView" }
+        },
+        "postUris": {
+          "type": "array",
+          "minLength": 1,
+          "description": "URIs of every liked post in this group, newest first. Hydrate with app.bsky.feed.getPosts to display the full list.",
+          "items": { "type": "string", "format": "at-uri" }
         },
         "count": {
           "type": "integer",
@@ -261,8 +313,16 @@
     },
     "subscribedPostGroup": {
       "type": "object",
-      "description": "One or more new posts from accounts the requesting account has an activity subscription to.",
-      "required": ["id", "isRead", "indexedAt", "posts", "count"],
+      "description": "One or more new posts from an account the requesting account has an activity subscription to.",
+      "required": [
+        "id",
+        "isRead",
+        "indexedAt",
+        "actor",
+        "posts",
+        "postUris",
+        "count"
+      ],
       "properties": {
         "id": {
           "type": "string",
@@ -278,11 +338,22 @@
           "format": "datetime",
           "description": "Timestamp of the newest notification in this group."
         },
+        "actor": {
+          "type": "ref",
+          "ref": "app.bsky.actor.defs#profileView",
+          "description": "The account that posted."
+        },
         "posts": {
           "type": "array",
           "minLength": 1,
           "description": "Sample of the new posts, newest first. May contain fewer entries than count.",
           "items": { "type": "ref", "ref": "app.bsky.feed.defs#postView" }
+        },
+        "postUris": {
+          "type": "array",
+          "minLength": 1,
+          "description": "URIs of every new post in this group, newest first. Hydrate with app.bsky.feed.getPosts to display the full list.",
+          "items": { "type": "string", "format": "at-uri" }
         },
         "count": {
           "type": "integer",


### PR DESCRIPTION
Sketch of the notifications v2 feed endpoint: `app.bsky.notification.getGroupedNotifications`. Notifications arrive pre-grouped by the AppView, and each item in the response is a member of a proper union — one object per group kind, carrying fully hydrated views — instead of the generic reason/record bag that `app.bsky.notification.listNotifications` returns today.

Spec: [Notifications v2 technical specification](https://linear.app/blueskyweb/document/notifications-v2-technical-specification-d1e15a5ccaac) · Discussion: #project-notifications-v2

## Shape

`getGroupedNotifications(filter?, limit?, cursor?)` → `{ cursor?, groups[], seenAt? }`

`filter` selects the feed (open enum): `all` (default) · `people-i-follow` · `conversations` · `followers` · `activity`. Grouping semantics and the application of notification preferences vary per feed: `all`/`people-i-follow` respect preferences, dedicated feeds do not.

`groups[]` is an open union of 15 members. Every member carries `id` (opaque), `isRead`, `indexedAt` (newest member).

Grouped kinds — bounded `actors` sample (newest first) plus total `count`:

| kind | payload |
|---|---|
| `likeGroup`, `repostGroup`, `likeViaRepostGroup`, `repostViaRepostGroup` | `post` (postView), `actors`, `count` |
| `followGroup` | `actors`, `count`, `starterPack?` (groups never mix starter packs) |
| `subscribedPostGroup` | `posts` (postView sample), `count` |
| `generatorLikeGroup` | `generator` (generatorView), `actors`, `count` |

Singular kinds:

| kind | payload |
|---|---|
| `replyNotification` | `post`, `parent` (required; union postView / notFoundPost / blockedPost) |
| `quoteNotification`, `mentionNotification` | `post`, `parent?` (when the post is itself a reply) |
| `followBackNotification`, `verifiedNotification`, `unverifiedNotification`, `contactMatchNotification` | `actor` (profileView) |
| `starterPackJoinedNotification` | `actor`, `starterPack` |

## Design notes

- **Kills every client-side n+1.** Today the app follows each `listNotifications` page with serial `getPosts` + `getStarterPacks` calls, a `getFeedGenerator` per feedgen-like, and a `getProfile` per reply-parent author just to render the "replied to X" line. All of those views are now inline; `parent` exists specifically because new designs show a single-line summary of the parent post.
- **Bounded `actors` + `count`, not full group membership.** Groups can hold ~100 notifications; a page of 30 groups can't afford full profileView lists. The collapsed row needs one name, a few avatars, and a count.
- **Dropped from v1:** raw `record`, the `seenAt` input param (the appview already rejects it as unsupported), `priority` (subsumed by `people-i-follow`), and `reasons` (subsumed by `filter`).
- `limit` is 1–50 (default 30) rather than the usual max 100, since groups are much heavier per item.
- Added the new NSID to `authManageNotifications` per house convention.

## Open questions

- **Group expansion:** the expanded view today renders every author as a profile card. With a bounded sample, "see all N" needs a story — existing `getLikes`/`getRepostedBy`/`getFollowers` lose group scoping; a future `getNotificationGroup(id)` is the likely answer (and why `id` exists). Same question for the Activity drill-in, currently `?posts=<≤25 uris>`.
- **`filter` values:** wire identifiers, deliberately decoupled from in-flux product tab names. `followers` vs `follows` needs a decision (`follows` already means "people I follow" in notification preferences vocabulary).
- **`quoteNotification.parent`** is the reply-parent, not the quoted post (which lives in `post.embed`) — needs a design double-check.
- **Server work:** appview's `hydrateNotifications` only fetches causing records today — subject-post hydration is a new round on top of the grouping algorithm.
- **Unread badges per tab** will eventually need the same `filter` on `getUnreadCount` (separate change).

`goat lex lint` is clean: all plain strings are capped (`id` 256, `cursor` 1024, `filter` 32).

Draft while the shape is kicked around — merging publishes to the network, so this shouldn't land until the design settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
