### PR TITLE
Update SDK leaveConvo lexicon (APP-3026)

### DIFF
--- a/.changeset/calm-chats-leave.md
+++ b/.changeset/calm-chats-leave.md
@@ -1,0 +1,5 @@
+---
+'@bsky/sdk': patch
+---
+
+Add `AlreadyLeftConvo` to the `chat.bsky.convo.leaveConvo` lexicon errors.

--- a/packages/sdk/lexicons.json
+++ b/packages/sdk/lexicons.json
@@ -951,7 +951,7 @@
     },
     "chat.bsky.convo.leaveConvo": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.leaveConvo",
-      "cid": "bafyreihvv4vhpnyct2ge4tzwk3n6bjmjfnhv6e3r4hocmobbubej3qgb3a"
+      "cid": "bafyreig6lc2kyksjbhjn7dllutffxmy7xu67hlibary7sykogslgrkc5k4"
     },
     "chat.bsky.convo.listConvoRequests": {
       "uri": "at://did:plc:4v4y5r3lwsbtmsxhile2ljac/com.atproto.lexicon.schema/chat.bsky.convo.listConvoRequests",

--- a/packages/sdk/lexicons/chat/bsky/convo/leaveConvo.json
+++ b/packages/sdk/lexicons/chat/bsky/convo/leaveConvo.json
@@ -10,6 +10,10 @@
           "name": "InvalidConvo"
         },
         {
+          "name": "AlreadyLeftConvo",
+          "description": "The user has already left the conversation and is not back in (a direct conversation can be restarted by a new message, which allows leaving again)."
+        },
+        {
           "name": "OwnerCannotLeave",
           "description": "The owner of a group conversation cannot leave before locking the group."
         }


### PR DESCRIPTION
Updates the SDK copy of `chat.bsky.convo.leaveConvo` with the published `AlreadyLeftConvo` error and recomputes its manifest CID.

Published lexicon: #45
Chat fix: bluesky-social/chat#263
Linear: https://linear.app/blueskyweb/issue/APP-3026/fix-inability-to-leave-restarted-direct-conversations