### PR TITLE
Publish content visibility declaration Lexicon

### DIFF
--- a/lexicons/app/bsky/actor/contentVisibilityDeclaration.json
+++ b/lexicons/app/bsky/actor/contentVisibilityDeclaration.json
@@ -1,0 +1,21 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.actor.contentVisibilityDeclaration",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "A declaration of an account's preferences for appearing in content discovery surfaces.",
+      "key": "literal:self",
+      "record": {
+        "type": "object",
+        "required": ["hideFromAlgorithmicRecommendations"],
+        "properties": {
+          "hideFromAlgorithmicRecommendations": {
+            "type": "boolean",
+            "description": "Whether the account requests that its posts be hidden from algorithmic recommendations. Consumers must treat a missing record as false."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- mirror `app.bsky.actor.contentVisibilityDeclaration` from bluesky-social/atproto#5372
- publish the schema through the authoritative `bsky` Lexicon workflow
- retain the specified behavior that a missing preference record means `hideFromAlgorithmicRecommendations: false`

## Context

The schema is already present in atproto, social-app, and indigo, and shipped in `@atproto/api`, but was not mirrored to this publishing repository. As a result, network Lexicon resolution currently fails with `invalid lexicon record proof`.

## Test plan

- verified the JSON parses successfully
- verified the file exactly matches the social-app schema
- verified `git diff --check` passes