### PR TITLE
Add AlreadyLeftConvo error to chat.bsky.convo.leaveConvo lexicon

### DIFF
--- a/lexicons/chat/bsky/convo/leaveConvo.json
+++ b/lexicons/chat/bsky/convo/leaveConvo.json
@@ -8,6 +8,10 @@
       "errors": [
         { "name": "InvalidConvo" },
         {
+          "name": "AlreadyLeftConvo",
+          "description": "The user has already left the conversation and is not back in (a direct conversation can be restarted by a new message, which allows leaving again)."
+        },
+        {
           "name": "OwnerCannotLeave",
           "description": "The owner of a group conversation cannot leave before locking the group."
         }

--- a/packages/sdk/lexicons/chat/bsky/convo/leaveConvo.json
+++ b/packages/sdk/lexicons/chat/bsky/convo/leaveConvo.json
@@ -10,10 +10,6 @@
           "name": "InvalidConvo"
         },
         {
-          "name": "AlreadyLeftConvo",
-          "description": "The user has already left the conversation and is not back in (a direct conversation can be restarted by a new message, which allows leaving again)."
-        },
-        {
           "name": "OwnerCannotLeave",
           "description": "The owner of a group conversation cannot leave before locking the group."
         }

--- a/packages/sdk/lexicons/chat/bsky/convo/leaveConvo.json
+++ b/packages/sdk/lexicons/chat/bsky/convo/leaveConvo.json
@@ -10,6 +10,10 @@
           "name": "InvalidConvo"
         },
         {
+          "name": "AlreadyLeftConvo",
+          "description": "The user has already left the conversation and is not back in (a direct conversation can be restarted by a new message, which allows leaving again)."
+        },
+        {
           "name": "OwnerCannotLeave",
           "description": "The owner of a group conversation cannot leave before locking the group."
         }


### PR DESCRIPTION
## What
Adds the `AlreadyLeftConvo` error to `chat.bsky.convo.leaveConvo` in both `lexicons/` and `packages/sdk/lexicons/`.

## Why
The chat service now returns this error from the leaveConvo procedure (APP-3026): the user has already left the conversation and is not back in. A direct conversation can be restarted by a new message, which puts the member back in an active state and allows leaving again.

Service-side change: https://linear.app/blueskyweb/issue/APP-3026/fix-inability-to-leave-restarted-direct-conversations