### PR TITLE
Add structuredClone fallback for older browsers

### DIFF
--- a/.changeset/warm-apples-clone.md
+++ b/.changeset/warm-apples-clone.md
@@ -1,0 +1,5 @@
+---
+'@bsky/sdk': patch
+---
+
+Support rich-text cloning in browsers without `structuredClone`

--- a/packages/sdk/src/rich-text/rich-text.ts
+++ b/packages/sdk/src/rich-text/rich-text.ts
@@ -206,13 +206,13 @@ export class RichText {
   clone() {
     return new RichText({
       text: this.unicodeText.utf16,
-      facets: structuredClone(this.facets),
+      facets: cloneDeep(this.facets),
     })
   }
 
   copyInto(target: RichText) {
     target.unicodeText = this.unicodeText
-    target.facets = structuredClone(this.facets)
+    target.facets = cloneDeep(this.facets)
   }
 
   *segments(): Generator<RichTextSegment, void, void> {
@@ -454,4 +454,14 @@ function entitiesToFacets(text: UnicodeString, entities: Entity[]): Facet[] {
     }
   }
   return facets
+}
+
+function cloneDeep<T>(value: T): T {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value)
+  }
+  if (typeof value === 'undefined') {
+    return value
+  }
+  return JSON.parse(JSON.stringify(value))
 }

--- a/packages/sdk/tests/rich-text.test.ts
+++ b/packages/sdk/tests/rich-text.test.ts
@@ -1,5 +1,5 @@
 import type { Unknown$Type } from '@atproto/lex'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { RichText } from '../src/rich-text/index.js'
 
 describe('RichText', () => {
@@ -108,6 +108,34 @@ describe('RichText', () => {
       const rt = new RichText({ text: '👨‍👩‍👧‍👧🔥 good!✅' })
       expect(rt.length).toBe(38)
       expect(rt.graphemeLength).toBe(9)
+    }
+  })
+
+  it('clones facets without structuredClone', () => {
+    vi.stubGlobal('structuredClone', undefined)
+    try {
+      const rt = new RichText({
+        text: 'test',
+        facets: [
+          {
+            index: { byteStart: 0, byteEnd: 4 },
+            features: [
+              {
+                $type: 'app.bsky.richtext.facet#link',
+                uri: 'https://example.com',
+              },
+            ],
+          },
+        ],
+      })
+
+      const clone = rt.clone()
+      clone.facets![0].index.byteStart = 1
+
+      expect(rt.facets![0].index.byteStart).toBe(0)
+      expect(new RichText({ text: 'test' }).clone().facets).toBeUndefined()
+    } finally {
+      vi.unstubAllGlobals()
     }
   })
 })


### PR DESCRIPTION
## Summary

- fall back to JSON cloning when `structuredClone` is unavailable
- preserve deep-clone behavior for rich-text facets
- add a patch changeset for `@bsky/sdk`

## Test plan

- In a browser without `structuredClone`, clone rich text with a facet and confirm mutating the clone does not affect the original.