### PR TITLE
Remove character limits from video alt text

### DIFF
--- a/.changeset/tall-moons-shave.md
+++ b/.changeset/tall-moons-shave.md
@@ -1,0 +1,5 @@
+---
+'@bsky/sdk': patch
+---
+
+Remove the `maxGraphemes` and `maxLength` constraints from video alt text, matching image alt text validation.

--- a/lexicons/app/bsky/embed/video.json
+++ b/lexicons/app/bsky/embed/video.json
@@ -20,9 +20,7 @@
         },
         "alt": {
           "type": "string",
-          "description": "Alt text description of the video, for accessibility.",
-          "maxGraphemes": 1000,
-          "maxLength": 10000
+          "description": "Alt text description of the video, for accessibility."
         },
         "aspectRatio": {
           "type": "ref",
@@ -58,9 +56,7 @@
         "playlist": { "type": "string", "format": "uri" },
         "thumbnail": { "type": "string", "format": "uri" },
         "alt": {
-          "type": "string",
-          "maxGraphemes": 1000,
-          "maxLength": 10000
+          "type": "string"
         },
         "aspectRatio": {
           "type": "ref",

--- a/packages/sdk/lexicons.json
+++ b/packages/sdk/lexicons.json
@@ -471,7 +471,7 @@
     },
     "app.bsky.embed.video": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.embed.video",
-      "cid": "bafyreif3f3hruxofdjx4d726veodmewpu5yyu3ketut25jrvjuyn2mbemq"
+      "cid": "bafyreienkrtmhhf45ah742jkltbt53kbk7om53yl42rvjho4vkbka5zg3m"
     },
     "app.bsky.feed.defs": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/app.bsky.feed.defs",

--- a/packages/sdk/lexicons/app/bsky/embed/video.json
+++ b/packages/sdk/lexicons/app/bsky/embed/video.json
@@ -9,9 +9,9 @@
       "properties": {
         "video": {
           "type": "blob",
-          "description": "The mp4 video file. May be up to 100mb, formerly limited to 50mb.",
+          "description": "The mp4 video file. May be up to 300mb, formerly limited to 100mb.",
           "accept": ["video/mp4"],
-          "maxSize": 100000000
+          "maxSize": 300000000
         },
         "captions": {
           "type": "array",
@@ -23,9 +23,7 @@
         },
         "alt": {
           "type": "string",
-          "description": "Alt text description of the video, for accessibility.",
-          "maxGraphemes": 1000,
-          "maxLength": 10000
+          "description": "Alt text description of the video, for accessibility."
         },
         "aspectRatio": {
           "type": "ref",
@@ -70,9 +68,7 @@
           "format": "uri"
         },
         "alt": {
-          "type": "string",
-          "maxGraphemes": 1000,
-          "maxLength": 10000
+          "type": "string"
         },
         "aspectRatio": {
           "type": "ref",

--- a/packages/sdk/tests/lexicons.test.ts
+++ b/packages/sdk/tests/lexicons.test.ts
@@ -1,3 +1,4 @@
+import { parseCid } from '@atproto/lex'
 import { describe, expect, it } from 'vitest'
 import { app } from '../src/lexicons/index.js'
 
@@ -15,6 +16,32 @@ describe('generated lexicons', () => {
     expect(
       app.bsky.feed.post.$matches({ $type: 'app.bsky.feed.post', text: 42 }),
     ).toBe(false)
+  })
+
+  it('accepts video alt text longer than 1,000 graphemes', () => {
+    const alt = 'a'.repeat(1_814)
+
+    expect(
+      app.bsky.embed.video.$matches({
+        $type: 'app.bsky.embed.video',
+        video: {
+          $type: 'blob',
+          ref: parseCid(
+            'bafkreieq5jui4j25lacwomsqgjeswwl3y5zcdrresptwgmfylxo2depppq',
+          ),
+          mimeType: 'video/mp4',
+          size: 1,
+        },
+        alt,
+      }),
+    ).toBe(true)
+    expect(
+      app.bsky.embed.video.view.matches({
+        cid: 'bafyreiclp443lavogvhj3d2ob2cxbfuscni2k5jk7bebjzg7khl3esabwq',
+        playlist: 'https://example.test/video.m3u8',
+        alt,
+      }),
+    ).toBe(true)
   })
 
   it('builds and validates a reference-list opt-out record', () => {


### PR DESCRIPTION
## Summary

- sync `app.bsky.embed.video` with the atproto Lexicon from bluesky-social/atproto#5350
- remove the schema-level `maxGraphemes` and `maxLength` constraints from record and view video alt text
- update the SDK vendored Lexicon and CID manifest
- cover video alt text longer than 1,000 graphemes in generated-schema tests
- add a patch changeset for `@bsky/sdk`

Fixes APP-3013.

## Test plan

- `pnpm --filter @bsky/sdk exec lex install --ci`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
